### PR TITLE
Fix conformance/portability issues in clox.

### DIFF
--- a/c/memory.c
+++ b/c/memory.c
@@ -340,7 +340,7 @@ void collectGarbage() {
 #ifdef DEBUG_LOG_GC
   printf("-- gc end\n");
 //> log-collected-amount
-  printf("   collected %ld bytes (from %ld to %ld) next at %ld\n",
+  printf("   collected %zu bytes (from %zu to %zu) next at %zu\n",
          before - vm.bytesAllocated, before, vm.bytesAllocated,
          vm.nextGC);
 //< log-collected-amount

--- a/c/memory.c
+++ b/c/memory.c
@@ -70,8 +70,8 @@ void markObject(Obj* object) {
 
   if (vm.grayCapacity < vm.grayCount + 1) {
     vm.grayCapacity = GROW_CAPACITY(vm.grayCapacity);
-    vm.grayStack = realloc(vm.grayStack,
-                           sizeof(Obj*) * vm.grayCapacity);
+    vm.grayStack = (Obj**)realloc(vm.grayStack,
+                                  sizeof(Obj*) * vm.grayCapacity);
 //> exit-gray-stack
 
     if (vm.grayStack == NULL) exit(1);

--- a/c/object.c
+++ b/c/object.c
@@ -30,7 +30,7 @@ static Obj* allocateObject(size_t size, ObjType type) {
 //> Garbage Collection debug-log-allocate
 
 #ifdef DEBUG_LOG_GC
-  printf("%p allocate %ld for %d\n", (void*)object, size, type);
+  printf("%p allocate %zu for %d\n", (void*)object, size, type);
 #endif
 
 //< Garbage Collection debug-log-allocate


### PR DESCRIPTION
These commits address a couple of compilation issues I ran into with clox:
1) Add missing cast on return value of realloc() in markObject(). This cast is required when compiling as C++.
2) Replace mismatched printf format specifier for size_t arguments. Whereas "%ld" does not match size_t on all platforms, "%zu" is an exact match everywhere and is available in [C99](https://en.cppreference.com/w/c/io/fprintf)/[C++11](https://en.cppreference.com/w/cpp/io/c/fprintf).

Thank you for the excellent book!