### PR TITLE
Fixes printObject() under DEBUG_STRESS_GC.

### DIFF
--- a/c/memory.c
+++ b/c/memory.c
@@ -216,6 +216,7 @@ static void freeObject(Obj* object) {
     case OBJ_STRING: {
       ObjString* string = (ObjString*)object;
       FREE_ARRAY(char, string->chars, string->length + 1);
+      string->chars = NULL;
       FREE(ObjString, object);
       break;
     }

--- a/c/object.c
+++ b/c/object.c
@@ -224,19 +224,23 @@ void printObject(Value value) {
 //< Methods and Initializers not-yet
 //> Closures not-yet
     case OBJ_CLOSURE:
-      printf("<fn %s>", AS_CLOSURE(value)->function->name->chars);
+      if (AS_CLOSURE(value)->function &&
+          AS_CLOSURE(value)->function->name &&
+          AS_CLOSURE(value)->function->name->chars) {
+        printf("<fn %s>", AS_CLOSURE(value)->function->name->chars);
+      } else {
+        printf("<fn uninit%ju>", (uintmax_t)(uintptr_t)AS_CLOSURE(value));
+      }
       break;
 //< Closures not-yet
 //> Calls and Functions not-yet
-    case OBJ_FUNCTION: {
-      ObjString *name = AS_FUNCTION(value)->name;
-      if (name) {
-        printf("<fn %p>", AS_FUNCTION(value)->name->chars);
+    case OBJ_FUNCTION:
+      if (AS_FUNCTION(value)->name) {
+          printf("<fn %s>", AS_FUNCTION(value)->name->chars);
       } else {
-        printf("<fn anon%ju>", (uintmax_t)(uintptr_t)AS_FUNCTION(value));
+          printf("<fn uninit%ju>", (uintmax_t)(uintptr_t)AS_FUNCTION(value));
       }
       break;
-    }
 //< Calls and Functions not-yet
 //> Classes and Instances not-yet
     case OBJ_INSTANCE:

--- a/c/object.c
+++ b/c/object.c
@@ -228,9 +228,15 @@ void printObject(Value value) {
       break;
 //< Closures not-yet
 //> Calls and Functions not-yet
-    case OBJ_FUNCTION:
-      printf("<fn %s>", AS_FUNCTION(value)->name->chars);
+    case OBJ_FUNCTION: {
+      ObjString *name = AS_FUNCTION(value)->name;
+      if (name) {
+        printf("<fn %p>", AS_FUNCTION(value)->name->chars);
+      } else {
+        printf("<fn anon%ju>", (uintmax_t)(uintptr_t)AS_FUNCTION(value));
+      }
       break;
+    }
 //< Calls and Functions not-yet
 //> Classes and Instances not-yet
     case OBJ_INSTANCE:


### PR DESCRIPTION
Corrects use-after-free issue with OBJ_FUNCTIONs.  This issue is able to be evoked from building with DEBUG_STRESS_GC, launching the REPL, and entering the following function:
f(x,y) { return x + y; }
