### PR TITLE
Fix local variable declaration error case

### DIFF
--- a/c/compiler.c
+++ b/c/compiler.c
@@ -528,6 +528,7 @@ static void declareVariable() {
     
     if (identifiersEqual(name, &local->name)) {
       error("Already variable with this name in this scope.");
+      return;
     }
   }
 


### PR DESCRIPTION
When we find a local variable with the same name, we show an error, but continue on in the loop to define the variable.

I mean, technically, because the error sets panic mode (assuming this is the first error encountered), there aren't any bad side-effects, but we do a bit more work than we need to - either continuing until there are no more variables found in the current scope or we reach the end of the list.  We then add the new variable anyway.  Again, not terrible as no actual user code will be executed.

But if we can exit early, we waste less of the user's time and don't expend wasted energy (in nano-quantities, I'm sure, which might be overshadowed by a possible pipeline flush).

Hmmm, after writing all this, it feels like I'm being a little pedantic, but I'm raising it anyway.