### PR TITLE
Refactor: Use isAtEnd() to remove duplicate logic in peek()

### DIFF
--- a/java/com/craftinginterpreters/lox/Scanner.java
+++ b/java/com/craftinginterpreters/lox/Scanner.java
@@ -188,7 +188,7 @@ class Scanner {
 //< match
 //> peek
   private char peek() {
-    if (current >= source.length()) return '\0';
+    if (isAtEnd()) return '\0';
     return source.charAt(current);
   }
 //< peek


### PR DESCRIPTION
I tried to build and test this change but ran into "UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 185: ordinal not in range(128)" error. Probably has something to do with my ec2 instance on which I remotely develop. Didn't get time to investigate but having said that, change looks pretty trivial so creating a pull request.