### PR TITLE
Add start of a glossary

### DIFF
--- a/asset/template/contents.html
+++ b/asset/template/contents.html
@@ -86,6 +86,7 @@
 <ul>
   <li><span class="num">A1.</span><a href="appendix-i.html">Appendix I: Lox Grammar</a></li>
   <li><span class="num">A2.</span><a href="appendix-ii.html">Appendix II: Generated Syntax Tree Classes</a></li>
+  <li><span class="num">A3.</span><a href="glossary.html">Glossary</a></li>
 </ul>
 
 <footer>

--- a/book/glossary.md
+++ b/book/glossary.md
@@ -1,0 +1,16 @@
+^title Glossary
+^part Backmatter
+
+**AST - Abstract Syntax Tree**: A special kind of *tree* that holds information about the parsed source code of a program.    
+**statically typed**: A language where type checking is performed at compile time. e.g. C, C++, C#, Java    
+**dynamically typed**: A language where type checking is performed at runtime. e.g. JavaScript, Lox, Python, Ruby, Lua    
+**strongly typed**: The type of an object is fixed and cannot be treated as a different type e.g. C#, Java, Python, Ruby, Lox    
+**weakly typed**: The type of an object is able to be used interchangably as others (type coercion). e.g JavaScript, Visual Basic with `Option Strict off`.    
+**data structure**: A structured area of memory that holds data. e.g. array, list, *tree*, *graph*    
+**graph**: A *data structure* with references from each *node* to zero or more other *nodes* and may contain circular references (or cycles).    
+**tree**: A strictly forward-referencing *graph* which may not contain cycles and each *node* must have exactly one path from the root *node*.    
+**node**: The basic unit of data in a *graph* that contains information about the *edges* connected to that node.    
+**edge (graph)**: A reference from one *node* to another. May have a direction.    
+**recursion**: A thing that refers to itself.  A recursive function is a function that calls itself inside the function body.    
+**meta-programming**: Code that adds to, or alters the running program code as a side-effect of its execution.  e.g. creating a class definition based on string input.    
+

--- a/util/book.py
+++ b/util/book.py
@@ -274,6 +274,10 @@ TOC = [
       {
         'name': 'Appendix II',
         'topics': [],
+      },
+      {
+        'name': 'Glossary',
+        'topics': [],
       }
     ],
   },


### PR DESCRIPTION
This has a few short terms defined that are a bit more
computer-science-y than is necessary knowledge to hack on the lox
interpreter.  However, the explanations of the implementation
necessarily uses these terms.  See #54 for more details.

I started with the term mentioned in #54 (AST) and explained the turtles holding up that term.  I also added the terms mentioned in the notes (dynamically and statically typed) and then added the natural complementary terms strongly and weakly typed.

Metaprogramming is a bonus.

This likely isn't complete and contains a mix of my interpretation of the terms and a short amount of googling.
The formatting is also probably not adequate, but I expect you'll want to be in control of that (note the extra whitespace at the line ends is how to force a newline in MD).

I don't think I used any UK english, but it's what I speak, so there might be some in there out of habit.  My ability to proof for that is limited at this point.