### PR TITLE
Go assignments are not expressions

### DIFF
--- a/book/statements-and-state.md
+++ b/book/statements-and-state.md
@@ -720,9 +720,9 @@ expression:
 
 <aside name="assign">
 
-Assignment is a statement in Python. It's an expression in Go, but the increment
+Assignment is a statement in Python. In Go too, plus the increment
 and decrement operators `++` and `--`, which are syntactic sugar for an
-assignment, are statements.
+assignment, are also statements.
 
 </aside>
 


### PR DESCRIPTION
See how [it's derived from `Statement` in the spec](https://golang.org/ref/spec#Statement), not from [`Expression`](https://golang.org/ref/spec#Expression).

I've reworded it, but probably it's not even worth mentioning now.