### PR TITLE
correct environment initializer when no environment is passed

### DIFF
--- a/java/com/craftinginterpreters/lox/Environment.java
+++ b/java/com/craftinginterpreters/lox/Environment.java
@@ -11,7 +11,7 @@ class Environment {
   private final Map<String, Object> values = new HashMap<>();
 //> environment-constructors
   Environment() {
-    enclosing = null;
+    this.enclosing = null;
   }
 
   Environment(Environment enclosing) {


### PR DESCRIPTION
i think this is what you meant to do.

probably works because `enclosing` is null by default