### PR TITLE
Fix GROW_ARRAY argument order in Ch14 Challenge 1 solution

### DIFF
--- a/note/answers/chapter14_chunks/1.md
+++ b/note/answers/chapter14_chunks/1.md
@@ -67,7 +67,7 @@ void writeChunk(Chunk* chunk, uint8_t byte, int line) {
   if (chunk->capacity < chunk->count + 1) {
     int oldCapacity = chunk->capacity;
     chunk->capacity = GROW_CAPACITY(oldCapacity);
-    chunk->code = GROW_ARRAY(chunk->code, uint8_t,
+    chunk->code = GROW_ARRAY(uint8_t, chunk->code,
         oldCapacity, chunk->capacity);
     // Don't grow line array here...
   }
@@ -85,7 +85,7 @@ void writeChunk(Chunk* chunk, uint8_t byte, int line) {
   if (chunk->lineCapacity < chunk->lineCount + 1) {
     int oldCapacity = chunk->lineCapacity;
     chunk->lineCapacity = GROW_CAPACITY(oldCapacity);
-    chunk->lines = GROW_ARRAY(chunk->lines, LineStart,
+    chunk->lines = GROW_ARRAY(LineStart, chunk->lines,
                               oldCapacity, chunk->lineCapacity);
   }
 


### PR DESCRIPTION
The order of arguments for `GROW_ARRAY` in the example solution for Ch14 Challenge 1 (run-length encoding) is wrong. `type` should come before the `pointer` parameter as per the macro definition:

```c
#define GROW_ARRAY(type, pointer, oldCount, newCount) \
    (type*)reallocate(pointer, sizeof(type) * (oldCount), \
        sizeof(type) * (newCount))
```