### PR TITLE
Skip 'test/regression' on chap09_control

### DIFF
--- a/util/test.py
+++ b/util/test.py
@@ -200,6 +200,8 @@ java_interpreter('chap09_control', {
   'test/while/return_closure.lox': 'skip',
   'test/while/return_inside.lox': 'skip',
 
+  'test/regression': 'skip',
+  
   # Broken because we haven't fixed it yet by detecting the error.
   'test/return/at_top_level.lox': 'skip',
   'test/variable/use_local_in_initializer.lox': 'skip',


### PR DESCRIPTION
Same as #91 but for Chapter 9 ^^' 
I didn't thought on checking other chapters before and I found this today while running tests for my implementation of ch9 alexito4/slox/pull/5

Chapter 10 is functions already so I guess it will be fine there.