### PR TITLE
Fix `for` statement parsing.

### DIFF
--- a/c/compiler.c
+++ b/c/compiler.c
@@ -1273,7 +1273,7 @@ static void forStatement() {
   
 //< for-exit
 /* Jumping Back and Forth for-statement < Jumping Back and Forth for-increment
-  consume(TOKEN_SEMICOLON, "Expect ')' after for clauses.");
+  consume(TOKEN_RIGHT_PAREN, "Expect ')' after for clauses.");
 */
 //> for-increment
   if (!match(TOKEN_RIGHT_PAREN)) {


### PR DESCRIPTION
Use `TOKEN_RIGHT_PAREN` (instead of `TOKEN_SEMICOLON`) in accordance with the expected ')' after `for` clauses in the grammar.