### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ on your PATH.
 You'll need to install a few Python packages:
 
 ```sh
-$ pip3 install markdown jinja2 pygments
+$ pip3 install markdown==2.6.11 jinja2 pygments
 ```
 
 The makefile also assumes Ruby (in particular `gem`) is on your PATH. You'll


### PR DESCRIPTION
## Because:
pip3 dependencies will default to Markdown==3.0.1

This is no longer compatible with calls in in  `util/build.py`

Error:
Traceback (most recent call last):
  File "util/build.py", line 542, in <module>
    format_files(False)
  File "util/build.py", line 492, in format_files
    format_file(file, skip_up_to_date, max(code_mod, templates_mod))
  File "util/build.py", line 384, in format_file
    body = markdown.markdown(contents, ['extra', 'codehilite', 'smarty'])
TypeError: markdown() takes 1 positional argument but 2 were given