### PR TITLE
Fixing typo on chapter 17

### DIFF
--- a/book/compiling-expressions.md
+++ b/book/compiling-expressions.md
@@ -505,7 +505,7 @@ this:
 ^code parse-precedence
 
 This function, once we implement it, starts at the current token and parses any
-expression at the given precence level or higher. We have some other setup to
+expression at the given precedence level or higher. We have some other setup to
 get through before we can write the body of this function, but you can probably
 guess that it will use that table of parsing function pointers I've been talking
 about. For now, don't worry too much about how it works. In order to take the


### PR DESCRIPTION
There is a typo on chapter 17 where `precence` is written instead of `precedence`.

kudos to [/u/nanoman1](https://www.reddit.com/r/craftinginterpreters/comments/giqqkz/typo_in_chapter_17_parsing_in_c/) for spotting it