### PR TITLE
Use extensions=[...] in call to markdown.markdown

### DIFF
--- a/util/build.py
+++ b/util/build.py
@@ -122,7 +122,7 @@ def format_code(language, length, lines):
 
   markup += '```'
 
-  html = markdown.markdown(markup, ['extra', 'codehilite'])
+  html = markdown.markdown(markup, extensions=['extra', 'codehilite'])
 
   if leading_newlines > 0:
     html = html.replace('<pre>', '<pre>' + ('<br>' * leading_newlines))
@@ -381,7 +381,7 @@ def format_file(path, skip_up_to_date, dependencies_mod):
   contents = contents.replace('<aside', '<aside markdown="1"')
   contents = contents.replace('<div class="challenges">', '<div class="challenges" markdown="1">')
   contents = contents.replace('<div class="design-note">', '<div class="design-note" markdown="1">')
-  body = markdown.markdown(contents, ['extra', 'codehilite', 'smarty'])
+  body = markdown.markdown(contents, extensions=['extra', 'codehilite', 'smarty'])
 
   # Turn aside markers in code into spans.
   # <span class="c1">// [repl]</span>


### PR DESCRIPTION
Howdy,

Just recently stumbled upon this project and am interested in learning about interpreters. Thank you for creating this!

While running `make` I had a problem with the code in `util/build.py`, the most recent version of `markdown` uses `kwargs` instead of positional arguments, so here's a fix if you're interested in upgrading. There is another pull request on here which updates the README : #297

Also, there doesn't seem to be a `Pipfile` or a `requirements.txt`. There aren't very many dependencies at the moment, but I could create a `Pipfile` if you want.