### PR TITLE
Correct redeclaration of semantics of binary operations

### DIFF
--- a/book/a-virtual-machine.md
+++ b/book/a-virtual-machine.md
@@ -323,8 +323,8 @@ argument. That side effect means we can see the exact order of operations.
 Don't worry about the VM for a minute. Think about just the semantics of Lox
 itself. The operands to an arithmetic operator obviously need to be evaluated
 before we can perform the operation itself. (It's pretty hard to add `a + b` if
-you don't know what `a` and `b` are.) I haven't specified this yet, but
-I'll go ahead and <span name="undefined">declare</span> that in Lox, the
+you don't know what `a` and `b` are.) I mentioned this when we were evaluating
+expressions in jlox, so to make sure we stay compatible, we ensure the
 left-hand side of a binary operator is evaluated before the right.
 
 <aside name="undefined">


### PR DESCRIPTION
In the 'evaluating expressions' portion of jlox, there is an aside that
explicitly mentions that the left-to-right order of evaluating binary
expression arguments is "nailed down".  It's then claimed in the clox
section that it isn't so we 'declare' it.

You will probably want to re-do the words to sound more like your voice / style, but I thought I would point out the re-declaration, even though it is a consistent re-declaration.

For reference, the initial statement is [here](https://github.com/munificent/craftinginterpreters/blame/master/book/evaluating-expressions.md#L285-L295)