### PR TITLE
Ensure custom interpreter uses custom args

### DIFF
--- a/tool/bin/test.dart
+++ b/tool/bin/test.dart
@@ -294,7 +294,7 @@ class Test {
   /// Invoke the interpreter and run the test.
   List<String> run() {
     var args = [
-      if (_customArguments != null) ...?_customArguments else ..._suite.args,
+      if (_customInterpreter != null) ...?_customArguments else ..._suite.args,
       _path
     ];
     var result = Process.runSync(_customInterpreter ?? _suite.executable, args);


### PR DESCRIPTION
As it currently stands, if a custom interpreter is passed to the test runner, but no custom arguments are passed, the process invocation on line 300 of `test.dart` will use the default arguments to the suite (consisting of the `-cp` flag & associated classpath). This will cause test failures for a working custom interpreter - this can be verified by passing the `jlox` executable already present in the repository to `test.dart` using `--interpreter`. 

This change fixes that, so that a custom interpreter is invoked with custom arguments only (and the relevant test file, of course).   