### PR TITLE
Unify function printing code paths

### DIFF
--- a/book/calls-and-functions.md
+++ b/book/calls-and-functions.md
@@ -100,8 +100,13 @@ least, we'll be able to once we [implement a garbage collector][gc].
 
 </aside>
 
-Over in the function to print objects, we also add a case. Since we have the
+It's useful to be able to print function objects for debugging purposes, and to
+represent them in a way that is meaningful to the user. Since we have the
 function's name, we may as well use it:
+
+^code print-function-def (0 before, 2 after)
+
+Over in the function to print objects, we also add a case for function objects:
 
 ^code print-function (1 before, 1 after)
 

--- a/c/object.c
+++ b/c/object.c
@@ -198,6 +198,18 @@ ObjUpvalue* newUpvalue(Value* slot) {
 }
 //< Closures not-yet
 //> print-object
+//> Calls and Functions print-function-def
+void printFunction(ObjFunction* function) {
+//> print-script
+  if (function->name == NULL) {
+    printf("<script>");
+    return;
+  }
+//< print-script
+  printf("<fn %s>", function->name->chars);
+}
+//< Calls and Functions print-function-def
+
 void printObject(Value value) {
   switch (OBJ_TYPE(value)) {
 //> Classes and Instances not-yet
@@ -207,29 +219,17 @@ void printObject(Value value) {
 //< Classes and Instances not-yet
 //> Methods and Initializers not-yet
     case OBJ_BOUND_METHOD:
-      printf("<fn %s>",
-             AS_BOUND_METHOD(value)->method->function->name->chars);
+      printFunction(AS_BOUND_METHOD(value)->method->function);
       break;
 //< Methods and Initializers not-yet
 //> Closures not-yet
     case OBJ_CLOSURE:
-// TODO: Omit this.
-//      if (AS_CLOSURE(value)->function->name == NULL) {
-//        printf("<script>");
-//        break;
-//      }
-      printf("<fn %s>", AS_CLOSURE(value)->function->name->chars);
+      printFunction(AS_CLOSURE(value)->function);
       break;
 //< Closures not-yet
 //> Calls and Functions print-function
     case OBJ_FUNCTION:
-//> print-script
-      if (AS_FUNCTION(value)->name == NULL) {
-        printf("<script>");
-        break;
-      }
-//< print-script
-      printf("<fn %s>", AS_FUNCTION(value)->name->chars);
+      printFunction(AS_FUNCTION(value));
       break;
 //< Calls and Functions print-function
 //> Classes and Instances not-yet

--- a/site/calls-and-functions.html
+++ b/site/calls-and-functions.html
@@ -250,15 +250,27 @@ chunk, so we call Chunk&rsquo;s destructor-like function.</p>
 That means we can let the garbage collector manage its lifetime for us. Or, at
 least, we&rsquo;ll be able to once we <a href="garbage-collection.html">implement a garbage collector</a>.</p>
 </aside>
-<p>Over in the function to print objects, we also add a case. Since we have the
+<p>It&rsquo;s useful to be able to print function objects for debugging purposes, and to
+represent them in a way that is meaningful to the user. Since we have the
 function&rsquo;s name, we may as well use it:</p>
-<div class="codehilite"><pre class="insert-before"><span></span>  <span class="k">switch</span> <span class="p">(</span><span class="n">OBJ_TYPE</span><span class="p">(</span><span class="n">value</span><span class="p">))</span> <span class="p">{</span>                             
+<div class="codehilite"><div class="source-file"><em>object.c</em><br>
+add after <em>copyString</em>()</div>
+<pre class="insert"><span></span><span class="kt">void</span> <span class="nf">printFunction</span><span class="p">(</span><span class="n">ObjFunction</span><span class="o">*</span> <span class="n">function</span><span class="p">)</span> <span class="p">{</span>
+  <span class="n">printf</span><span class="p">(</span><span class="s">&quot;&lt;fn %s&gt;&quot;</span><span class="p">,</span> <span class="n">function</span><span class="o">-&gt;</span><span class="n">name</span><span class="o">-&gt;</span><span class="n">chars</span><span class="p">);</span>
+<span class="p">}</span>                                          
+</pre><pre class="insert-after"><br><span></span><span class="kt">void</span> <span class="nf">printObject</span><span class="p">(</span><span class="n">Value</span> <span class="n">value</span><span class="p">)</span> <span class="p">{</span>            
+</pre></div>
+
+<div class="source-file-narrow"><em>object.c</em>, add after <em>copyString</em>()</div>
+
+<p>Over in the function to print objects, we also add a case for function objects:</p>
+<div class="codehilite"><pre class="insert-before"><span></span>  <span class="k">switch</span> <span class="p">(</span><span class="n">OBJ_TYPE</span><span class="p">(</span><span class="n">value</span><span class="p">))</span> <span class="p">{</span>            
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>printObject</em>()</div>
-<pre class="insert"><span></span>    <span class="k">case</span> <span class="nl">OBJ_FUNCTION</span><span class="p">:</span>                                   
-      <span class="n">printf</span><span class="p">(</span><span class="s">&quot;&lt;fn %s&gt;&quot;</span><span class="p">,</span> <span class="n">AS_FUNCTION</span><span class="p">(</span><span class="n">value</span><span class="p">)</span><span class="o">-&gt;</span><span class="n">name</span><span class="o">-&gt;</span><span class="n">chars</span><span class="p">);</span>
-      <span class="k">break</span><span class="p">;</span>                                             
-</pre><pre class="insert-after"><span></span>    <span class="k">case</span> <span class="nl">OBJ_STRING</span><span class="p">:</span>                                     
+<pre class="insert"><span></span>    <span class="k">case</span> <span class="nl">OBJ_FUNCTION</span><span class="p">:</span>                  
+      <span class="n">printFunction</span><span class="p">(</span><span class="n">AS_FUNCTION</span><span class="p">(</span><span class="n">value</span><span class="p">));</span>
+      <span class="k">break</span><span class="p">;</span>                            
+</pre><pre class="insert-after"><span></span>    <span class="k">case</span> <span class="nl">OBJ_STRING</span><span class="p">:</span>                    
 </pre></div>
 
 <div class="source-file-narrow"><em>object.c</em>, in <em>printObject</em>()</div>
@@ -270,17 +282,17 @@ note that there&rsquo;s no way for a user to get a reference to that function in
 first place. But our diagnostic code that prints the entire stack when
 <code>DEBUG_TRACE_EXECUTION</code> is defined <em>will</em> print it, and we don&rsquo;t want that to
 blow up. So:</p>
-<div class="codehilite"><pre class="insert-before"><span></span>    <span class="k">case</span> <span class="nl">OBJ_FUNCTION</span><span class="p">:</span>                                   
+<div class="codehilite"><pre class="insert-before"><span></span><span class="kt">void</span> <span class="nf">printFunction</span><span class="p">(</span><span class="n">ObjFunction</span><span class="o">*</span> <span class="n">function</span><span class="p">)</span> <span class="p">{</span>
 </pre><div class="source-file"><em>object.c</em><br>
-in <em>printObject</em>()</div>
-<pre class="insert"><span></span>      <span class="k">if</span> <span class="p">(</span><span class="n">AS_FUNCTION</span><span class="p">(</span><span class="n">value</span><span class="p">)</span><span class="o">-&gt;</span><span class="n">name</span> <span class="o">==</span> <span class="nb">NULL</span><span class="p">)</span> <span class="p">{</span>            
-        <span class="n">printf</span><span class="p">(</span><span class="s">&quot;&lt;script&gt;&quot;</span><span class="p">);</span>                              
-        <span class="k">break</span><span class="p">;</span>                                           
-      <span class="p">}</span>                                                  
-</pre><pre class="insert-after"><span></span>      <span class="n">printf</span><span class="p">(</span><span class="s">&quot;&lt;fn %s&gt;&quot;</span><span class="p">,</span> <span class="n">AS_FUNCTION</span><span class="p">(</span><span class="n">value</span><span class="p">)</span><span class="o">-&gt;</span><span class="n">name</span><span class="o">-&gt;</span><span class="n">chars</span><span class="p">);</span>
+in <em>printFunction</em>()</div>
+<pre class="insert"><span></span>  <span class="k">if</span> <span class="p">(</span><span class="n">function</span><span class="o">-&gt;</span><span class="n">name</span> <span class="o">==</span> <span class="nb">NULL</span><span class="p">)</span> <span class="p">{</span>            
+    <span class="n">printf</span><span class="p">(</span><span class="s">&quot;&lt;script&gt;&quot;</span><span class="p">);</span>                    
+    <span class="k">return</span><span class="p">;</span>                                
+  <span class="p">}</span>                                        
+</pre><pre class="insert-after"><span></span>  <span class="n">printf</span><span class="p">(</span><span class="s">&quot;&lt;fn %s&gt;&quot;</span><span class="p">,</span> <span class="n">function</span><span class="o">-&gt;</span><span class="n">name</span><span class="o">-&gt;</span><span class="n">chars</span><span class="p">);</span>
 </pre></div>
 
-<div class="source-file-narrow"><em>object.c</em>, in <em>printObject</em>()</div>
+<div class="source-file-narrow"><em>object.c</em>, in <em>printFunction</em>()</div>
 
 <p>Finally, we have a couple of macros for converting values to functions. First,
 make sure your value actually <em>is</em> a function:</p>
@@ -1778,14 +1790,14 @@ in <em>freeObject</em>()</div>
 
 <p>There isn&rsquo;t much here since ObjNative doesn&rsquo;t own any extra memory. The other
 capability all Lox objects support is being printed:</p>
-<div class="codehilite"><pre class="insert-before"><span></span>      <span class="n">printf</span><span class="p">(</span><span class="s">&quot;&lt;fn %s&gt;&quot;</span><span class="p">,</span> <span class="n">AS_FUNCTION</span><span class="p">(</span><span class="n">value</span><span class="p">)</span><span class="o">-&gt;</span><span class="n">name</span><span class="o">-&gt;</span><span class="n">chars</span><span class="p">);</span>
-      <span class="k">break</span><span class="p">;</span>                                             
+<div class="codehilite"><pre class="insert-before"><span></span>      <span class="n">printFunction</span><span class="p">(</span><span class="n">AS_FUNCTION</span><span class="p">(</span><span class="n">value</span><span class="p">));</span>
+      <span class="k">break</span><span class="p">;</span>                            
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>printObject</em>()</div>
-<pre class="insert"><span></span>    <span class="k">case</span> <span class="nl">OBJ_NATIVE</span><span class="p">:</span>                                     
-      <span class="n">printf</span><span class="p">(</span><span class="s">&quot;&lt;native fn&gt;&quot;</span><span class="p">);</span>                             
-      <span class="k">break</span><span class="p">;</span>                                             
-</pre><pre class="insert-after"><span></span>    <span class="k">case</span> <span class="nl">OBJ_STRING</span><span class="p">:</span>                                     
+<pre class="insert"><span></span>    <span class="k">case</span> <span class="nl">OBJ_NATIVE</span><span class="p">:</span>                    
+      <span class="n">printf</span><span class="p">(</span><span class="s">&quot;&lt;native fn&gt;&quot;</span><span class="p">);</span>            
+      <span class="k">break</span><span class="p">;</span>                            
+</pre><pre class="insert-after"><span></span>    <span class="k">case</span> <span class="nl">OBJ_STRING</span><span class="p">:</span>                    
 </pre></div>
 
 <div class="source-file-narrow"><em>object.c</em>, in <em>printObject</em>()</div>


### PR DESCRIPTION
All of the cases in `printObject` which result in printing a function object (method, closure, function) now use a single code path.

### Explanation
I first encountered this issue because I was getting seg fault crashes after evaluating any line which parsed correctly with clox (both in the REPL and running a file).

The cause was a combination of factors:
* [execution tracing debug output was turned on by default][1]
* [pushing a closure onto the stack before calling it in `interpret`][2]
* [NULL check when printing a closure was commented out][3]

The NULL check code in the closure case for `printObject` [is included][4] in the `closures` branch, so I'm guessing that leaving it commented on `master` was due to book snippet issues? This PR would resolve that by re-using the same NULL check in all code paths.

The execution tracing output configuration being on by default will be addressed in a separate PR.

### Alternative
This PR is focused on a minimal change to address the crash issue, but a larger change could also be made to address nameless functions in general.

I haven't done much review of the clox code, but the nameless functions that seem to be triggering this crash seem to be a result of the `compile` function which returns a function object that wraps the entirety of the compiled source. We could potentially change that code to provide a unique name rather than leave it NULL (e.g. '<script>' which would not normally be a valid function identifier).

I still think the NULL check makes sense, since a nameless function shouldn't prevent correct behavior of the interpreter. But in this case we would want `printFunction` to output something other than `<script>`, probably something indicating an exceptional circumstance, when printing an unnamed function.

[1]: https://github.com/munificent/craftinginterpreters/commit/2cc7075154e3449e8b83604e7fa4b8240ec2e15e#diff-99b914deb835cd9470f7a0cc4f85fa3fR33
[2]: https://github.com/munificent/craftinginterpreters/commit/6de53bc1a56d709cefe44afa6c2aa9dbf0ce527b#diff-00b14333b02cd11f6cc109f57878c987R943
[3]: https://github.com/munificent/craftinginterpreters/commit/6de53bc1a56d709cefe44afa6c2aa9dbf0ce527b#diff-f596e6fce9a2be19d93225dc51b1b6f5R216-R220
[4]: https://github.com/munificent/craftinginterpreters/commit/9e8263f318a684578dde15b6af653e10b65ea7c5#diff-f596e6fce9a2be19d93225dc51b1b6f5R219-R224