### PR TITLE
Return do not need a stacktrace given it is used for control flow

### DIFF
--- a/java/com/craftinginterpreters/lox/Return.java
+++ b/java/com/craftinginterpreters/lox/Return.java
@@ -5,6 +5,7 @@ class Return extends RuntimeException {
   final Object value;
 
   Return(Object value) {
+    super(null, null, false, false);
     this.value = value;
   }
 }


### PR DESCRIPTION
gently ask to do not have a stacktrace and supressed exceptions given this runtime exception is used for control flow