### PR TITLE
Debug execution tracing is turned off by default

### DIFF
--- a/c/common.h
+++ b/c/common.h
@@ -30,5 +30,5 @@
 // In the book, we show them defined, but for working on them locally,
 // we don't want them to be.
 #undef DEBUG_PRINT_CODE
-//#undef DEBUG_TRACE_EXECUTION
+#undef DEBUG_TRACE_EXECUTION
 //< omit


### PR DESCRIPTION
It seems likely that this directive was left commented unintentionally after [this commit](https://github.com/munificent/craftinginterpreters/commit/2cc7075154e3449e8b83604e7fa4b8240ec2e15e#diff-99b914deb835cd9470f7a0cc4f85fa3fR33).