### PR TITLE
Fix fatal warning in value.c

### DIFF
--- a/c/value.c
+++ b/c/value.c
@@ -95,6 +95,8 @@ bool valuesEqual(Value a, Value b) {
       return AS_OBJ(a) == AS_OBJ(b);
 //< Hash Tables equal
   }
+
+  return false;
 //> Optimization not-yet
 #endif
 //< Optimization not-yet


### PR DESCRIPTION
Otherwise this is what you get from `make c_chapters`:

    make[1]: Entering directory '/home/hinrik/src/craftinginterpreters'
          cc gen/chap18_types/value.c                 -std=c99 -Wall -Wextra -Werror -Wno-unused-parameter -O3 -flto
    gen/chap18_types/value.c: In function ‘valuesEqual’:
    gen/chap18_types/value.c:41:1: error: control reaches end of non-void function [-Werror=return-type]
     }
     ^
    cc1: all warnings being treated as errors
    make[1]: *** [util/c.make:36: build/release/chap18_types/value.o] Error 1
    make[1]: Leaving directory '/home/hinrik/src/craftinginterpreters'
    make: *** [Makefile:111: c_chapters] Error 2