### PR TITLE
Minor fix for Parsing Expressions

### DIFF
--- a/book/parsing-expressions.md
+++ b/book/parsing-expressions.md
@@ -697,7 +697,7 @@ we'll get the machinery in place for later.
 ### Entering panic mode
 
 Back before we went on this side trek about error recovery, we were writing the
-the code to parse a parenthesized expression. After parsing the expression, it
+code to parse a parenthesized expression. After parsing the expression, it
 looks for the closing `)` by calling `consume()`. Here, finally, is that method:
 
 ^code consume


### PR DESCRIPTION
This PR removes an extraneous `the` from the Parsing Expressions chapter.