### PR TITLE
11.3.2 Resolving Variable Declarations - Verbiage of resolve(Expr expr)

### DIFF
--- a/site/resolving-and-binding.html
+++ b/site/resolving-and-binding.html
@@ -588,13 +588,13 @@ add after <em>visitBlockStmt</em>()</div>
 <p>Before we get to the interesting code, we need another overload of <code>resolve()</code>
 to resolve an expression instead of a statement:</p>
 <div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
-in <em>resolve</em>()</div>
+after <em>resolve</em>(Stmt stmt)</div>
 <pre><span></span>  <span class="kd">private</span> <span class="kt">void</span> <span class="nf">resolve</span><span class="o">(</span><span class="n">Expr</span> <span class="n">expr</span><span class="o">)</span> <span class="o">{</span>
     <span class="n">expr</span><span class="o">.</span><span class="na">accept</span><span class="o">(</span><span class="k">this</span><span class="o">);</span>             
   <span class="o">}</span>                                
 </pre></div>
 
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>resolve</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, after <em>resolve</em>(Stmt stmt)</div>
 
 <p>Now to the semantics. We split binding into two separate steps<span class="em">&mdash;</span>declaring and
 defining<span class="em">&mdash;</span>in order to handle this funny edge case:</p>


### PR DESCRIPTION
Hi there 👋 ,

I updated the verbiage of the explanatory text for adding `void resolve(Expr expr)` to the `Resolver` class.  The text to me seemed to imply we were meant to be doing some sort of function nesting within `void resolve(Stmt stmt)`, which I don't _think_ was the intention.  Updated the text for both larger/smaller screens to read that this overloaded `resolve` should come after the version that accepts a `Stmt` to follow the order in which they are implemented in this section

Quick Link to Section Updated: http://craftinginterpreters.com/resolving-and-binding.html#resolving-variable-declarations (as of https://github.com/munificent/craftinginterpreters/commit/dcb3b0cbb57160bc51c91bc2e4819210e199af6a)