### PR TITLE
Fix 'value' snippet, and fix aside comments

### DIFF
--- a/c/value.h
+++ b/c/value.h
@@ -71,9 +71,6 @@ static inline Value numToValue(double num) {
 #else
 
 //< Optimization not-yet
-/* Chunks of Bytecode value-h < Types of Values value
-typedef double Value;
-*/
 //> Types of Values value-type
 typedef enum {
   VAL_BOOL,
@@ -85,6 +82,9 @@ typedef enum {
 } ValueType;
 
 //< Types of Values value-type
+/* Chunks of Bytecode value-h < Types of Values value
+typedef double Value;
+*/
 //> Types of Values value
 typedef struct {
   ValueType type;

--- a/site/a-virtual-machine.html
+++ b/site/a-virtual-machine.html
@@ -162,7 +162,7 @@ create new file</div>
 <pre><span></span><span class="cp">#include</span> <span class="cpf">&quot;common.h&quot;</span><span class="cp"></span>
 <span class="cp">#include</span> <span class="cpf">&quot;vm.h&quot;    </span><span class="cp"></span>
 
-<span class="n">VM</span> <span class="n">vm</span><span class="p">;</span> <span class="c1">// [one]    </span>
+<span class="n">VM</span> <span class="n">vm</span><span class="p">;</span> <span name="one"></span>
 
 <span class="kt">void</span> <span class="nf">initVM</span><span class="p">()</span> <span class="p">{</span>    
 <span class="p">}</span>                  

--- a/site/classes.html
+++ b/site/classes.html
@@ -588,7 +588,7 @@ add after <em>LoxInstance</em>()</div>
       <span class="k">return</span> <span class="n">fields</span><span class="o">.</span><span class="na">get</span><span class="o">(</span><span class="n">name</span><span class="o">.</span><span class="na">lexeme</span><span class="o">);</span>                
     <span class="o">}</span>
 
-    <span class="k">throw</span> <span class="k">new</span> <span class="n">RuntimeError</span><span class="o">(</span><span class="n">name</span><span class="o">,</span> <span class="c1">// [hidden]         </span>
+    <span class="k">throw</span> <span class="k">new</span> <span class="n">RuntimeError</span><span class="o">(</span><span class="n">name</span><span class="o">,</span> <span name="hidden"></span>
         <span class="s">&quot;Undefined property &#39;&quot;</span> <span class="o">+</span> <span class="n">name</span><span class="o">.</span><span class="na">lexeme</span> <span class="o">+</span> <span class="s">&quot;&#39;.&quot;</span><span class="o">);</span>
   <span class="o">}</span>                                                  
 </pre></div>
@@ -704,7 +704,7 @@ add after <em>visitLogicalExpr</em>()</div>
   <span class="kd">public</span> <span class="n">Object</span> <span class="nf">visitSetExpr</span><span class="o">(</span><span class="n">Expr</span><span class="o">.</span><span class="na">Set</span> <span class="n">expr</span><span class="o">)</span> <span class="o">{</span>                          
     <span class="n">Object</span> <span class="n">object</span> <span class="o">=</span> <span class="n">evaluate</span><span class="o">(</span><span class="n">expr</span><span class="o">.</span><span class="na">object</span><span class="o">);</span>
 
-    <span class="k">if</span> <span class="o">(!(</span><span class="n">object</span> <span class="k">instanceof</span> <span class="n">LoxInstance</span><span class="o">))</span> <span class="o">{</span> <span class="c1">// [order]                 </span>
+    <span class="k">if</span> <span class="o">(!(</span><span class="n">object</span> <span class="k">instanceof</span> <span class="n">LoxInstance</span><span class="o">))</span> <span class="o">{</span> <span name="order"></span>
       <span class="k">throw</span> <span class="k">new</span> <span class="n">RuntimeError</span><span class="o">(</span><span class="n">expr</span><span class="o">.</span><span class="na">name</span><span class="o">,</span> <span class="s">&quot;Only instances have fields.&quot;</span><span class="o">);</span>
     <span class="o">}</span>                                                                  
 
@@ -964,7 +964,7 @@ owned by the class, they are still accessed through instances of that class:</p>
 in <em>get</em>()</div>
 <pre class="insert"><span></span>    <span class="n">LoxFunction</span> <span class="n">method</span> <span class="o">=</span> <span class="n">klass</span><span class="o">.</span><span class="na">findMethod</span><span class="o">(</span><span class="k">this</span><span class="o">,</span> <span class="n">name</span><span class="o">.</span><span class="na">lexeme</span><span class="o">);</span>
     <span class="k">if</span> <span class="o">(</span><span class="n">method</span> <span class="o">!=</span> <span class="kc">null</span><span class="o">)</span> <span class="k">return</span> <span class="n">method</span><span class="o">;</span>                       
-<br></pre><pre class="insert-after"><span></span>    <span class="k">throw</span> <span class="k">new</span> <span class="n">RuntimeError</span><span class="o">(</span><span class="n">name</span><span class="o">,</span> <span class="c1">// [hidden]                 </span>
+<br></pre><pre class="insert-after"><span></span>    <span class="k">throw</span> <span class="k">new</span> <span class="n">RuntimeError</span><span class="o">(</span><span class="n">name</span><span class="o">,</span> <span name="hidden"></span>
         <span class="s">&quot;Undefined property &#39;&quot;</span> <span class="o">+</span> <span class="n">name</span><span class="o">.</span><span class="na">lexeme</span> <span class="o">+</span> <span class="s">&quot;&#39;.&quot;</span><span class="o">);</span>        
 </pre></div>
 

--- a/site/evaluating-expressions.html
+++ b/site/evaluating-expressions.html
@@ -399,7 +399,7 @@ add after <em>evaluate</em>()</div>
 <pre><span></span>  <span class="nd">@Override</span>                                        
   <span class="kd">public</span> <span class="n">Object</span> <span class="nf">visitBinaryExpr</span><span class="o">(</span><span class="n">Expr</span><span class="o">.</span><span class="na">Binary</span> <span class="n">expr</span><span class="o">)</span> <span class="o">{</span>
     <span class="n">Object</span> <span class="n">left</span> <span class="o">=</span> <span class="n">evaluate</span><span class="o">(</span><span class="n">expr</span><span class="o">.</span><span class="na">left</span><span class="o">);</span>             
-    <span class="n">Object</span> <span class="n">right</span> <span class="o">=</span> <span class="n">evaluate</span><span class="o">(</span><span class="n">expr</span><span class="o">.</span><span class="na">right</span><span class="o">);</span> <span class="c1">// [left] </span>
+    <span class="n">Object</span> <span class="n">right</span> <span class="o">=</span> <span class="n">evaluate</span><span class="o">(</span><span class="n">expr</span><span class="o">.</span><span class="na">right</span><span class="o">);</span> <span name="left"></span>
 
     <span class="k">switch</span> <span class="o">(</span><span class="n">expr</span><span class="o">.</span><span class="na">operator</span><span class="o">.</span><span class="na">type</span><span class="o">)</span> <span class="o">{</span>                  
       <span class="k">case</span> <span class="n">MINUS</span><span class="o">:</span>                                  
@@ -436,7 +436,7 @@ in <em>visitBinaryExpr</em>()</div>
 <pre class="insert"><span></span>      <span class="k">case</span> <span class="n">PLUS</span><span class="o">:</span>                                                
         <span class="k">if</span> <span class="o">(</span><span class="n">left</span> <span class="k">instanceof</span> <span class="n">Double</span> <span class="o">&amp;&amp;</span> <span class="n">right</span> <span class="k">instanceof</span> <span class="n">Double</span><span class="o">)</span> <span class="o">{</span>
           <span class="k">return</span> <span class="o">(</span><span class="kt">double</span><span class="o">)</span><span class="n">left</span> <span class="o">+</span> <span class="o">(</span><span class="kt">double</span><span class="o">)</span><span class="n">right</span><span class="o">;</span>                  
-        <span class="o">}</span> <span class="c1">// [plus]                                             </span>
+        <span class="o">}</span> <span name="plus"></span>
 
         <span class="k">if</span> <span class="o">(</span><span class="n">left</span> <span class="k">instanceof</span> <span class="n">String</span> <span class="o">&amp;&amp;</span> <span class="n">right</span> <span class="k">instanceof</span> <span class="n">String</span><span class="o">)</span> <span class="o">{</span>
           <span class="k">return</span> <span class="o">(</span><span class="n">String</span><span class="o">)</span><span class="n">left</span> <span class="o">+</span> <span class="o">(</span><span class="n">String</span><span class="o">)</span><span class="n">right</span><span class="o">;</span>                  
@@ -704,7 +704,7 @@ add after <em>checkNumberOperand</em>()</div>
 <pre><span></span>  <span class="kd">private</span> <span class="kt">void</span> <span class="nf">checkNumberOperands</span><span class="o">(</span><span class="n">Token</span> <span class="n">operator</span><span class="o">,</span>                
                                    <span class="n">Object</span> <span class="n">left</span><span class="o">,</span> <span class="n">Object</span> <span class="n">right</span><span class="o">)</span> <span class="o">{</span>   
     <span class="k">if</span> <span class="o">(</span><span class="n">left</span> <span class="k">instanceof</span> <span class="n">Double</span> <span class="o">&amp;&amp;</span> <span class="n">right</span> <span class="k">instanceof</span> <span class="n">Double</span><span class="o">)</span> <span class="k">return</span><span class="o">;</span>
-    <span class="c1">// [operand]                                                  </span>
+    <span name="operand"></span>
     <span class="k">throw</span> <span class="k">new</span> <span class="n">RuntimeError</span><span class="o">(</span><span class="n">operator</span><span class="o">,</span> <span class="s">&quot;Operands must be numbers.&quot;</span><span class="o">);</span>
   <span class="o">}</span>                                                               
 </pre></div>

--- a/site/scanning-on-demand.html
+++ b/site/scanning-on-demand.html
@@ -196,7 +196,7 @@ add after <em>repl</em>()</div>
 <pre><span></span><span class="k">static</span> <span class="kt">void</span> <span class="nf">runFile</span><span class="p">(</span><span class="k">const</span> <span class="kt">char</span><span class="o">*</span> <span class="n">path</span><span class="p">)</span> <span class="p">{</span>           
   <span class="kt">char</span><span class="o">*</span> <span class="n">source</span> <span class="o">=</span> <span class="n">readFile</span><span class="p">(</span><span class="n">path</span><span class="p">);</span>                  
   <span class="n">InterpretResult</span> <span class="n">result</span> <span class="o">=</span> <span class="n">interpret</span><span class="p">(</span><span class="n">source</span><span class="p">);</span>     
-  <span class="n">free</span><span class="p">(</span><span class="n">source</span><span class="p">);</span> <span class="c1">// [owner]                        </span>
+  <span class="n">free</span><span class="p">(</span><span class="n">source</span><span class="p">);</span> <span name="owner"></span>
 
   <span class="k">if</span> <span class="p">(</span><span class="n">result</span> <span class="o">==</span> <span class="n">INTERPRET_COMPILE_ERROR</span><span class="p">)</span> <span class="n">exit</span><span class="p">(</span><span class="mi">65</span><span class="p">);</span>
   <span class="k">if</span> <span class="p">(</span><span class="n">result</span> <span class="o">==</span> <span class="n">INTERPRET_RUNTIME_ERROR</span><span class="p">)</span> <span class="n">exit</span><span class="p">(</span><span class="mi">70</span><span class="p">);</span>

--- a/site/scanning.html
+++ b/site/scanning.html
@@ -163,7 +163,7 @@ create new file</div>
   <span class="kd">public</span> <span class="kd">static</span> <span class="kt">void</span> <span class="nf">main</span><span class="o">(</span><span class="n">String</span><span class="o">[]</span> <span class="n">args</span><span class="o">)</span> <span class="kd">throws</span> <span class="n">IOException</span> <span class="o">{</span>
     <span class="k">if</span> <span class="o">(</span><span class="n">args</span><span class="o">.</span><span class="na">length</span> <span class="o">&gt;</span> <span class="mi">1</span><span class="o">)</span> <span class="o">{</span>                                   
       <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">println</span><span class="o">(</span><span class="s">&quot;Usage: jlox [script]&quot;</span><span class="o">);</span>            
-      <span class="n">System</span><span class="o">.</span><span class="na">exit</span><span class="o">(</span><span class="mi">64</span><span class="o">);</span> <span class="c1">// [64]                               </span>
+      <span class="n">System</span><span class="o">.</span><span class="na">exit</span><span class="o">(</span><span class="mi">64</span><span class="o">);</span> <span name="64"></span>
     <span class="o">}</span> <span class="k">else</span> <span class="k">if</span> <span class="o">(</span><span class="n">args</span><span class="o">.</span><span class="na">length</span> <span class="o">==</span> <span class="mi">1</span><span class="o">)</span> <span class="o">{</span>                           
       <span class="n">runFile</span><span class="o">(</span><span class="n">args</span><span class="o">[</span><span class="mi">0</span><span class="o">]);</span>                                      
     <span class="o">}</span> <span class="k">else</span> <span class="o">{</span>                                                 
@@ -214,7 +214,7 @@ add after <em>runFile</em>()</div>
     <span class="n">InputStreamReader</span> <span class="n">input</span> <span class="o">=</span> <span class="k">new</span> <span class="n">InputStreamReader</span><span class="o">(</span><span class="n">System</span><span class="o">.</span><span class="na">in</span><span class="o">);</span>
     <span class="n">BufferedReader</span> <span class="n">reader</span> <span class="o">=</span> <span class="k">new</span> <span class="n">BufferedReader</span><span class="o">(</span><span class="n">input</span><span class="o">);</span>
 
-    <span class="k">for</span> <span class="o">(;;)</span> <span class="o">{</span> <span class="c1">// [repl]                                       </span>
+    <span class="k">for</span> <span class="o">(;;)</span> <span class="o">{</span> <span name="repl"></span>
       <span class="n">System</span><span class="o">.</span><span class="na">out</span><span class="o">.</span><span class="na">print</span><span class="o">(</span><span class="s">&quot;&gt; &quot;</span><span class="o">);</span>                                  
       <span class="n">run</span><span class="o">(</span><span class="n">reader</span><span class="o">.</span><span class="na">readLine</span><span class="o">());</span>                                  
     <span class="o">}</span>                                                          
@@ -445,7 +445,7 @@ create new file</div>
   <span class="kd">final</span> <span class="n">TokenType</span> <span class="n">type</span><span class="o">;</span>                                           
   <span class="kd">final</span> <span class="n">String</span> <span class="n">lexeme</span><span class="o">;</span>                                            
   <span class="kd">final</span> <span class="n">Object</span> <span class="n">literal</span><span class="o">;</span>                                           
-  <span class="kd">final</span> <span class="kt">int</span> <span class="n">line</span><span class="o">;</span> <span class="c1">// [location]                                   </span>
+  <span class="kd">final</span> <span class="kt">int</span> <span class="n">line</span><span class="o">;</span> <span name="location"></span>
 
   <span class="n">Token</span><span class="o">(</span><span class="n">TokenType</span> <span class="n">type</span><span class="o">,</span> <span class="n">String</span> <span class="n">lexeme</span><span class="o">,</span> <span class="n">Object</span> <span class="n">literal</span><span class="o">,</span> <span class="kt">int</span> <span class="n">line</span><span class="o">)</span> <span class="o">{</span>
     <span class="k">this</span><span class="o">.</span><span class="na">type</span> <span class="o">=</span> <span class="n">type</span><span class="o">;</span>                                             
@@ -653,7 +653,7 @@ lexical level. What happens if a user throws a source file containing some
 characters Lox doesn&rsquo;t use, like <code>@#^</code> at our interpreter? Right now, those
 characters get silently added to the next token. That ain&rsquo;t right.</p>
 <p>Let&rsquo;s fix that:</p>
-<div class="codehilite"><pre class="insert-before"><span></span>      <span class="k">case</span> <span class="sc">&#39;*&#39;</span><span class="o">:</span> <span class="n">addToken</span><span class="o">(</span><span class="n">STAR</span><span class="o">);</span> <span class="k">break</span><span class="o">;</span> <span class="c1">// [slash]  </span>
+<div class="codehilite"><pre class="insert-before"><span></span>      <span class="k">case</span> <span class="sc">&#39;*&#39;</span><span class="o">:</span> <span class="n">addToken</span><span class="o">(</span><span class="n">STAR</span><span class="o">);</span> <span class="k">break</span><span class="o">;</span> <span name="slash"></span>
 </pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert"><br><span></span>      <span class="k">default</span><span class="o">:</span>                                     
@@ -685,7 +685,7 @@ operators. What about <code>!</code>? It&rsquo;s a single character, right? Some
 not when it&rsquo;s followed by a <code>=</code>. In that case, it should be a <code>!=</code> lexeme.
 Likewise, <code>&lt;</code>, <code>&gt;</code>, and <code>=</code> can all be followed by <code>=</code>.</p>
 <p>For those, we need to look at the second character:</p>
-<div class="codehilite"><pre class="insert-before"><span></span>      <span class="k">case</span> <span class="sc">&#39;*&#39;</span><span class="o">:</span> <span class="n">addToken</span><span class="o">(</span><span class="n">STAR</span><span class="o">);</span> <span class="k">break</span><span class="o">;</span> <span class="c1">// [slash]                     </span>
+<div class="codehilite"><pre class="insert-before"><span></span>      <span class="k">case</span> <span class="sc">&#39;*&#39;</span><span class="o">:</span> <span class="n">addToken</span><span class="o">(</span><span class="n">STAR</span><span class="o">);</span> <span class="k">break</span><span class="o">;</span> <span name="slash"></span>
 </pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert"><span></span>      <span class="k">case</span> <span class="sc">&#39;!&#39;</span><span class="o">:</span> <span class="n">addToken</span><span class="o">(</span><span class="n">match</span><span class="o">(</span><span class="sc">&#39;=&#39;</span><span class="o">)</span> <span class="o">?</span> <span class="n">BANG_EQUAL</span> <span class="o">:</span> <span class="n">BANG</span><span class="o">);</span> <span class="k">break</span><span class="o">;</span>      
@@ -907,7 +907,7 @@ replace 1 line</div>
 add after <em>peek</em>()</div>
 <pre><span></span>  <span class="kd">private</span> <span class="kt">boolean</span> <span class="nf">isDigit</span><span class="o">(</span><span class="kt">char</span> <span class="n">c</span><span class="o">)</span> <span class="o">{</span>
     <span class="k">return</span> <span class="n">c</span> <span class="o">&gt;=</span> <span class="sc">&#39;0&#39;</span> <span class="o">&amp;&amp;</span> <span class="n">c</span> <span class="o">&lt;=</span> <span class="sc">&#39;9&#39;</span><span class="o">;</span>   
-  <span class="o">}</span> <span class="c1">// [is-digit]                  </span>
+  <span class="o">}</span> <span name="is-digit"></span>
 </pre></div>
 
 <div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>peek</em>()</div>
@@ -949,7 +949,7 @@ add after <em>peek</em>()</div>
 <pre><span></span>  <span class="kd">private</span> <span class="kt">char</span> <span class="nf">peekNext</span><span class="o">()</span> <span class="o">{</span>                         
     <span class="k">if</span> <span class="o">(</span><span class="n">current</span> <span class="o">+</span> <span class="mi">1</span> <span class="o">&gt;=</span> <span class="n">source</span><span class="o">.</span><span class="na">length</span><span class="o">())</span> <span class="k">return</span> <span class="sc">&#39;\0&#39;</span><span class="o">;</span>
     <span class="k">return</span> <span class="n">source</span><span class="o">.</span><span class="na">charAt</span><span class="o">(</span><span class="n">current</span> <span class="o">+</span> <span class="mi">1</span><span class="o">);</span>              
-  <span class="o">}</span> <span class="c1">// [peek-next]                                  </span>
+  <span class="o">}</span> <span name="peek-next"></span>
 </pre></div>
 
 <div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>peek</em>()</div>

--- a/site/statements-and-state.html
+++ b/site/statements-and-state.html
@@ -357,7 +357,7 @@ add after <em>evaluate</em>()</div>
 <pre><span></span>  <span class="nd">@Override</span>                                              
   <span class="kd">public</span> <span class="n">Void</span> <span class="nf">visitExpressionStmt</span><span class="o">(</span><span class="n">Stmt</span><span class="o">.</span><span class="na">Expression</span> <span class="n">stmt</span><span class="o">)</span> <span class="o">{</span>
     <span class="n">evaluate</span><span class="o">(</span><span class="n">stmt</span><span class="o">.</span><span class="na">expression</span><span class="o">);</span>                           
-    <span class="k">return</span> <span class="kc">null</span><span class="o">;</span> <span class="c1">// [void]                               </span>
+    <span class="k">return</span> <span class="kc">null</span><span class="o">;</span> <span name="void"></span>
   <span class="o">}</span>                                                      
 </pre></div>
 

--- a/site/types-of-values.html
+++ b/site/types-of-values.html
@@ -159,15 +159,15 @@ pack the above information into as few bits as possible. For now, we&rsquo;ll st
 with the simplest, classic solution: a <strong>tagged union</strong>. A value contains two
 parts: a type &ldquo;tag&rdquo;, and a payload for the actual value. To store the value&rsquo;s
 type, we define an enum for each kind of value the VM supports:</p>
-<div class="codehilite"><pre class="insert-before"><br><span></span><span class="k">typedef</span> <span class="kt">double</span> <span class="n">Value</span><span class="p">;</span>     
-</pre><div class="source-file"><em>value.h</em></div>
+<div class="codehilite"><pre class="insert-before"><span></span><span class="cp">#include</span> <span class="cpf">&quot;common.h&quot;       </span><span class="cp"></span>
+<br></pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span></span><span class="k">typedef</span> <span class="k">enum</span> <span class="p">{</span>            
   <span class="n">VAL_BOOL</span><span class="p">,</span>               
   <span class="n">VAL_NIL</span><span class="p">,</span> <span name="user-types"></span>
   <span class="n">VAL_NUMBER</span><span class="p">,</span>             
 <span class="p">}</span> <span class="n">ValueType</span><span class="p">;</span>              
-<br></pre><pre class="insert-after"><br><span></span><span class="k">typedef</span> <span class="k">struct</span> <span class="p">{</span>          
-</pre></div>
+<br></pre><pre class="insert-after"><span></span><span class="k">typedef</span> <span class="kt">double</span> <span class="n">Value</span><span class="p">;</span>     
+<br></pre></div>
 
 <div class="source-file-narrow"><em>value.h</em></div>
 
@@ -206,20 +206,21 @@ unsafe and will happily saw your fingers off if you don&rsquo;t watch out.</p>
 </aside>
 <p>As the name &ldquo;tagged union&rdquo; implies, our new value representation combines these
 two parts into a single struct:</p>
-<div class="codehilite"><pre class="insert-before"><span></span><span class="cp">#include</span> <span class="cpf">&quot;common.h&quot;</span><span class="cp"></span>
+<div class="codehilite"><pre class="insert-before"><span></span><span class="p">}</span> <span class="n">ValueType</span><span class="p">;</span>      
 <br></pre><div class="source-file"><em>value.h</em><br>
+add after enum <em>ValueType</em><br>
 replace 1 line</div>
-<pre class="insert"><span></span><span class="k">typedef</span> <span class="k">struct</span> <span class="p">{</span>   
-  <span class="n">ValueType</span> <span class="n">type</span><span class="p">;</span>  
-  <span class="k">union</span> <span class="p">{</span>          
-    <span class="kt">bool</span> <span class="n">boolean</span><span class="p">;</span>  
-    <span class="kt">double</span> <span class="n">number</span><span class="p">;</span> 
-  <span class="p">}</span> <span class="n">as</span><span class="p">;</span> <span class="c1">// [as]    </span>
-<span class="p">}</span> <span class="n">Value</span><span class="p">;</span>           
-</pre><pre class="insert-after"><br><span></span><span class="k">typedef</span> <span class="k">struct</span> <span class="p">{</span>   
+<pre class="insert"><span></span><span class="k">typedef</span> <span class="k">struct</span> <span class="p">{</span>  
+  <span class="n">ValueType</span> <span class="n">type</span><span class="p">;</span> 
+  <span class="k">union</span> <span class="p">{</span>         
+    <span class="kt">bool</span> <span class="n">boolean</span><span class="p">;</span> 
+    <span class="kt">double</span> <span class="n">number</span><span class="p">;</span>
+  <span class="p">}</span> <span class="n">as</span><span class="p">;</span> <span name="as"></span>
+<span class="p">}</span> <span class="n">Value</span><span class="p">;</span>          
+</pre><pre class="insert-after"><br><span></span><span class="k">typedef</span> <span class="k">struct</span> <span class="p">{</span>  
 </pre></div>
 
-<div class="source-file-narrow"><em>value.h</em>, replace 1 line</div>
+<div class="source-file-narrow"><em>value.h</em>, add after enum <em>ValueType</em>, replace 1 line</div>
 
 <p>There&rsquo;s a field for the type tag, and then a second field containing the union
 of all of the underlying values. On a 64-bit machine with a typical C compiler,

--- a/util/build.py
+++ b/util/build.py
@@ -30,8 +30,8 @@ CODE_OPTIONS_PATTERN = re.compile(r'([-a-z0-9]+) \(([^)]+)\)')
 BEFORE_PATTERN = re.compile(r'(\d+) before')
 AFTER_PATTERN = re.compile(r'(\d+) after')
 
-ASIDE_COMMENT_PATTERN = re.compile(r'<span class="c1">// \[([-a-z0-9]+)\]</span>')
-ASIDE_WITH_COMMENT_PATTERN = re.compile(r'<span class="c1">// (.+) \[([-a-z0-9]+)\]</span>')
+ASIDE_COMMENT_PATTERN = re.compile(r'<span class="c1">// \[([-a-z0-9]+)\] *</span>')
+ASIDE_WITH_COMMENT_PATTERN = re.compile(r'<span class="c1">// (.+) \[([-a-z0-9]+)\] *</span>')
 # The "(?!-)" is a hack. scanning.md has an inline code sample containing a
 # "--" operator. We don't want that to get matched, so fail the match if the
 # character after the "-- " is "-", which is the next character in the code

--- a/util/code_snippets.py
+++ b/util/code_snippets.py
@@ -108,7 +108,7 @@ class SourceCode:
     last_lines = {}
 
     # Create a new snippet for [name] if it doesn't already exist.
-    def ensure_snippet(name, line_num):
+    def ensure_snippet(name, line_num = None):
       if not name in snippets:
         snippet = Snippet(file, name)
         snippets[name] = snippet
@@ -116,6 +116,8 @@ class SourceCode:
         return snippet
 
       snippet = snippets[name]
+      if first_lines[snippet] is None:
+        first_lines[snippet] = line_num
       if name != 'not-yet' and name != 'omit' and snippet.file.path != file.path:
         print('Error: "{} {}" appears in two files, {} and {}.'.format(
                 chapter, name, snippet.file.path, file.path),
@@ -137,9 +139,8 @@ class SourceCode:
             snippet.location = line.location
 
         if line.end and line.end.chapter == chapter:
-          snippet = ensure_snippet(line.end.name, line_num)
+          snippet = ensure_snippet(line.end.name)
           snippet.removed.append(line.text)
-          last_lines[snippet] = line_num
 
         line_num += 1
 


### PR DESCRIPTION
The `value` snippet got me slightly confused because it showed the `#include "common.h"` line as the preceding line, but I had just finished typing out the `ValueType` enum and that's what should've been shown as the preceding context.

So I decided to look into what was going on in the snippet generator, and had a lot of fun doing so! 😄 

The problem seemed to be that in `value.h`, the block comment snippet that was set to be replaced by the `value` snippet was placed a ways before the actual `value` snippet's code. So the Snippet was created with the wrong starting line number.

I fixed that by making sure block comment snippets don't have any effect on the `first_lines` or `last_lines` of the snippet that replaces them. But then I realized the issue could've also been fixed by just moving the block comment snippet down so it's right next to the snippet that actually replaces that line of code, so I did that too. I still think the original fix might be worth having though.

Finally, I noticed there was this `// [as]` comment showing up that seemed kind of weird. I found out it's for asides, and it wasn't being rendered properly because it had some whitespace after it due to a recent change that adds padding spaces to the code. So I updated the regexes that match aside comments to account for the extra spaces.

#### Before

<img width="949" alt="screen shot 2018-08-16 at 10 39 53 pm" src="https://user-images.githubusercontent.com/41981177/44248027-72a6a600-a1a5-11e8-89a3-b882b1fcc53d.png">

#### After

<img width="937" alt="screen shot 2018-08-16 at 10 40 13 pm" src="https://user-images.githubusercontent.com/41981177/44248029-75a19680-a1a5-11e8-9611-808ded9c9672.png">
