### PR TITLE
use `fun` for declaring static class methods, not `class`.

### DIFF
--- a/book/classes.md
+++ b/book/classes.md
@@ -1146,12 +1146,12 @@ interpreter has grown an entire programming paradigm. Classes, methods, fields,
 
 1.  We have methods on instances, but there is no way to define "static" methods
     that can be called directly on the class object itself. Add support for
-    them. Use a `class` keyword preceding the method to indicate a static method
+    them. Use the `fun` keyword preceding the method to indicate a static method
     that hangs off the class object:
 
         :::lox
         class Math {
-          class square(n) {
+          fun square(n) {
             return n * n;
           }
         }


### PR DESCRIPTION
Hope you don't mind my sending a PR for this suggestion, if you're interested in it.

First off, a huge thanks for writing this book!  I've gone through the chapters you've written so far, and you've turned something that I thought was a scary black art into something digestible and approachable.

Anyhow... I was about to implement the first challenge on the Classes chapter: adding static class methods.  Your challenge text suggests using `class` to denote static methods.  I was thinking this has one major downside: it precludes the idea of being able to go further and, say, add support for inner classes, since it'd be hard/weird to disambiguate between the two cases.

Even regardless of that, reusing `fun` instead for this purpose seemed to fit better, given that it's a clear distinction between an instance method and a function attached to a class, and what are static methods but just functions attached to a class?

Consider this example:
```
class Foo {
  fun somethingStatic() {
    print "Look at all that static";
  }
}

print Foo.somethingStatic(); // Prints "Look at all that static".

Foo.hello = fun (what) {
  print "Hello " +what;
}
Foo.hello("world"); // Prints "Hello world".
```
Note that it also allows you to naturally assign anon functions to a class, using the same familiar syntax (assuming one implements the anon function challenge in the previous chapter).

My PR doesn't include changes to the answer code for this challenge, but I'd be happy to work up those changes if you agree with this idea.