### PR TITLE
Remove aside about adding comma to previous line

### DIFF
--- a/book/statements-and-state.md
+++ b/book/statements-and-state.md
@@ -419,14 +419,6 @@ The generated code for the new node is in [Appendix II][appendix-var-stmt].
 declaring, along with the initializer expression. (If there isn't an
 initializer, that's `null`.)
 
-<aside name="comma">
-
-The existing line for the Print statement is marked as being replaced because we
-need to add a comma at the end of it. Likewise in the next code snippet. Details
-matter!
-
-</aside>
-
 Then we add an expression node for accessing a variable:
 
 ^code var-expr (1 before, 1 after)

--- a/site/statements-and-state.html
+++ b/site/statements-and-state.html
@@ -586,11 +586,6 @@ add <em>&ldquo;,&rdquo;</em> to previous line</div>
 <p><span name="comma">It</span> stores the name token so we know what it&rsquo;s
 declaring, along with the initializer expression. (If there isn&rsquo;t an
 initializer, that&rsquo;s <code>null</code>.)</p>
-<aside name="comma">
-<p>The existing line for the Print statement is marked as being replaced because we
-need to add a comma at the end of it. Likewise in the next code snippet. Details
-matter!</p>
-</aside>
 <p>Then we add an expression node for accessing a variable:</p>
 <div class="codehilite"><pre class="insert-before"><span></span>      <span class="s">&quot;Literal  : Object value&quot;</span><span class="o">,</span>
 </pre><pre class="insert-before"><span></span>      <span class="s">&quot;Unary    : Token operator, Expr right&quot;</span><span class="o"><span class="insert-comma">,</span></span>


### PR DESCRIPTION
Since 357c6c8c this aside is no longer accurate, because the snippet generator detects such cases and creates a snippet (and associated instructions) that clearly indicates the added comma.