### PR TITLE
Ch 18.3.2 Update reference to BINARY_OP macro

### DIFF
--- a/book/types-of-values.md
+++ b/book/types-of-values.md
@@ -354,7 +354,7 @@ That macro seemed like overkill a [few chapters ago][], but we get the benefit
 from it today. It lets us add the necessary type checking and conversions in one
 place.
 
-[few chapters ago]: a-virtual-machine.html
+[few chapters ago]: a-virtual-machine.html#binary-operators
 
 ^code binary-op (2 before, 2 after)
 

--- a/book/types-of-values.md
+++ b/book/types-of-values.md
@@ -350,11 +350,11 @@ underlying C operator they use. To minimize redundant code between the four
 operators, we wrapped up the commonality in a big preprocessor macro that takes
 the operator token as a parameter.
 
-That macro seemed like overkill in the [last chapter][], but we get the benefit
+That macro seemed like overkill a [few chapters ago][], but we get the benefit
 from it today. It lets us add the necessary type checking and conversions in one
 place.
 
-[last chapter]: compiling-expressions.html
+[few chapters ago]: a-virtual-machine.html
 
 ^code binary-op (2 before, 2 after)
 

--- a/site/types-of-values.html
+++ b/site/types-of-values.html
@@ -510,7 +510,7 @@ today: <code>+</code>, <code>-</code>, <code>*</code>, and <code>/</code>. The o
 underlying C operator they use. To minimize redundant code between the four
 operators, we wrapped up the commonality in a big preprocessor macro that takes
 the operator token as a parameter.</p>
-<p>That macro seemed like overkill in the <a href="compiling-expressions.html">last chapter</a>, but we get the benefit
+<p>That macro seemed like overkill a <a href="a-virtual-machine.html">few chapters ago</a>, but we get the benefit
 from it today. It lets us add the necessary type checking and conversions in one
 place.</p>
 <div class="codehilite"><pre class="insert-before">

--- a/site/types-of-values.html
+++ b/site/types-of-values.html
@@ -510,7 +510,7 @@ today: <code>+</code>, <code>-</code>, <code>*</code>, and <code>/</code>. The o
 underlying C operator they use. To minimize redundant code between the four
 operators, we wrapped up the commonality in a big preprocessor macro that takes
 the operator token as a parameter.</p>
-<p>That macro seemed like overkill a <a href="a-virtual-machine.html">few chapters ago</a>, but we get the benefit
+<p>That macro seemed like overkill a <a href="a-virtual-machine.html#binary-operators">few chapters ago</a>, but we get the benefit
 from it today. It lets us add the necessary type checking and conversions in one
 place.</p>
 <div class="codehilite"><pre class="insert-before">


### PR DESCRIPTION
Fixes #866 

Changes:
- Update reference to BINARY_OP macro to point back to Ch 15.3.1

Testing:
- I made the changes to `book/types-of-values.md` seen in this PR's diff
- Ran `make serve` to build the book on a local server 
- Navigated to http://localhost:8000/types-of-values.html, clicked on the newly renamed link to make sure it worked

Notes:
- I refrained from explicit chapter numbers/names, as that seems to be the convention in this file. 
- The changes to the `html` file I'm guessing is a part of the build process, please let me know if this gets generated some other way/shouldn't be in this merge
- Thanks for having a clear/easy to understand startup section in the README!