### PR TITLE
Add null check to visitLiteralExpr

### DIFF
--- a/java/com/craftinginterpreters/lox/AstPrinter.java
+++ b/java/com/craftinginterpreters/lox/AstPrinter.java
@@ -161,6 +161,7 @@ class AstPrinter implements Expr.Visitor<String>, Stmt.Visitor<String> {
 
   @Override
   public String visitLiteralExpr(Expr.Literal expr) {
+    if (expr.value == null) return "nil";
     return expr.value.toString();
   }
 //> Control Flow not-yet


### PR DESCRIPTION
I'm assuming that it isn't intentional to leave this AstPrinter NPE as an exercise to the reader.

I've added a singleton Nil object in my version so I don't have to special case null all over (and because I converted my Expr types to AutoValue.)