### PR TITLE
21.3 Reading Variables - Update sentence fragment

### DIFF
--- a/book/global-variables.md
+++ b/book/global-variables.md
@@ -536,8 +536,8 @@ onto the stack.
 
 ^code disassemble-get-global (1 before, 1 after)
 
-A little bit of disassembling, and we're done. Our interpreter now able to run
-code like this:
+A little bit of disassembling, and we're done. Our interpreter is now able to
+run code like this:
 
 ```lox
 var beverage = "cafe au lait";

--- a/book/global-variables.md
+++ b/book/global-variables.md
@@ -536,8 +536,8 @@ onto the stack.
 
 ^code disassemble-get-global (1 before, 1 after)
 
-A little bit of disassembling, and we're done. Our interpreter is now able to
-run code like this:
+A little bit of disassembling, and we're done. Our interpreter is almost able
+to run code like this:
 
 ```lox
 var beverage = "cafe au lait";

--- a/site/global-variables.html
+++ b/site/global-variables.html
@@ -920,8 +920,8 @@ in <em>disassembleInstruction</em>()</div>
 </pre></div>
 <div class="source-file-narrow"><em>debug.c</em>, in <em>disassembleInstruction</em>()</div>
 
-<p>A little bit of disassembling, and we&rsquo;re done. Our interpreter now able to run
-code like this:</p>
+<p>A little bit of disassembling, and we&rsquo;re done. Our interpreter is now able to
+run code like this:</p>
 <div class="codehilite"><pre>
 <span class="k">var</span> <span class="i">beverage</span> = <span class="s">&quot;cafe au lait&quot;</span>;
 <span class="k">var</span> <span class="i">breakfast</span> = <span class="s">&quot;beignets with &quot;</span> + <span class="i">beverage</span>;

--- a/site/global-variables.html
+++ b/site/global-variables.html
@@ -920,8 +920,8 @@ in <em>disassembleInstruction</em>()</div>
 </pre></div>
 <div class="source-file-narrow"><em>debug.c</em>, in <em>disassembleInstruction</em>()</div>
 
-<p>A little bit of disassembling, and we&rsquo;re done. Our interpreter is now able to
-run code like this:</p>
+<p>A little bit of disassembling, and we&rsquo;re done. Our interpreter is almost able
+to run code like this:</p>
 <div class="codehilite"><pre>
 <span class="k">var</span> <span class="i">beverage</span> = <span class="s">&quot;cafe au lait&quot;</span>;
 <span class="k">var</span> <span class="i">breakfast</span> = <span class="s">&quot;beignets with &quot;</span> + <span class="i">beverage</span>;


### PR DESCRIPTION
Changes:
- The first commit fixes a sentence fragment at the very end of section 21.3 by inserting the word 'is'
- The second commit is a bit more pedantic, since we haven't gotten around to store values in variables we can't technically run the code in the example yet (that or I've done something wrong in my implementation to this point, which is very possible :laughing:). Happy to roll this one back if that's the case (or otherwise)

Testing:
- I made the changes to `book/global-variables.md` seen in this PR's diff
- Ran `make serve` to build the book on a local server 
- Navigated to http://localhost:8000/global-variables.html to verify the text