### PR TITLE
Fix location of 'Superclass is not a class' error.

### DIFF
--- a/java/com/craftinginterpreters/lox/Interpreter.java
+++ b/java/com/craftinginterpreters/lox/Interpreter.java
@@ -115,7 +115,7 @@ class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
     if (stmt.superclass != null) {
       superclass = evaluate(stmt.superclass);
       if (!(superclass instanceof LoxClass)) {
-        throw new RuntimeError(stmt.name,
+        throw new RuntimeError(stmt.superclass.name,
             "Superclass must be a class.");
       }
 //> begin-superclass-environment

--- a/java/com/craftinginterpreters/lox/Parser.java
+++ b/java/com/craftinginterpreters/lox/Parser.java
@@ -80,7 +80,7 @@ class Parser {
     Token name = consume(IDENTIFIER, "Expect class name.");
 //> Inheritance parse-superclass
 
-    Expr superclass = null;
+    Expr.Variable superclass = null;
     if (match(LESS)) {
       consume(IDENTIFIER, "Expect superclass name.");
       superclass = new Expr.Variable(previous());

--- a/java/com/craftinginterpreters/lox/Stmt.java
+++ b/java/com/craftinginterpreters/lox/Stmt.java
@@ -32,7 +32,7 @@ abstract class Stmt {
 //< stmt-block
 //> stmt-class
   static class Class extends Stmt {
-    Class(Token name, Expr superclass, List<Stmt.Function> methods) {
+    Class(Token name, Expr.Variable superclass, List<Stmt.Function> methods) {
       this.name = name;
       this.superclass = superclass;
       this.methods = methods;
@@ -43,7 +43,7 @@ abstract class Stmt {
     }
 
     final Token name;
-    final Expr superclass;
+    final Expr.Variable superclass;
     final List<Stmt.Function> methods;
   }
 //< stmt-class

--- a/java/com/craftinginterpreters/tool/GenerateAst.java
+++ b/java/com/craftinginterpreters/tool/GenerateAst.java
@@ -57,7 +57,7 @@ public class GenerateAst {
       "Class      : Token name, List<Stmt.Function> methods",
 */
 //> Inheritance superclass-ast
-      "Class      : Token name, Expr superclass," +
+      "Class      : Token name, Expr.Variable superclass," +
                   " List<Stmt.Function> methods",
 //< Inheritance superclass-ast
       "Expression : Expr expression",

--- a/site/inheritance.html
+++ b/site/inheritance.html
@@ -254,7 +254,7 @@ in <em>visitClassStmt</em>()</div>
     <span class="k">if</span> <span class="o">(</span><span class="n">stmt</span><span class="o">.</span><span class="na">superclass</span> <span class="o">!=</span> <span class="kc">null</span><span class="o">)</span> <span class="o">{</span>
       <span class="n">superclass</span> <span class="o">=</span> <span class="n">evaluate</span><span class="o">(</span><span class="n">stmt</span><span class="o">.</span><span class="na">superclass</span><span class="o">);</span>
       <span class="k">if</span> <span class="o">(!(</span><span class="n">superclass</span> <span class="k">instanceof</span> <span class="n">LoxClass</span><span class="o">))</span> <span class="o">{</span>
-        <span class="k">throw</span> <span class="k">new</span> <span class="n">RuntimeError</span><span class="o">(</span><span class="n">stmt</span><span class="o">.</span><span class="na">name</span><span class="o">,</span>
+        <span class="k">throw</span> <span class="k">new</span> <span class="n">RuntimeError</span><span class="o">(</span><span class="n">stmt</span><span class="o">.</span><span class="na">superclass</span><span class="o">.</span><span class="na">name</span><span class="o">,</span>
             <span class="s">&quot;Superclass must be a class.&quot;</span><span class="o">);</span>
       <span class="o">}</span>
     <span class="o">}</span>
@@ -574,7 +574,7 @@ definition, we create a new environment:</p>
 <div class="codehilite"><pre class="insert-before"><span></span>    <span class="k">if</span> <span class="o">(</span><span class="n">stmt</span><span class="o">.</span><span class="na">superclass</span> <span class="o">!=</span> <span class="kc">null</span><span class="o">)</span> <span class="o">{</span>
       <span class="n">superclass</span> <span class="o">=</span> <span class="n">evaluate</span><span class="o">(</span><span class="n">stmt</span><span class="o">.</span><span class="na">superclass</span><span class="o">);</span>
       <span class="k">if</span> <span class="o">(!(</span><span class="n">superclass</span> <span class="k">instanceof</span> <span class="n">LoxClass</span><span class="o">))</span> <span class="o">{</span>
-        <span class="k">throw</span> <span class="k">new</span> <span class="n">RuntimeError</span><span class="o">(</span><span class="n">stmt</span><span class="o">.</span><span class="na">name</span><span class="o">,</span>
+        <span class="k">throw</span> <span class="k">new</span> <span class="n">RuntimeError</span><span class="o">(</span><span class="n">stmt</span><span class="o">.</span><span class="na">superclass</span><span class="o">.</span><span class="na">name</span><span class="o">,</span>
             <span class="s">&quot;Superclass must be a class.&quot;</span><span class="o">);</span>
       <span class="o">}</span>
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>


### PR DESCRIPTION
Part 1 of #193.

Fix for jlox to match clox.

jlox seems to be cutting a corner due to the superclass expression having been typed as a general `Expr` instead of an `Expr.Variable`? But this vague typing doesn't help anyone in the first place.

The exposition could probably stay the same, as the following is still a correct sentence:
> You might be surprised that we store the superclass name as an Expr, not a Token. 