### PR TITLE
Chapter 6: Remove semicolon in the unary expression rule

### DIFF
--- a/book/parsing-expressions.md
+++ b/book/parsing-expressions.md
@@ -304,7 +304,7 @@ equality       → comparison ( ( "!=" | "==" ) comparison )* ;
 comparison     → addition ( ( ">" | ">=" | "<" | "<=" ) addition )* ;
 addition       → multiplication ( ( "-" | "+" ) multiplication )* ;
 multiplication → unary ( ( "/" | "*" ) unary )* ;
-unary          → ( "!" | "-" ) unary ;
+unary          → ( "!" | "-" ) unary
                | primary ;
 primary        → NUMBER | STRING | "false" | "true" | "nil"
                | "(" expression ")" ;


### PR DESCRIPTION
I don't know if it's a typo or not, but there seems to be an extra semicolon in the unary expression rule.