### PR TITLE
Fixed some typos for Section 29: Superclasses

### DIFF
--- a/book/superclasses.md
+++ b/book/superclasses.md
@@ -117,7 +117,7 @@ reference to its superclass. When a method was accessed, if we didn't find it in
 the subclass's method table, we recursed through the inheritance chain looking
 at each ancestor's method table until we found it.
 
-For example, calling `cook()` on an instance Cruller sends the VM on this
+For example, calling `cook()` on an instance of Cruller sends the VM on this
 journey:
 
 <img src="image/superclasses/jlox-resolve.png" alt="Resolving a call to cook() in an instance of Cruller means walking the superclass chain." />

--- a/book/superclasses.md
+++ b/book/superclasses.md
@@ -62,7 +62,7 @@ variable reference, and emits code to load the variable's value. In other words,
 it looks up the superclass by name and pushes it onto the stack.
 
 After that, we call `namedVariable()` to load the subclass doing the inheriting
-onto to the stack, followed by an `OP_INHERIT` instruction. That instruction
+onto the stack, followed by an `OP_INHERIT` instruction. That instruction
 wires up the superclass to the new subclass. In the last chapter, we defined an
 `OP_METHOD` instruction to mutate an existing class object by adding a method to
 its method table. This is similar -- the `OP_INHERIT` instruction takes an

--- a/book/superclasses.md
+++ b/book/superclasses.md
@@ -32,7 +32,7 @@ much faster, way of handling inherited method calls this time around.
 
 ## Inheriting Methods
 
-We'll kick things of with method inheritance since it's the simpler piece. To
+We'll kick things off with method inheritance since it's the simpler piece. To
 refresh your memory, Lox inheritance syntax looks like this:
 
 ```lox

--- a/book/superclasses.md
+++ b/book/superclasses.md
@@ -217,7 +217,7 @@ refresh your memory on how super calls are statically resolved.
 
 <aside name="may">
 
-"May" might not a strong enough word. Presumably the method *has* been
+"May" might not be a strong enough word. Presumably the method *has* been
 overridden. Otherwise, why are you bothering to use `super` instead of just
 calling it directly?
 

--- a/site/superclasses.html
+++ b/site/superclasses.html
@@ -335,7 +335,7 @@ name="may">may</span> override the superclass method, we need to be able to get
 our hands on superclass method tables. Before we get to mechanism, I want to
 refresh your memory on how super calls are statically resolved.</p>
 <aside name="may">
-<p>&ldquo;May&rdquo; might not a strong enough word. Presumably the method <em>has</em> been
+<p>&ldquo;May&rdquo; might not be a strong enough word. Presumably the method <em>has</em> been
 overridden. Otherwise, why are you bothering to use <code>super</code> instead of just
 calling it directly?</p>
 </aside>

--- a/site/superclasses.html
+++ b/site/superclasses.html
@@ -250,7 +250,7 @@ different path than jlox. In our first interpreter, each subclass stored a
 reference to its superclass. When a method was accessed, if we didn&rsquo;t find it in
 the subclass&rsquo;s method table, we recursed through the inheritance chain looking
 at each ancestor&rsquo;s method table until we found it.</p>
-<p>For example, calling <code>cook()</code> on an instance Cruller sends the VM on this
+<p>For example, calling <code>cook()</code> on an instance of Cruller sends the VM on this
 journey:</p>
 <p><img src="image/superclasses/jlox-resolve.png" alt="Resolving a call to cook() in an instance of Cruller means walking the superclass chain." /></p>
 <p>That&rsquo;s a lot of work to perform during method <em>invocation</em> time. It&rsquo;s slow and,

--- a/site/superclasses.html
+++ b/site/superclasses.html
@@ -172,7 +172,7 @@ superclass clause. We consume the superclass&rsquo;s identifier token, then call
 variable reference, and emits code to load the variable&rsquo;s value. In other words,
 it looks up the superclass by name and pushes it onto the stack.</p>
 <p>After that, we call <code>namedVariable()</code> to load the subclass doing the inheriting
-onto to the stack, followed by an <code>OP_INHERIT</code> instruction. That instruction
+onto the stack, followed by an <code>OP_INHERIT</code> instruction. That instruction
 wires up the superclass to the new subclass. In the last chapter, we defined an
 <code>OP_METHOD</code> instruction to mutate an existing class object by adding a method to
 its method table. This is similar<span class="em">&mdash;</span>the <code>OP_INHERIT</code> instruction takes an

--- a/site/superclasses.html
+++ b/site/superclasses.html
@@ -133,7 +133,7 @@ super calls is pretty much the same, though viewed through clox&rsquo;s more com
 mechanism for storing state on the stack. But we have an entirely different,
 much faster, way of handling inherited method calls this time around.</p>
 <h2><a href="#inheriting-methods" name="inheriting-methods"><small>29&#8202;.&#8202;1</small> Inheriting Methods</a></h2>
-<p>We&rsquo;ll kick things of with method inheritance since it&rsquo;s the simpler piece. To
+<p>We&rsquo;ll kick things off with method inheritance since it&rsquo;s the simpler piece. To
 refresh your memory, Lox inheritance syntax looks like this:</p>
 <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="vg">Doughnut</span> <span class="p">{</span>
   <span class="n">cook</span><span class="p">()</span> <span class="p">{</span>


### PR DESCRIPTION
Fixed Issues #624, #625, and #626.
"kick things **off**"
"instance **of**"
"might not **be**"

Edit: also fixed Issue #688.
"onto **to**"