### PR TITLE
Fix even/odd mutual recursion test examples.

### DIFF
--- a/test/function/local_mutual_recursion.lox
+++ b/test/function/local_mutual_recursion.lox
@@ -5,6 +5,7 @@
   }
 
   fun isOdd(n) {
+    if (n == 0) return false;
     return isEven(n - 1);
   }
 

--- a/test/function/mutual_recursion.lox
+++ b/test/function/mutual_recursion.lox
@@ -4,6 +4,7 @@ fun isEven(n) {
 }
 
 fun isOdd(n) {
+  if (n == 0) return false;
   return isEven(n - 1);
 }
 


### PR DESCRIPTION
Spotted these small omissions while get interpreters up and running and picking out code to run from the `test` directory.  

Both tests missed the odd function's base case,  each of which will cause runtime/stack overflows errors in both interpreters when running the functions where with arguments that should cause functions to evaluate to false.

Not sure if these omissions were on purpose or not, but for your consideration.

