### PR TITLE
Correct Python version

### DIFF
--- a/site/statements-and-state.html
+++ b/site/statements-and-state.html
@@ -176,7 +176,7 @@ for calling a procedure, but functions can only be called where an expression is
     effects.</p>
 <aside markdown="1" name="print">
 
-<p>I will note with only a modicum of defensiveness that BASIC and Python
+<p>I will note with only a modicum of defensiveness that BASIC and Python 2
 have dedicated print statements and they are real languages.</p>
 </aside>
 


### PR DESCRIPTION
Python now has a print function instead of a statement in Python 3, however this is still correct for Python 2.