### PR TITLE
OP_INVOKE takes three bytes

### DIFF
--- a/c/debug.c
+++ b/c/debug.c
@@ -36,7 +36,7 @@ static int invokeInstruction(const char* name, Chunk* chunk,
   printf("%-16s (%d args) %4d '", name, argCount, constant);
   printValue(chunk->constants.values[constant]);
   printf("'\n");
-  return offset + 2;
+  return offset + 3;
 }
 //< Methods and Initializers invoke-instruction
 //> simple-instruction


### PR DESCRIPTION
+1 is for method name constant, +2 is for `argCount`,
so `OP_INVOKE` takes three bytes.

I've tested the code below:

```javascript
class Foo {
  bar() {
  }
}

Foo().bar();
```

with `DEBUG_PRINT_CODE` enabled.

#### Before fix

```
== bar ==
0000    3 OP_NIL
0001    | OP_RETURN
== <script> ==
0000    1 OP_CLASS            0 'Foo'
0002    | OP_DEFINE_GLOBAL    0 'Foo'
0004    | OP_GET_GLOBAL       1 'Foo'
0006    3 OP_CLOSURE          3 <fn bar>
0008    | OP_METHOD           2 'bar'
0010    4 OP_POP
0011    6 OP_GET_GLOBAL       4 'Foo'
0013    | OP_CALL             0
0015    | OP_INVOKE        (0 args)    5 'bar'
0017    | OP_CONSTANT         4 'Foo'    // <= Wrong
0019    7 OP_NIL
0020    | OP_RETURN
```

#### After fix

```
== bar ==
0000    3 OP_NIL
0001    | OP_RETURN
== <script> ==
0000    1 OP_CLASS            0 'Foo'
0002    | OP_DEFINE_GLOBAL    0 'Foo'
0004    | OP_GET_GLOBAL       1 'Foo'
0006    3 OP_CLOSURE          3 <fn bar>
0008    | OP_METHOD           2 'bar'
0010    4 OP_POP
0011    6 OP_GET_GLOBAL       4 'Foo'
0013    | OP_CALL             0
0015    | OP_INVOKE        (0 args)    5 'bar'
0018    | OP_POP    // <= Fixed
0019    7 OP_NIL
0020    | OP_RETURN
```
