### PR TITLE
code snipped formatting in chapter04_scanning.md

### DIFF
--- a/note/answers/chapter04_scanning.md
+++ b/note/answers/chapter04_scanning.md
@@ -47,6 +47,7 @@
     someFunction () -> someLambda
     # Means the same as:
     someFunction(() -> someLambda)
+    ```
 
     Ruby has similar corner cases because it also allow omitting the parentheses
     in method calls (which is where CoffeeScript gets it from).


### PR DESCRIPTION
The markdown was missing a tripple \` to end a code snipped, which caused some regular explanation text to be displayed and highlighted as code. This change adds the 3 missing \`.