### PR TITLE
Fix off-by-one error in Chapter 24 challenge answer.

### DIFF
--- a/note/answers/chapter24_calls/2.md
+++ b/note/answers/chapter24_calls/2.md
@@ -47,7 +47,7 @@ code looks like this:
           vm.stackTop -= argCount;
           return true;
         } else {
-          runtimeError(AS_STRING(vm.stackTop[-argCount])->chars);
+          runtimeError(AS_STRING(vm.stackTop[-argCount - 1])->chars);
           return false;
         }
       }


### PR DESCRIPTION
The error string is stored before the first argument, so it must be retrieved from ```vm.stackTop[-argCount - 1]```.