### PR TITLE
Note removal of Parser.parse() error handling

### DIFF
--- a/book/statements-and-state.md
+++ b/book/statements-and-state.md
@@ -149,6 +149,13 @@ the correct starting rule, `program`, we can turn `parse()` into the real deal:
 
 ^code parse
 
+<aside name="parse-error-handling">
+
+We've also removed the temporary handling for `ParseError` exceptions, because it
+will be handled differently when we add support for additional statement types.
+
+</aside>
+
 It parses a series of statements, as many as it can find until it hits the end
 of the input. This is a pretty direct translation of the `program` rule into
 recursive descent style. We must also chant a minor prayer to the Java Verbosity

--- a/site/statements-and-state.html
+++ b/site/statements-and-state.html
@@ -260,6 +260,10 @@ replace 7 lines</div>
 
 <div class="source-file-narrow"><em>lox/Parser.java</em>, method <em>parse</em>(), replace 7 lines</div>
 
+<aside name="parse-error-handling">
+<p>We&rsquo;ve also removed the temporary handling for <code>ParseError</code> exceptions, because it
+will be handled differently when we add support for additional statement types.</p>
+</aside>
 <p>It parses a series of statements, as many as it can find until it hits the end
 of the input. This is a pretty direct translation of the <code>program</code> rule into
 recursive descent style. We must also chant a minor prayer to the Java Verbosity


### PR DESCRIPTION
This is pretty minor, but I was confused for a bit that the revamped `Parser.parse()` method to handle statements no longer included the `try..catch` structure for handling `ParseError`s.