### PR TITLE
Fix typos found via a Levenshtein-style corrector

### DIFF
--- a/book/garbage-collection.md
+++ b/book/garbage-collection.md
@@ -703,7 +703,7 @@ every object in the heap, checking their mark bits. If an object is unmarked
 function we already wrote.
 
 Most of the other code in here deals with the fact that removing a node from a
-singly-linked list is cumbersome. We have to continously remember the previous
+singly-linked list is cumbersome. We have to continuously remember the previous
 node so we can unlink its next pointer, and we have to handle the edge case
 where we are freeing the first node. But, otherwise, it's pretty simple --
 delete every node in a linked list that doesn't have a bit set in it.

--- a/book/resolving-and-binding.md
+++ b/book/resolving-and-binding.md
@@ -292,7 +292,7 @@ previously-declared variables along with the one new name. Declaring a variable
 would do the implicit "split" where you have an environment before the variable
 is declared and one after:
 
-<img src="image/resolving-and-binding/split.png" alt="Seperate environments before and after the variable is declared." />
+<img src="image/resolving-and-binding/split.png" alt="Separate environments before and after the variable is declared." />
 
 A closure retains a reference to the Environment instance in play when the
 function was declared. Since any later declarations in that block would produce

--- a/note/design breaks.md
+++ b/note/design breaks.md
@@ -12,7 +12,7 @@
 
 - Choosing reserved words. Abbreviations to avoid name collisions.
 
-- When to write a language spec and what it's for. Usefull to help think
+- When to write a language spec and what it's for. Useful to help think
   precisely about semantics. Doesn't help improve usability of language. Need to
   actually play with an implementation for that. Very time consuming. Users
   don't need it. They need more user-friendly docs. Important when you have

--- a/note/log.txt
+++ b/note/log.txt
@@ -716,7 +716,7 @@
 2017/12/24 - more work organizing "chunks of bytecode"
 2017/12/23 - 149 words outline "chunks of bytecode"
 2017/12/22 - 164 words outline "chunks of bytecode"
-2017/12/21 - finish spliting snippets for "chunks of bytecode"
+2017/12/21 - finish splitting snippets for "chunks of bytecode"
 2017/12/20 - split up and organize snippets for "chunks of bytecode"
 2017/12/19 - more outline "chunks of bytecode"
 2017/12/18 - 186 words, outline "chunks of bytecode"

--- a/site/garbage-collection.html
+++ b/site/garbage-collection.html
@@ -1097,7 +1097,7 @@ every object in the heap, checking their mark bits. If an object is unmarked
 (white), we unlink it from the list and free it using the <code>freeObject()</code>
 function we already wrote.</p>
 <p>Most of the other code in here deals with the fact that removing a node from a
-singly-linked list is cumbersome. We have to continously remember the previous
+singly-linked list is cumbersome. We have to continuously remember the previous
 node so we can unlink its next pointer, and we have to handle the edge case
 where we are freeing the first node. But, otherwise, it&rsquo;s pretty simple<span class="em">&mdash;</span>delete every node in a linked list that doesn&rsquo;t have a bit set in it.</p>
 <p><img src="image/garbage-collection/unlink.png" alt="A recycle bin full of bits." /></p>

--- a/site/resolving-and-binding.html
+++ b/site/resolving-and-binding.html
@@ -354,7 +354,7 @@ a variable it would return a <em>new</em> environment that contained all of the
 previously-declared variables along with the one new name. Declaring a variable
 would do the implicit &ldquo;split&rdquo; where you have an environment before the variable
 is declared and one after:</p>
-<p><img src="image/resolving-and-binding/split.png" alt="Seperate environments before and after the variable is declared." /></p>
+<p><img src="image/resolving-and-binding/split.png" alt="Separate environments before and after the variable is declared." /></p>
 <p>A closure retains a reference to the Environment instance in play when the
 function was declared. Since any later declarations in that block would produce
 new Environment objects, the closure wouldn&rsquo;t see the new variables and our bug


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.