### PR TITLE
Fixed typo

### DIFF
--- a/book/the-lox-language.md
+++ b/book/the-lox-language.md
@@ -193,7 +193,7 @@ data types. There are only a few:
     point. Since floating point numbers can also represent a wide range of
     integers, that covers a lot of territory, while keeping things simple.
 
-    Full-featured languages have lots of syntax for numbers -- hexidecimal,
+    Full-featured languages have lots of syntax for numbers -- hexadecimal,
     scientific notation, octal, all sorts of fun stuff. We'll settle for basic
     integer and decimal literals:
 


### PR DESCRIPTION
I just stumbled upon this typo (`hexidecimal->hexadecimal`) while reading and thought I might correct it. It is the only one that caught my eye.

Cheers