### PR TITLE
Change "almost a hundred" to "almost fifty"

### DIFF
--- a/book/representing-code.md
+++ b/book/representing-code.md
@@ -610,8 +610,8 @@ There we go. All of that glorious Java boilerplate is done. It declares each
 field in the class body. It defines a constructor for the class with parameters
 for each field and initializes them in the body.
 
-Run this script now and it blasts out almost a hundred lines of code. That's
-about to get even longer.
+Run this script now and it blasts out almost fifty lines of code. That's about
+to get even longer.
 
 ## Working with Trees
 


### PR DESCRIPTION
The script which generates the Expr.java file seems to only be outputting 44 lines of code, which caused me to go back and reread and rewrite when the text says "almost a hundred lines of code." I wouldn't normally consider 44 being "almost a hundred," and find this more clear while still sounding impressive.

Another wording I think could work would be ".. blasts out a few dozen lines of code."