### PR TITLE
Fix off-by-one error in Chapter 21 challenge answer.

### DIFF
--- a/note/answers/chapter21_global.md
+++ b/note/answers/chapter21_global.md
@@ -103,8 +103,8 @@ static uint8_t identifierConstant(Token* name) {
     return (uint8_t)AS_NUMBER(index);
   }
 
-  writeValueArray(&vm.globalValues, UNDEFINED_VAL);
   uint8_t newIndex = (uint8_t)vm.globalValues.count;
+  writeValueArray(&vm.globalValues, UNDEFINED_VAL);
 
   tableSet(&vm.globalNames, identifier, NUMBER_VAL((double)newIndex));
   return newIndex;


### PR DESCRIPTION
The index in the global array is equal to the count *before* the new value has been appended.

As an aside, there are a couple of things that are not bugs but would make this code mesh better with later chapters:
1. Instead of replacing ```identifierConstant```, which is needed to implement classes in later chapters, this could be defined as a new function named ```resolveGlobal```. The existing callers in ```parseVariable``` and ```namedVariable``` would need to be replaced.
2. The identifier string could be collected by the GC in either the ```writeValueArray``` or ```tableSet``` calls. For safety, it could be temporarily pushed onto the VM stack.