### PR TITLE
Check function arity before evaluating arguments

### DIFF
--- a/book/functions.md
+++ b/book/functions.md
@@ -287,10 +287,10 @@ is too short or too long.
 I think the latter is a better approach. Passing the wrong number of arguments
 is almost always a bug, and it's a mistake I do make in practice. Given that,
 the sooner the implementation draws my attention to it, the better. So for Lox,
-we'll take Python's approach. Before invoking the callable, we check to see if
-the argument list's length matches the callable's arity:
+we'll take Python's approach. Before evaluating the arguments, we check to see
+if the number of arguments provided matches the callable's arity:
 
-^code check-arity (2 before, 1 after)
+^code check-arity (2 before, 2 after)
 
 That requires a new method on the LoxCallable interface to ask it its arity:
 

--- a/java/com/craftinginterpreters/lox/Interpreter.java
+++ b/java/com/craftinginterpreters/lox/Interpreter.java
@@ -329,12 +329,6 @@ class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
   @Override
   public Object visitCallExpr(Expr.Call expr) {
     Object callee = evaluate(expr.callee);
-
-    List<Object> arguments = new ArrayList<>();
-    for (Expr argument : expr.arguments) { // [in-order]
-      arguments.add(evaluate(argument));
-    }
-
 //> check-is-callable
     if (!(callee instanceof LoxCallable)) {
       throw new RuntimeError(expr.paren,
@@ -344,13 +338,18 @@ class Interpreter implements Expr.Visitor<Object>, Stmt.Visitor<Void> {
 //< check-is-callable
     LoxCallable function = (LoxCallable)callee;
 //> check-arity
-    if (arguments.size() != function.arity()) {
+    if (expr.arguments.size() != function.arity()) {
       throw new RuntimeError(expr.paren, "Expected " +
           function.arity() + " arguments but got " +
           arguments.size() + ".");
     }
-
 //< check-arity
+
+    List<Object> arguments = new ArrayList<>();
+    for (Expr argument : expr.arguments) { // [in-order]
+      arguments.add(evaluate(argument));
+    }
+
     return function.call(this, arguments);
   }
 //< Functions visit-call

--- a/site/functions.html
+++ b/site/functions.html
@@ -328,14 +328,14 @@ expression node:</p>
 add after <em>visitBinaryExpr</em>()</div>
 <pre><span></span>  <span class="nd">@Override</span>                                             
   <span class="kd">public</span> <span class="n">Object</span> <span class="nf">visitCallExpr</span><span class="o">(</span><span class="n">Expr</span><span class="o">.</span><span class="na">Call</span> <span class="n">expr</span><span class="o">)</span> <span class="o">{</span>         
-    <span class="n">Object</span> <span class="n">callee</span> <span class="o">=</span> <span class="n">evaluate</span><span class="o">(</span><span class="n">expr</span><span class="o">.</span><span class="na">callee</span><span class="o">);</span>
+    <span class="n">Object</span> <span class="n">callee</span> <span class="o">=</span> <span class="n">evaluate</span><span class="o">(</span><span class="n">expr</span><span class="o">.</span><span class="na">callee</span><span class="o">);</span>              
+    <span class="n">LoxCallable</span> <span class="n">function</span> <span class="o">=</span> <span class="o">(</span><span class="n">LoxCallable</span><span class="o">)</span><span class="n">callee</span><span class="o">;</span>
 
     <span class="n">List</span><span class="o">&lt;</span><span class="n">Object</span><span class="o">&gt;</span> <span class="n">arguments</span> <span class="o">=</span> <span class="k">new</span> <span class="n">ArrayList</span><span class="o">&lt;&gt;();</span>         
     <span class="k">for</span> <span class="o">(</span><span class="n">Expr</span> <span class="n">argument</span> <span class="o">:</span> <span class="n">expr</span><span class="o">.</span><span class="na">arguments</span><span class="o">)</span> <span class="o">{</span> <span name="in-order">&#8203;</span>
       <span class="n">arguments</span><span class="o">.</span><span class="na">add</span><span class="o">(</span><span class="n">evaluate</span><span class="o">(</span><span class="n">argument</span><span class="o">));</span>                
     <span class="o">}</span>                                                   
 
-    <span class="n">LoxCallable</span> <span class="n">function</span> <span class="o">=</span> <span class="o">(</span><span class="n">LoxCallable</span><span class="o">)</span><span class="n">callee</span><span class="o">;</span>         
     <span class="k">return</span> <span class="n">function</span><span class="o">.</span><span class="na">call</span><span class="o">(</span><span class="k">this</span><span class="o">,</span> <span class="n">arguments</span><span class="o">);</span>              
   <span class="o">}</span>                                                     
 </pre></div>
@@ -394,8 +394,9 @@ you can call? What if you try to do this:</p>
 Java string, so when we cast that to LoxCallable, the JVM will throw a
 ClassCastException. We don&rsquo;t want our interpreter to vomit out some nasty Java
 stack trace and die. Instead, we need to check the type ourselves first:</p>
-<div class="codehilite"><pre class="insert-before"><span></span>    <span class="o">}</span>                                             
-<br></pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><pre class="insert-before"><span></span>  <span class="kd">public</span> <span class="n">Object</span> <span class="nf">visitCallExpr</span><span class="o">(</span><span class="n">Expr</span><span class="o">.</span><span class="na">Call</span> <span class="n">expr</span><span class="o">)</span> <span class="o">{</span>   
+    <span class="n">Object</span> <span class="n">callee</span> <span class="o">=</span> <span class="n">evaluate</span><span class="o">(</span><span class="n">expr</span><span class="o">.</span><span class="na">callee</span><span class="o">);</span>        
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitCallExpr</em>()</div>
 <pre class="insert"><span></span>    <span class="k">if</span> <span class="o">(!(</span><span class="n">callee</span> <span class="k">instanceof</span> <span class="n">LoxCallable</span><span class="o">))</span> <span class="o">{</span>       
       <span class="k">throw</span> <span class="k">new</span> <span class="n">RuntimeError</span><span class="o">(</span><span class="n">expr</span><span class="o">.</span><span class="na">paren</span><span class="o">,</span>          
@@ -436,17 +437,17 @@ is too short or too long.</p>
 <p>I think the latter is a better approach. Passing the wrong number of arguments
 is almost always a bug, and it&rsquo;s a mistake I do make in practice. Given that,
 the sooner the implementation draws my attention to it, the better. So for Lox,
-we&rsquo;ll take Python&rsquo;s approach. Before invoking the callable, we check to see if
-the argument list&rsquo;s length matches the callable&rsquo;s arity:</p>
+we&rsquo;ll take Python&rsquo;s approach. Before evaluating the arguments, we check to see
+if the number of arguments provided matches the callable&rsquo;s arity:</p>
 <div class="codehilite"><pre class="insert-before"><br><span></span>    <span class="n">LoxCallable</span> <span class="n">function</span> <span class="o">=</span> <span class="o">(</span><span class="n">LoxCallable</span><span class="o">)</span><span class="n">callee</span><span class="o">;</span>       
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitCallExpr</em>()</div>
-<pre class="insert"><span></span>    <span class="k">if</span> <span class="o">(</span><span class="n">arguments</span><span class="o">.</span><span class="na">size</span><span class="o">()</span> <span class="o">!=</span> <span class="n">function</span><span class="o">.</span><span class="na">arity</span><span class="o">())</span> <span class="o">{</span>       
+<pre class="insert"><span></span>    <span class="k">if</span> <span class="o">(</span><span class="n">expr</span><span class="o">.</span><span class="na">arguments</span><span class="o">.</span><span class="na">size</span><span class="o">()</span> <span class="o">!=</span> <span class="n">function</span><span class="o">.</span><span class="na">arity</span><span class="o">())</span> <span class="o">{</span>  
       <span class="k">throw</span> <span class="k">new</span> <span class="n">RuntimeError</span><span class="o">(</span><span class="n">expr</span><span class="o">.</span><span class="na">paren</span><span class="o">,</span> <span class="s">&quot;Expected &quot;</span> <span class="o">+</span>
           <span class="n">function</span><span class="o">.</span><span class="na">arity</span><span class="o">()</span> <span class="o">+</span> <span class="s">&quot; arguments but got &quot;</span> <span class="o">+</span>  
           <span class="n">arguments</span><span class="o">.</span><span class="na">size</span><span class="o">()</span> <span class="o">+</span> <span class="s">&quot;.&quot;</span><span class="o">);</span>                    
     <span class="o">}</span>                                                 
-<br></pre><pre class="insert-after"><span></span>    <span class="k">return</span> <span class="n">function</span><span class="o">.</span><span class="na">call</span><span class="o">(</span><span class="k">this</span><span class="o">,</span> <span class="n">arguments</span><span class="o">);</span>            
+</pre><pre class="insert-after"><br><span></span>    <span class="n">List</span><span class="o">&lt;</span><span class="n">Object</span><span class="o">&gt;</span> <span class="n">arguments</span> <span class="o">=</span> <span class="k">new</span> <span class="n">ArrayList</span><span class="o">&lt;&gt;();</span>       
 </pre></div>
 
 <div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitCallExpr</em>()</div>


### PR DESCRIPTION
If the function is not going to be executed due to the thrown `RuntimeError` it makes sense to also not evaluate the arguments that are part of the call expression.


One thing to note is that the order of the text explaining the original `visitCallExpr` snippet is no longer exactly matching the order of the lines of code. I couldn't think of a simple way to re-organize the text based on its current form, but it also doesn't seem like it would confuse readers.