### PR TITLE
Fix LoxArray Length return type

### DIFF
--- a/note/answers/chapter13_inheritance/3.md
+++ b/note/answers/chapter13_inheritance/3.md
@@ -106,7 +106,7 @@ class LoxArray extends LoxInstance {
         }
       };
     } else if (name.lexeme.equals("length")) {
-      return elements.length;
+      return (double) elements.length;
     }
 
     throw new RuntimeError(name, // [hidden]


### PR DESCRIPTION
Thanks for the wonderful book, still in the middle of going through it. I found a small bug in the implementation of the LoxArray length returns. This is due to Java's array.length returning an integer rather than a double. The checkNumberOperand checks for Double only. To fix this, we cast the primitive into a double.

To reproduce:
```
var a = Array(5);
for (var i = 0; i < a.length; i = i+1) {
  print i;
}
```

Will return `Operands must be a number.` as it errors out here: https://github.com/munificent/craftinginterpreters/blob/master/java/com/craftinginterpreters/lox/Interpreter.java#L495

