### PR TITLE
Fix grammar in parsing-expressions.md

### DIFF
--- a/book/parsing-expressions.md
+++ b/book/parsing-expressions.md
@@ -336,7 +336,7 @@ for it.
 
 ## Recursive Descent Parsing
 
-There are a whole pack of parsing techniques whose names mostly seem to be
+There is a whole pack of parsing techniques whose names mostly seem to be
 combinations of "L" and "R" -- [LL(k)][], [LR(1)][lr], [LALR][] -- along with
 more exotic beasts like [parser combinators][], [Earley parsers][], [the
 shunting yard algorithm][], and [packrat parsing][]. For our first interpreter,


### PR DESCRIPTION
Changed `There are a whole pack of parsing techniques...` to `There is a whole pack of parsing techniques...`

After further research, there seems to be contention on whether 'is' or 'are' is appropriate in these cases, but the way I learned it is this:

When you refer to a group of something, the verb refers to the group itself, of which there is only one. I like to picture the sentence without the "of ..."

```
There are a group of teenagers in the park.
```
```
There are a group in the park.
```

To me, the following flows much better:

```
There is a group of teenagers in the park.
```
```
There is a group in the park.
```

Totally up to you to select which sounds best, just offering my suggestion :)