### PR TITLE
Add support for dark theme

### DIFF
--- a/asset/index.scss
+++ b/asset/index.scss
@@ -25,6 +25,10 @@ main {
   background: #fff;
   border-radius: 6px;
   box-shadow: 0 10px 30px 10px hsla(35, 90%, 15%, 0.2);
+
+  @media (prefers-color-scheme: dark) {
+    background: $body-background-dark;
+  }
 }
 
 h2 {
@@ -92,6 +96,10 @@ code {
   color: $warm-dark;
   font: normal 16px $mono;
   white-space: nowrap;
+
+  @media (prefers-color-scheme: dark) {
+    color: $warm-light;
+  }
 }
 
 // Then bring the margins in some.

--- a/asset/sass/chapter.scss
+++ b/asset/sass/chapter.scss
@@ -22,8 +22,12 @@ article.chapter {
   }
 
   h2 a, h3 a {
-    color: #222;
+    color: $body-color-light;
     border-bottom: none;
+
+    @media (prefers-color-scheme: dark) {
+      color: $body-color-dark;
+    }
   }
 
   h2 a:hover, h3 a:hover {
@@ -39,10 +43,28 @@ article.chapter {
     color: #fff;
     transition: color 0.2s ease;
     text-align: center;
+
+    @media (prefers-color-scheme: dark) {
+      color: $body-background-dark;
+    }
   }
 
   h2 a:hover::before, h3 a:hover::before {
     color: #ddd;
+
+    @media (prefers-color-scheme: dark) {
+      color: #444;
+    }
+  }
+
+  img {
+    @media (prefers-color-scheme: dark) {
+      mix-blend-mode: screen;
+
+      &:not(.negate) {
+        filter: invert(1);
+      }
+    }
   }
 
   .challenges, .design-note {
@@ -105,6 +127,11 @@ article.chapter {
       code, .codehilite {
         color: $warm-dark;
         background: $warm-light;
+
+        @media(prefers-color-scheme: dark) {
+          color: $warm-light;
+          background-color: $warm-dark;
+        }
       }
     }
 
@@ -122,16 +149,36 @@ article.chapter {
   .challenges {
     background: $lighter;
 
+    @media (prefers-color-scheme: dark) {
+      color: $body-color-dark;
+      background: $darker;
+    }
+
     code, .codehilite {
       background: hsl(195, 30%, 92%);
+
+      @media (prefers-color-scheme: dark) {
+        color: $body-color-dark;
+        background: hsl(225, 20%, 20%);
+      }
     }
   }
 
   .design-note {
     background: hsl(80, 30%, 96%);
 
+    @media (prefers-color-scheme: dark) {
+      color: $body-color-dark;
+      background: #1b2631;
+    }
+
     code, .codehilite {
       background: hsl(80, 20%, 93%);
+
+      @media (prefers-color-scheme: dark) {
+        color: $body-color-dark;
+        background: hsl(225, 20%, 20%);
+      }
     }
   }
 

--- a/asset/sass/shared.scss
+++ b/asset/sass/shared.scss
@@ -3,12 +3,18 @@ $serif:   "Crimson", Georgia, serif;
 $mono:    "Source Code Pro", Menlo, Consolas, Monaco, monospace;
 $nav:     "Source Sans Pro", sans-serif;
 
+// Default body colors.
+$body-color-light: #222;
+$body-color-dark: #dbe6ec;
+$body-background-dark: #181C21;
+
 // The main intense primary accent color.
 $primary:       hsl(200, 80%, 40%);
 $primary-dark:  hsl(200, 100%, 20%);
 $primary-light: hsl(200, 70%, 60%);
 
 // A ramp of washed out blues from dark to light.
+$darker:  hsl(215, 15%, 15%);
 $dark:    hsl(215, 20%, 20%);
 $gray-1:  hsl(212, 23%, 30%);
 $gray-2:  hsl(209, 26%, 40%);
@@ -94,6 +100,11 @@ img.dot {
 // Basic styles.
 
 body {
-  color: #222;
+  color: $body-color-light;
   font: normal 16px/24px $serif;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: $body-background-dark;
+    color: $body-color-dark;
+  }
 }

--- a/asset/style.scss
+++ b/asset/style.scss
@@ -33,6 +33,10 @@ a {
 a:hover {
   color: $primary;
   border-bottom: solid 1px opacify($light, 1.0);
+
+  @media(prefers-color-scheme: dark) {
+    border-bottom: solid 1px opacify($dark, 1.0);
+  }
 }
 
 nav {
@@ -280,6 +284,10 @@ code {
   color: $warm-1;
   white-space: nowrap;
   padding: 2px;
+
+  @media(prefers-color-scheme: dark) {
+    color: $warm-5;
+  }
 }
 
 strong code {
@@ -297,6 +305,11 @@ a code {
   border-radius: 3px;
   padding: 12px;
   margin: -12px;
+
+  @media(prefers-color-scheme: dark) {
+    color: $body-color-dark;
+    background: #1C2430;
+  }
 }
 
 pre {
@@ -343,6 +356,10 @@ article {
 
     font: 300 96px $nav;
     color: $light;
+
+    @media(prefers-color-scheme: dark) {
+      color: $dark;
+    }
   }
 
   p {
@@ -372,6 +389,10 @@ aside {
   font: normal 14px/20px $serif;
 
   border-top: solid 1px $light;
+
+  @media(prefers-color-scheme: dark) {
+    border-top: solid 1px $dark;
+  }
 
   p {
     margin: 20px 0;
@@ -480,6 +501,10 @@ footer {
   margin: 48px 0;
   padding-top: 48px;
 
+  @media(prefers-color-scheme: dark) {
+    border-top: solid 1px $dark;
+  }
+
   a, a:hover {
     border: none;
   }
@@ -495,11 +520,19 @@ footer {
     font: 400 17px/24px $nav;
     text-transform: uppercase;
     letter-spacing: 1px;
+
+    @media(prefers-color-scheme: dark) {
+      background-color: $body-background-dark;
+    }
   }
 
   .next:hover {
     color: $primary-dark;
     border: none;
+
+    @media(prefers-color-scheme: dark) {
+      color: $primary-light;
+    }
   }
 }
 
@@ -510,6 +543,10 @@ footer {
   em {
     color: $warm-2;
     font-style: normal;
+
+    @media (prefers-color-scheme: dark) {
+      color: $warm-4;
+    }
   }
 }
 
@@ -535,6 +572,10 @@ footer {
     left: -($col - 12px);
     width: $col - 12px;
     text-align: center;
+
+    @media (prefers-color-scheme: dark) {
+      color: $warm-dark;
+    }
   }
 }
 
@@ -591,6 +632,113 @@ footer {
 
     background: $warm-5;
     color: $warm-dark;
+  }
+
+  // Syntax highlighting - Dark theme
+  @media (prefers-color-scheme: dark) {
+
+    pre { color: $body-color-dark; }
+
+    .k { color: #B89FF7; }                  // Keyword.
+    .n { color: #0FDEBD; }                  // Number.
+    .s { color: #16C98D; }                  // String.
+    .e { color: hsl(45, 80%, 55%); }        // String escape.
+    .c { color: #2C98EC; }                  // Comment.
+    .a { color: #B89FF7; }                  // Preprocessor, annotation.
+    .i { color: #FF708E; }                  // Identifier.
+    .t { color: #FFC83F;}                   // Type name.
+
+    .insert {
+      margin: -2px -12px;
+      padding: 2px 10px;
+      border-left: solid 2px $warm-4;
+      border-right: solid 2px $warm-4;
+      background: $warm-5;
+
+      @media (prefers-color-scheme: dark) {
+        background: #242D3D;
+        border-left: solid 2px #323F55;
+        border-right: solid 2px #323F55;
+      }
+    }
+
+    .delete {
+      margin: -2px -12px;
+      padding: 2px 10px;
+      border-left: solid 2px $warm-4;
+      border-right: solid 2px $warm-4;
+      // Hatched lines.
+      background: repeating-linear-gradient(
+                      -45deg,
+                      $warm-4,
+                      $warm-4 1px,
+                      rgba(0, 0, 0, 0.0) 1px,
+                      rgba(0, 0, 0, 0.0) 6px
+      );
+
+      span {
+        color: $warm-3;
+      }
+    }
+
+    // Snippets of code before and after real code to show where to insert it.
+    .insert-before, .insert-after {
+      color: $warm-3;
+
+      @media (prefers-color-scheme: dark) {
+        color: #4E596C;
+      }
+    }
+
+    // When we just add a trailing comma to a line, highlight it specially.
+    .insert-before .insert-comma {
+      margin: -2px -1px;
+      padding: 2px 1px;
+      border-radius: 2px;
+
+      background: $warm-5;
+      color: $warm-dark;
+
+      @media (prefers-color-scheme: dark) {
+        background-color: #242D3D;
+        color: $body-color-dark;
+      }
+    }
+  }
+}
+
+// On a not-entirely-large screen, don't show the fixed nav on the left.
+@media only screen and (max-width: 1344px) {
+  nav.wide { display: none; }
+  nav.floating { display: block; }
+
+  body {
+    margin: 0 24px;
+  }
+
+  .page {
+    position: relative;
+    width: inherit;
+    max-width: $col * 19;
+    margin: 0 auto;
+  }
+
+  article {
+    width: inherit;
+    margin-right: $col * 7;
+
+    // Move the number over to not be hidden behind the navigation.
+    .number {
+      top: 73px;
+      left: inherit;
+      right: 0;
+      font-size: 72px;
+    }
+
+    h1 {
+      padding: 110px 0 18px 0;
+      font-size: 44px;
+    }
   }
 }
 

--- a/book/evaluating-expressions.md
+++ b/book/evaluating-expressions.md
@@ -9,7 +9,7 @@ chapter, our interpreter will take breath, open its eyes, and execute some code.
 
 <span name="spooky"></span>
 
-<img src="image/evaluating-expressions/lightning.png" alt="A bolt of lightning strikes a Victorian mansion. Spooky!" />
+<img src="image/evaluating-expressions/lightning.png" class="negate" alt="A bolt of lightning strikes a Victorian mansion. Spooky!" />
 
 <aside name="spooky">
 
@@ -430,7 +430,7 @@ the way out.
 
 I don't know, man, *can* you negate a muffin?
 
-<img src="image/evaluating-expressions/muffin.png" alt="A muffin, negated.">
+<img src="image/evaluating-expressions/muffin.png" class="negate" alt="A muffin, negated.">
 
 </aside>
 
@@ -642,7 +642,7 @@ and the visitor pattern we've set up today form the skeleton that later chapters
 will stuff full of interesting guts -- variables, functions, etc. Right now, the
 interpreter doesn't do very much, but it's alive!
 
-<img src="image/evaluating-expressions/skeleton.png" alt="A skeleton waving hello." />
+<img src="image/evaluating-expressions/skeleton.png" class="negate" alt="A skeleton waving hello." />
 
 <div class="challenges">
 

--- a/book/types-of-values.md
+++ b/book/types-of-values.md
@@ -203,7 +203,7 @@ type. Any time we call one of the `AS_` macros, we need to guard it behind a
 call to one of these first. With these eight macros, we can now safely shuttle
 data between Lox's dynamic world and C's static one.
 
-<aside name="universe">
+<aside name="universe" class="negate">
 
 <img src="image/types-of-values/universe.png" alt="The earthly C firmament with the Lox heavens above.">
 

--- a/site/evaluating-expressions.html
+++ b/site/evaluating-expressions.html
@@ -120,7 +120,7 @@
 thunderstorm, one of those swirling tempests that likes to yank open shutters at
 the climax of the story. Maybe toss in a few bolts of lightning. In this
 chapter, our interpreter will take breath, open its eyes, and execute some code.</p>
-<p><span name="spooky"></span></p><img src="image/evaluating-expressions/lightning.png" alt="A bolt of lightning strikes a Victorian mansion. Spooky!" />
+<p><span name="spooky"></span></p><img src="image/evaluating-expressions/lightning.png" class="negate" alt="A bolt of lightning strikes a Victorian mansion. Spooky!" />
 <aside name="spooky">
 <p>A decrepit Victorian mansion is optional, but adds to the ambiance.</p>
 </aside>
@@ -570,7 +570,7 @@ the <code>/</code> expression since it has no meaningful right operand. Likewise
 So when a runtime error occurs deep in some expression, we need to escape all
 the way out.</p>
 <aside name="muffin">
-<p>I don&rsquo;t know, man, <em>can</em> you negate a muffin?</p><img src="image/evaluating-expressions/muffin.png" alt="A muffin, negated.">
+<p>I don&rsquo;t know, man, <em>can</em> you negate a muffin?</p><img src="image/evaluating-expressions/muffin.png" class="negate" alt="A muffin, negated.">
 </aside>
 <p>We could print a runtime error and then abort the process and exit the
 application entirely. That has a certain melodramatic flair. Sort of the
@@ -923,7 +923,7 @@ execution. Congratulations, you now have your very own arithmetic calculator.</p
 <p>As you can see, the interpreter is pretty bare bones. But the Interpreter class
 and the visitor pattern we&rsquo;ve set up today form the skeleton that later chapters
 will stuff full of interesting guts<span class="em">&mdash;</span>variables, functions, etc. Right now, the
-interpreter doesn&rsquo;t do very much, but it&rsquo;s alive!</p><img src="image/evaluating-expressions/skeleton.png" alt="A skeleton waving hello." />
+interpreter doesn&rsquo;t do very much, but it&rsquo;s alive!</p><img src="image/evaluating-expressions/skeleton.png" class="negate" alt="A skeleton waving hello." />
 <div class="challenges">
 <h2><a href="#challenges" name="challenges">Challenges</a></h2>
 <ol>

--- a/site/index.css
+++ b/site/index.css
@@ -52,6 +52,12 @@ body {
   color: #222;
   font: normal 16px/24px "Crimson", Georgia, serif;
 }
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #181C21;
+    color: #dbe6ec;
+  }
+}
 
 .sign-up {
   position: relative;
@@ -146,6 +152,11 @@ main {
   border-radius: 6px;
   box-shadow: 0 10px 30px 10px rgba(73, 44, 4, 0.2);
 }
+@media (prefers-color-scheme: dark) {
+  main {
+    background: #181C21;
+  }
+}
 
 h2 {
   font: 600 20px/24px "Crimson", Georgia, serif;
@@ -209,6 +220,11 @@ code {
   color: #595959;
   font: normal 16px "Source Code Pro", Menlo, Consolas, Monaco, monospace;
   white-space: nowrap;
+}
+@media (prefers-color-scheme: dark) {
+  code {
+    color: #faf8f5;
+  }
 }
 
 @media only screen and (max-width: 630px) {

--- a/site/style.css
+++ b/site/style.css
@@ -53,6 +53,12 @@ body {
   color: #222;
   font: normal 16px/24px "Crimson", Georgia, serif;
 }
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #181C21;
+    color: #dbe6ec;
+  }
+}
 
 article.chapter h2 {
   font: 600 30px/24px "Crimson", Georgia, serif;
@@ -76,6 +82,11 @@ article.chapter h2 a, article.chapter h3 a {
   color: #222;
   border-bottom: none;
 }
+@media (prefers-color-scheme: dark) {
+  article.chapter h2 a, article.chapter h3 a {
+    color: #dbe6ec;
+  }
+}
 article.chapter h2 a:hover, article.chapter h3 a:hover {
   border-bottom: none;
   color: inherit;
@@ -89,8 +100,26 @@ article.chapter h2 a::before, article.chapter h3 a::before {
   transition: color 0.2s ease;
   text-align: center;
 }
+@media (prefers-color-scheme: dark) {
+  article.chapter h2 a::before, article.chapter h3 a::before {
+    color: #181C21;
+  }
+}
 article.chapter h2 a:hover::before, article.chapter h3 a:hover::before {
   color: #ddd;
+}
+@media (prefers-color-scheme: dark) {
+  article.chapter h2 a:hover::before, article.chapter h3 a:hover::before {
+    color: #444;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  article.chapter img {
+    mix-blend-mode: screen;
+  }
+  article.chapter img:not(.negate) {
+    filter: invert(1);
+  }
 }
 article.chapter .challenges, article.chapter .design-note {
   border-radius: 3px;
@@ -137,6 +166,12 @@ article.chapter .challenges aside code, article.chapter .challenges aside .codeh
   color: #595959;
   background: #faf8f5;
 }
+@media (prefers-color-scheme: dark) {
+  article.chapter .challenges aside code, article.chapter .challenges aside .codehilite, article.chapter .design-note aside code, article.chapter .design-note aside .codehilite {
+    color: #faf8f5;
+    background-color: #595959;
+  }
+}
 article.chapter .challenges *:last-child, article.chapter .design-note *:last-child {
   margin-bottom: 0;
 }
@@ -147,14 +182,38 @@ article.chapter .design-note .codehilite {
 article.chapter .challenges {
   background: #eef4f7;
 }
+@media (prefers-color-scheme: dark) {
+  article.chapter .challenges {
+    color: #dbe6ec;
+    background: #21252c;
+  }
+}
 article.chapter .challenges code, article.chapter .challenges .codehilite {
   background: #e4eef1;
+}
+@media (prefers-color-scheme: dark) {
+  article.chapter .challenges code, article.chapter .challenges .codehilite {
+    color: #dbe6ec;
+    background: #292e3d;
+  }
 }
 article.chapter .design-note {
   background: #f6f8f2;
 }
+@media (prefers-color-scheme: dark) {
+  article.chapter .design-note {
+    color: #dbe6ec;
+    background: #1b2631;
+  }
+}
 article.chapter .design-note code, article.chapter .design-note .codehilite {
   background: #eef1ea;
+}
+@media (prefers-color-scheme: dark) {
+  article.chapter .design-note code, article.chapter .design-note .codehilite {
+    color: #dbe6ec;
+    background: #292e3d;
+  }
 }
 article.chapter table {
   width: 100%;
@@ -441,6 +500,12 @@ body {
   color: #222;
   font: normal 16px/24px "Crimson", Georgia, serif;
 }
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #181C21;
+    color: #dbe6ec;
+  }
+}
 
 @media print {
   body, a, code {
@@ -502,6 +567,11 @@ a {
 a:hover {
   color: #1481b8;
   border-bottom: solid 1px #dee9ed;
+}
+@media (prefers-color-scheme: dark) {
+  a:hover {
+    border-bottom: solid 1px #29313d;
+  }
 }
 
 nav {
@@ -689,6 +759,11 @@ code {
   white-space: nowrap;
   padding: 2px;
 }
+@media (prefers-color-scheme: dark) {
+  code {
+    color: #f5f3f0;
+  }
+}
 
 strong code {
   font-weight: bold;
@@ -705,6 +780,12 @@ a code {
   border-radius: 3px;
   padding: 12px;
   margin: -12px;
+}
+@media (prefers-color-scheme: dark) {
+  .codehilite {
+    color: #dbe6ec;
+    background: #1C2430;
+  }
 }
 
 pre {
@@ -743,6 +824,11 @@ article .number {
   font: 300 96px "Source Sans Pro", sans-serif;
   color: #dee9ed;
 }
+@media (prefers-color-scheme: dark) {
+  article .number {
+    color: #29313d;
+  }
+}
 article p {
   margin: 24px 0;
 }
@@ -764,6 +850,11 @@ aside {
   width: 288px;
   font: normal 14px/20px "Crimson", Georgia, serif;
   border-top: solid 1px #dee9ed;
+}
+@media (prefers-color-scheme: dark) {
+  aside {
+    border-top: solid 1px #29313d;
+  }
 }
 aside p {
   margin: 20px 0;
@@ -853,6 +944,11 @@ footer {
   margin: 48px 0;
   padding-top: 48px;
 }
+@media (prefers-color-scheme: dark) {
+  footer {
+    border-top: solid 1px #29313d;
+  }
+}
 footer a, footer a:hover {
   border: none;
 }
@@ -866,9 +962,19 @@ footer .next {
   text-transform: uppercase;
   letter-spacing: 1px;
 }
+@media (prefers-color-scheme: dark) {
+  footer .next {
+    background-color: #181C21;
+  }
+}
 footer .next:hover {
   color: #004466;
   border: none;
+}
+@media (prefers-color-scheme: dark) {
+  footer .next:hover {
+    color: #52b1e0;
+  }
 }
 
 .source-file, .source-file-narrow {
@@ -878,6 +984,11 @@ footer .next:hover {
 .source-file em, .source-file-narrow em {
   color: #999997;
   font-style: normal;
+}
+@media (prefers-color-scheme: dark) {
+  .source-file em, .source-file-narrow em {
+    color: #dad8d6;
+  }
 }
 
 .source-file-narrow {
@@ -900,6 +1011,11 @@ footer .next:hover {
   left: -36px;
   width: 36px;
   text-align: center;
+}
+@media (prefers-color-scheme: dark) {
+  .source-file::before {
+    color: #595959;
+  }
 }
 
 .codehilite pre {
@@ -956,7 +1072,122 @@ footer .next:hover {
   background: #f5f3f0;
   color: #595959;
 }
+@media (prefers-color-scheme: dark) {
+  .codehilite pre {
+    color: #dbe6ec;
+  }
+  .codehilite .k {
+    color: #B89FF7;
+  }
+  .codehilite .n {
+    color: #0FDEBD;
+  }
+  .codehilite .s {
+    color: #16C98D;
+  }
+  .codehilite .e {
+    color: #e8ba30;
+  }
+  .codehilite .c {
+    color: #2C98EC;
+  }
+  .codehilite .a {
+    color: #B89FF7;
+  }
+  .codehilite .i {
+    color: #FF708E;
+  }
+  .codehilite .t {
+    color: #FFC83F;
+  }
+  .codehilite .insert {
+    margin: -2px -12px;
+    padding: 2px 10px;
+    border-left: solid 2px #dad8d6;
+    border-right: solid 2px #dad8d6;
+    background: #f5f3f0;
+  }
+}
+@media (prefers-color-scheme: dark) and (prefers-color-scheme: dark) {
+  .codehilite .insert {
+    background: #242D3D;
+    border-left: solid 2px #323F55;
+    border-right: solid 2px #323F55;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .codehilite .delete {
+    margin: -2px -12px;
+    padding: 2px 10px;
+    border-left: solid 2px #dad8d6;
+    border-right: solid 2px #dad8d6;
+    background: repeating-linear-gradient(-45deg, #dad8d6, #dad8d6 1px, rgba(0, 0, 0, 0) 1px, rgba(0, 0, 0, 0) 6px);
+  }
+  .codehilite .delete span {
+    color: #bab8b7;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .codehilite .insert-before, .codehilite .insert-after {
+    color: #bab8b7;
+  }
+}
+@media (prefers-color-scheme: dark) and (prefers-color-scheme: dark) {
+  .codehilite .insert-before, .codehilite .insert-after {
+    color: #4E596C;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .codehilite .insert-before .insert-comma {
+    margin: -2px -1px;
+    padding: 2px 1px;
+    border-radius: 2px;
+    background: #f5f3f0;
+    color: #595959;
+  }
+}
+@media (prefers-color-scheme: dark) and (prefers-color-scheme: dark) {
+  .codehilite .insert-before .insert-comma {
+    background-color: #242D3D;
+    color: #dbe6ec;
+  }
+}
 
+@media only screen and (max-width: 1344px) {
+  nav.wide {
+    display: none;
+  }
+
+  nav.floating {
+    display: block;
+  }
+
+  body {
+    margin: 0 24px;
+  }
+
+  .page {
+    position: relative;
+    width: inherit;
+    max-width: 912px;
+    margin: 0 auto;
+  }
+
+  article {
+    width: inherit;
+    margin-right: 336px;
+  }
+  article .number {
+    top: 73px;
+    left: inherit;
+    right: 0;
+    font-size: 72px;
+  }
+  article h1 {
+    padding: 110px 0 18px 0;
+    font-size: 44px;
+  }
+}
 @media only screen and (max-width: 1344px) {
   nav.wide {
     display: none;

--- a/site/types-of-values.html
+++ b/site/types-of-values.html
@@ -336,7 +336,7 @@ add after struct <em>Value</em></div>
 type. Any time we call one of the <code>AS_</code> macros, we need to guard it behind a
 call to one of these first. With these eight macros, we can now safely shuttle
 data between Lox&rsquo;s dynamic world and C&rsquo;s static one.</p>
-<aside name="universe"><img src="image/types-of-values/universe.png" alt="The earthly C firmament with the Lox heavens above.">
+<aside name="universe" class="negate"><img src="image/types-of-values/universe.png" alt="The earthly C firmament with the Lox heavens above.">
 <p>The <code>_VAL</code> macros lift a C value into the heavens. The <code>AS_</code> macros bring it
 back down.</p>
 </aside>


### PR DESCRIPTION
## Add support for a dark theme (#732)

- Automatically follow user's OS theme settings
- Keep white/blue scheme default 
- Correctly handle images which should be negated (eg. muffin)
- Credit to @dannymcgee for colour suggestions (thanks!)
