### PR TITLE
Fixed  `pub get` command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ other utilities are all written in [Dart][]. Instructions to install Dart are
 [here][install]. Once you have Dart installed and on your path, run:
 
 ```sh
-$ pub get
+$ pushd tool; pub get; popd
 ```
+
+(Or simply invoke `pub get` from inside the `tool` directory).
 
 [dart]: https://dart.dev/
 [install]: https://dart.dev/get-dart


### PR DESCRIPTION
Update README to reflect correct usage of the `pub get` command to pull in the project build dependencies.