### PR TITLE
Reorder comparison between structs/unions and product/sum types

### DIFF
--- a/book/types-of-values.md
+++ b/book/types-of-values.md
@@ -86,7 +86,7 @@ looks like a struct except that all of its fields overlap in memory:
 <aside name="sum">
 
 If you're familiar with a language in the ML family, structs and unions in C
-roughly mirror the difference between sum and product types, between tuples
+roughly mirror the difference between product and sum types, between tuples
 and algebraic data types.
 
 </aside>


### PR DESCRIPTION
I think you are trying to show the following are analogous:

C structs ~ product types ~ tuples
C unions ~ sum types ~ algebraic data types

However, the middle pair is swapped in the text, which seems like it could be a little confusing for any readers who aren't familiar with those terms, since they might think you are making the following analogy:

C structs ~ ~sum types~ ~ tuples
C unions ~ ~product types~ ~ algebraic data types

I'm really enjoying the book. Thank you for creating it!