### PR TITLE
Make deemphasised text visible

### DIFF
--- a/site/style.css
+++ b/site/style.css
@@ -641,7 +641,7 @@ footer {
   width: 288px;
   padding: 2px 0 0 0;
   font: normal 11px/16px "Source Code Pro", Menlo, Consolas, Monaco, monospace;
-  color: #dad8d6; }
+  color: #bab8b6; }
   .source-file em {
     color: #999997;
     font-style: normal; }
@@ -679,7 +679,7 @@ footer {
   border-right: solid 2px #dad8d6;
   background: #f5f3f0; }
 .codehilite .insert-before span, .codehilite .insert-after span {
-  color: #dad8d6; }
+  color: #7a7876; }
 
 @media only screen and (max-width: 1344px) {
   nav.wide {


### PR DESCRIPTION
#bab8b6 on #faf8f5 or #ffffff is barely visible. At first, I didn't even see there were letters there, it just looked like an unusually large padding. Let's darken them a bit.