### PR TITLE
Remove trailing newline from C to be consistent with Java

### DIFF
--- a/c/main.c
+++ b/c/main.c
@@ -1,6 +1,7 @@
 //> Chunks of Bytecode not-yet
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "common.h"
 /* Chunks of Bytecode not-yet < Scanning on Demand not-yet
@@ -24,6 +25,7 @@ static void repl() {
       break;
     }
 
+    line[strlen(line) - 1] = '\0';
     interpret(line);
   }
 }


### PR DESCRIPTION
Java's BufferedReader::readline() discards the trailing newline, whereas C's fgets keeps the trailing newline. This results in slightly wrong error messages in the C version sometimes.