### PR TITLE
Fix insert code block width / selection - take two

### DIFF
--- a/asset/style.scss
+++ b/asset/style.scss
@@ -527,7 +527,10 @@ footer {
 
 // Syntax highlighting.
 .codehilite {
-  pre { color: mix($warm-light, $warm-dark, 20%); }
+  pre {
+    color: mix($warm-light, $warm-dark, 20%);
+    padding: 10px 10px 0 12px;
+  }
 
   // Keyword.
   .k, .kd, .kt, .kn, .kr  { color: hsl(200, 100%, 45%); }
@@ -556,8 +559,14 @@ footer {
   // Built-in name ("this", etc.).
   .nb                     { color: hsl(200, 100%, 45%); }
 
+  .code-wrapper {
+    display: inline-block;
+    min-width: 100%;
+    box-sizing: border-box;
+    margin: -12px;
+  }
+
   .insert {
-    margin: -2px -12px;
     padding: 2px 10px;
     border-left: solid 2px $warm-80;
     border-right: solid 2px $warm-80;
@@ -565,8 +574,12 @@ footer {
 
     // Make sure the background is as wide as needed even when it overflows and
     // needs to scroll.
-    display: inline-block;
+    display: block;
     min-width: 100%;
+  }
+
+  .insert-after {
+    padding: 0 10px 0 12px;
   }
 
   .delete {

--- a/util/build.py
+++ b/util/build.py
@@ -96,7 +96,7 @@ def get_part_chapters(title):
   return chapters
 
 
-def format_code(language, length, lines):
+def format_code(language, lines):
   markup = '```{}\n'.format(language)
 
   # Hack. Markdown seems to discard leading and trailing newlines, so we'll
@@ -112,7 +112,7 @@ def format_code(language, length, lines):
     trailing_newlines += 1
 
   for line in lines:
-    markup += line.ljust(length, ' ') + '\n'
+    markup += line + '\n'
 
   markup += '```'
 
@@ -197,25 +197,10 @@ def insert_snippet(snippets, arg, contents, errors):
 
   # TODO: Show indentation in snippets somehow.
 
-  # Figure out the length of the longest line. We pad all of the snippets to
-  # this length so that the background on the pre sections is as wide as the
-  # entire chunk of code.
-  length = 0
-  if before_lines > 0:
-    length = longest_line(length, snippet.context_before[-before_lines:])
-  if snippet.removed and not snippet.added:
-    length = longest_line(length, snippet.removed)
-  if snippet.added_comma:
-    length = longest_line(length, snippet.added_comma)
-  if snippet.added:
-    length = longest_line(length, snippet.added)
-  if after_lines > 0:
-    length = longest_line(length, snippet.context_after[:after_lines])
-
-  contents += '<div class="codehilite">'
+  contents += '<div class="codehilite"><div class="code-wrapper">'
 
   if before_lines > 0:
-    before = format_code(snippet.file.language(), length,
+    before = format_code(snippet.file.language(),
         snippet.context_before[-before_lines:])
     if snippet.added:
       before = before.replace('<pre>', '<pre class="insert-before">')
@@ -225,7 +210,7 @@ def insert_snippet(snippets, arg, contents, errors):
     def replace_last(string, old, new):
       return new.join(string.rsplit(old, 1))
 
-    comma = format_code(snippet.file.language(), length, [snippet.added_comma])
+    comma = format_code(snippet.file.language(), [snippet.added_comma])
     comma = comma.replace('<pre>', '<pre class="insert-before">')
     comma = replace_last(comma, ',', '<span class="insert-comma">,</span>')
     contents += comma
@@ -235,24 +220,24 @@ def insert_snippet(snippets, arg, contents, errors):
         '<br>\n'.join(location))
 
   if snippet.removed and not snippet.added:
-    removed = format_code(snippet.file.language(), length, snippet.removed)
+    removed = format_code(snippet.file.language(), snippet.removed)
     removed = removed.replace('<pre>', '<pre class="delete">')
     contents += removed
 
   if snippet.added:
-    added = format_code(snippet.file.language(), length, snippet.added)
+    added = format_code(snippet.file.language(), snippet.added)
     if before_lines > 0 or after_lines > 0:
       added = added.replace('<pre>', '<pre class="insert">')
     contents += added
 
   if after_lines > 0:
-    after = format_code(snippet.file.language(), length,
+    after = format_code(snippet.file.language(),
         snippet.context_after[:after_lines])
     if snippet.added:
       after = after.replace('<pre>', '<pre class="insert-after">')
     contents += after
 
-  contents += '</div>'
+  contents += '</div></div>'
 
   if show_location:
     contents += '<div class="source-file-narrow">{}</div>\n'.format(


### PR DESCRIPTION
Add a wrapper around the code blocks.  This wrapper will take its size
from the code contents, thus being full width _and_ be the immediate
parent of the code elements.  The codehilite block can therefore
overflow and have a limited viewport / size that doesn't matter to the
sizing of the child, as we established that its size will be dictated by
its contents.  CSS is ~~awesome~~ pathologial.

Fixes #276 while maintaining the fix for #252