### PR TITLE
identifierType() uses K&R bracket style

### DIFF
--- a/c/scanner.c
+++ b/c/scanner.c
@@ -131,8 +131,7 @@ static TokenType checkKeyword(int start, int length,
 }
 //< check-keyword
 //> identifier-type
-static TokenType identifierType()
-{
+static TokenType identifierType() {
 //> keywords
   switch (scanner.start[0]) {
     case 'a': return checkKeyword(1, 2, "nd", TOKEN_AND);


### PR DESCRIPTION
...but the other definitions have the opening bracket on the declaration line, and this inconsistency irks me :smile: