### PR TITLE
Make the metaphor consistent

### DIFF
--- a/book/a-virtual-machine.md
+++ b/book/a-virtual-machine.md
@@ -590,7 +590,7 @@ contents of the stack before we interpret each instruction:
 We loop, printing each value in the array, starting at the first (bottom of the
 stack) and ending when we reach the top. This lets us observe the effect of each
 instruction on the stack. The output is pretty verbose, but it's useful when
-we're tracking down a bug deep in the sewers of the interpreter.
+we're tracking down a bug deep in the bowels of the interpreter.
 
 Stack in hand, let's revisit our two instructions. First up:
 


### PR DESCRIPTION
A wise person [once said](https://github.com/munificent/craftinginterpreters/blame/master/book/control-flow.md#L552-L553)
> Why introduce a metaphor if you aren't going to stick with it?

And then (unintentionally) mixed his metaphors by referring to the interpreter as a city with sewers, instead of a [living](https://github.com/munificent/craftinginterpreters/blame/master/book/evaluating-expressions.md#L644-L647), [breathing](https://github.com/munificent/craftinginterpreters/blame/master/book/a-virtual-machine.md#L11-L14), thing as he [had](https://github.com/munificent/craftinginterpreters/blame/master/book/a-virtual-machine.md#L18-L20) [previously](https://github.com/munificent/craftinginterpreters/blame/master/book/resolving-and-binding.md#L546-L547).

I mean, yeah, it's a tiny thing, but if you intend to publish commercially, then this sort of thing is helpful.