### PR TITLE
Fix a bunch of minor grammar mistakes

### DIFF
--- a/book/control-flow.md
+++ b/book/control-flow.md
@@ -714,8 +714,9 @@ syntax to get out of the way of the semantics, so they focus on keeping both the
 grammar and libraries simple. Code should be obvious more than beautiful.
 
 Somewhere in the middle you have languages like Java, C# and Python. Eventually
-you reach Ruby, C++, Perl, and D, languages who have stuffed so much syntax into
-their grammar, they are running out of punctuation characters on the keyboard.
+you reach Ruby, C++, Perl, and D, languages which have stuffed so much syntax
+into their grammar, they are running out of punctuation characters on the
+keyboard.
 
 To some degree, location on the spectrum correlates with age. It's relatively
 easy to add bits of syntactic sugar in later releases. New syntax is a crowd

--- a/book/evaluating-expressions.md
+++ b/book/evaluating-expressions.md
@@ -364,7 +364,7 @@ What do you expect this to evaluate to:
 
 According to [IEEE 754][], which specifies the behavior of double precision
 numbers, dividing a zero by zero gives you the special "NaN" ("not a number")
-value. Strangely enough, NaN is supposed to be *not* equal itself.
+value. Strangely enough, NaN is supposed to be *not* equal to itself.
 
 In Java, the `==` operator on doubles preserves that behavior, but the
 `equals()` method on Double does not. Lox uses the latter, so doesn't follow

--- a/book/parsing-expressions.md
+++ b/book/parsing-expressions.md
@@ -549,8 +549,8 @@ The code for this is a little different:
 
 Again, we look at the <span name="current">current<span> token to see how to
 parse. If it's a `!` or `-`, we must have a unary expression. In that case, we
-grab the token, and then recursively call `unary()` again to the parse the
-operand. Wrap that all up in a unary expression syntax tree and we're done.
+grab the token, and then recursively call `unary()` again to parse the operand.
+Wrap that all up in a unary expression syntax tree and we're done.
 
 <aside name="current">
 

--- a/book/statements-and-state.md
+++ b/book/statements-and-state.md
@@ -547,8 +547,8 @@ a new name to a value:
 ^code environment-define
 
 Not exactly brain surgery, but we have made one interesting semantic choice.
-When we add the key to the map, we don't check to see that if it's already
-present. That means that this program works:
+When we add the key to the map, we don't check to see if it's already present.
+That means that this program works:
 
 ```lox
 var a = "before";


### PR DESCRIPTION
This commit fixes #299 #300 #301 #302.