### PR TITLE
fix redeclaration of variables in global space

### DIFF
--- a/java/com/craftinginterpreters/lox/Resolver.java
+++ b/java/com/craftinginterpreters/lox/Resolver.java
@@ -51,9 +51,11 @@ class Resolver implements Expr.Visitor<Void>, Stmt.Visitor<Void> {
 //< Classes class-type
 //> resolve-statements
   void resolve(List<Stmt> statements) {
+    beginScope();
     for (Stmt statement : statements) {
       resolve(statement);
     }
+    endScope();
   }
 //< resolve-statements
 //> visit-block-stmt


### PR DESCRIPTION
In the current version this code is valid:

```
var abc = 123;
var abc = 333;
print abc;
```

I think that's not a good idea. It can be fixed by wrap up global variables in a scope.