### PR TITLE
Netscape -> Netscape Navigator

### DIFF
--- a/book/the-lox-language.md
+++ b/book/the-lox-language.md
@@ -91,9 +91,9 @@ indebted to Lua's clean, efficient implementation.
 
 Now that JavaScript has taken over the world and is used to build ginormous
 applications, it's hard to think of it as a "little scripting language". But
-Brendan Eich hacked it into Netscape Navigator in *ten days* to make buttons animate on
-web pages. JavaScript has grown up since then, but it was once a cute little
-language.
+Brendan Eich hacked it into Netscape Navigator in *ten days* to make buttons
+animate on web pages. JavaScript has grown up since then, but it was once a
+cute little language.
 
 Because Eich slapped JS together with roughly the same raw materials and time as
 an episode of MacGyver, it has some weird semantic corners where the duct tape

--- a/book/the-lox-language.md
+++ b/book/the-lox-language.md
@@ -91,7 +91,7 @@ indebted to Lua's clean, efficient implementation.
 
 Now that JavaScript has taken over the world and is used to build ginormous
 applications, it's hard to think of it as a "little scripting language". But
-Brendan Eich hacked it into Netscape in *ten days* to make buttons animate on
+Brendan Eich hacked it into Netscape Navigator in *ten days* to make buttons animate on
 web pages. JavaScript has grown up since then, but it was once a cute little
 language.
 


### PR DESCRIPTION
A teensy nit. Wasn't the browser itself called "Netscape Navigator" by this point? It was Mozilla Netscape when it was 0.x, but the 2.0 release was called Netscape Navigator (see [official book cover](https://archive.org/details/officialnetscape00jame)). Also see [this Wikipedia article](https://en.wikipedia.org/wiki/JavaScript#Beginnings_at_Netscape).