### PR TITLE
Add missing pronoun in Ch29.2

### DIFF
--- a/book/superclasses.md
+++ b/book/superclasses.md
@@ -209,8 +209,8 @@ superclass, so we don't.
 
 That won't be sufficient to support super calls. Since a subclass <span
 name="may">may</span> override the superclass method, we need to be able to get
-our hands on superclass method tables. Before we get to mechanism, I want to
-refresh your memory on how super calls are statically resolved.
+our hands on superclass method tables. Before we get to that mechanism, I want 
+to refresh your memory on how super calls are statically resolved.
 
 <aside name="may">
 

--- a/site/superclasses.html
+++ b/site/superclasses.html
@@ -345,8 +345,8 @@ over, we forget the superclass entirely. We don&rsquo;t need to keep a handle on
 superclass, so we don&rsquo;t.</p>
 <p>That won&rsquo;t be sufficient to support super calls. Since a subclass <span
 name="may">may</span> override the superclass method, we need to be able to get
-our hands on superclass method tables. Before we get to mechanism, I want to
-refresh your memory on how super calls are statically resolved.</p>
+our hands on superclass method tables. Before we get to that mechanism, I want 
+to refresh your memory on how super calls are statically resolved.</p>
 <aside name="may">
 <p>&ldquo;May&rdquo; might not be a strong enough word. Presumably the method <em>has</em> been
 overridden. Otherwise, why are you bothering to use <code>super</code> instead of just


### PR DESCRIPTION
Changes:
- Add missing pronoun, 'that' to an opening sentence in Ch29.2

Testing:
- I made the changes to `book/superclasses.md` seen in this PR's diff
- Ran `make serve` to build the book on a local server 
- Navigated to http://localhost:8000/superclasses.html to verify the changes
