### PR TITLE
use parentheses for grouping

### DIFF
--- a/book/representing-code.md
+++ b/book/representing-code.md
@@ -363,12 +363,12 @@ recursion.
 With all of those syntactic niceties, our breakfast grammar condenses down to:
 
 ```ebnf
-breakfast → protein ( "with" breakfast "on the side" )?
+breakfast → ( protein ( "with" breakfast "on the side" )? )
           | bread ;
 
-protein   → "really"+ "crispy" "bacon"
+protein   → ( "really"+ "crispy" "bacon" )
           | "sausage"
-          | ( "scrambled" | "poached" | "fried" ) "eggs" ;
+          | ( ( "scrambled" | "poached" | "fried" ) "eggs" ) ;
 
 bread     → "toast" | "biscuits" | "English muffin" ;
 ```


### PR DESCRIPTION
considering the parentheses were introduced just a few paragraphs earlier, it would probably make sense to use them here.
otherwise 'protein bread' would be a possible breakfast, just as 'really really crispy poached eggs' would be a possible protein.

these groups were already on separate lines, hence the meaning could be inferred, but the pipe rule doesn't state anything about newlines, and making these groups explicit is probably the 'correct' way to state intent.

thank you for making this so accessible!