### PR TITLE
Use the article 'an' before '='

### DIFF
--- a/book/scanning.md
+++ b/book/scanning.md
@@ -445,7 +445,7 @@ user experience.
 
 We have single-character lexemes covered, but that doesn't cover all of Lox's
 operators. What about `!`? It's a single character, right? Sometimes, yes, but
-not when it's followed by a `=`. In that case, it should be a `!=` lexeme.
+not when it's followed by an `=`. In that case, it should be a `!=` lexeme.
 Likewise, `<`, `>`, and `=` can all be followed by `=`.
 
 For those, we need to look at the second character:

--- a/book/statements-and-state.md
+++ b/book/statements-and-state.md
@@ -877,7 +877,10 @@ Consider a complex field assignment like:
 
 You can still use this trick even if there are assignment targets that are not
 valid expressions. Define a **cover grammar**, a looser grammar that accepts
-both all of the valid expression *and* assignment target syntaxes. When you hit a `=`, report an error if the left-hand side isn't within the valid assignment target grammar. Conversely, if you *don't* hit a `=`, report an error if the left-hand side isn't a valid *expression*.
+both all of the valid expression *and* assignment target syntaxes. When you hit
+an `=`, report an error if the left-hand side isn't within the valid assignment
+target grammar. Conversely, if you *don't* hit an `=`, report an error if the
+left-hand side isn't a valid *expression*.
 
 </aside>
 


### PR DESCRIPTION
```s/a `=`/an `=`/```

Fixes #740 