### PR TITLE
Fix typo in assignation grammar rule?

### DIFF
--- a/book/statements-and-state.md
+++ b/book/statements-and-state.md
@@ -763,7 +763,7 @@ In some other languages, like Pascal, Python, and Go, assignment is a statement.
 
 ```lox
 expression → assignment ;
-assignment → identifier "=" assignment
+assignment → IDENTIFIER "=" assignment
            | equality ;
 ```
 


### PR DESCRIPTION
Hi Bob! Wonderful job with your book, I have been enjoying it a lot and now starting to follow the 3rd part.

Maybe it's a misunderstanding on my end but I'm sending you this small fix for what I believe could be a typo in the grammar rule for assignation in chapter 8 (Statements and State).

Should not be the identifier in assignation grammar rule be written in all caps?

If this is not the case and I'm wrong, just let me know.

Thanks and keep up the great work.
