### PR TITLE
accept-method: add missing @Override annotation

### DIFF
--- a/java/com/craftinginterpreters/tool/GenerateAst.java
+++ b/java/com/craftinginterpreters/tool/GenerateAst.java
@@ -184,6 +184,7 @@ public class GenerateAst {
 
     // Visitor pattern.
     writer.println();
+    writer.println("    @Override");
     writer.println("    <R> R accept(Visitor<R> visitor) {");
     writer.println("      return visitor.visit" +
         className + baseName + "(this);");


### PR DESCRIPTION
Thanks for an _incredibly nice_ book! I have been thinking of writing a programming language of my own for a couple of years, so this book is a literal gold-mine for me in learning more about the subject. :slightly_smiling_face: 

While converting the `GenerateAst` class to Ruby (don't ask... I just happen to have used it for a number of years and felt like it would be a useful & fun little task instead of "just reading" and copy-pasting the Java code into my project :slightly_smiling_face:) I noted that this annotation seemed to be missing, so here goes.

----

(Do you btw happen to have some "contrib" section where I could add a link to my Ruby version of the `GenerateAst` class in its entirety btw? I feel like it could be useful to share with others who also feel - like you also imply in `representing-code.md` - that Java is perhaps not the optimal tool for this, and want to try out something else.)