### PR TITLE
Replace `fopen` with `fopen_s`?

### DIFF
--- a/c/main.c
+++ b/c/main.c
@@ -33,7 +33,8 @@ static void repl() {
 //< Scanning on Demand repl
 //> Scanning on Demand read-file
 static char* readFile(const char* path) {
-  FILE* file = fopen(path, "rb");
+  FILE* file = NULL;
+  fopen_s(&file, path, "rb");
 //> no-file
   if (file == NULL) {
     fprintf(stderr, "Could not open file \"%s\".\n", path);


### PR DESCRIPTION
When I run this on Windows 10, It looks like Microsoft has deprecated `fopen`.

You should probably do something like this though:
```
#ifdef _WIN32
#define _CRT_SECURE_NO_DEPRECATE
#endif
```
Because other platforms don't need that defined during compile time.
Since Microsoft may remove the function in question in a later version of the CRT, I added this. :)