### PR TITLE
Fix typo in 30.3.3

### DIFF
--- a/book/optimization.md
+++ b/book/optimization.md
@@ -779,7 +779,7 @@ It hands off the double to:
 ^code num-to-value (1 before, 2 after)
 
 This creates a temporary union, stores the double in it, and then yanks out the
-uint64_4 whose bits overlap that in memory. This code appears slow: a function
+uint64_t whose bits overlap that in memory. This code appears slow: a function
 call, a local variable, an assignment, and a read. Fortunately, compilers are
 smart enough to optimize it all away.
 


### PR DESCRIPTION
uint64_4 sounds like some kinda 256bit SIMD type to me. While SIMD is one of my favorite optimizations, it's not quite what the rest of the section is about.