### PR TITLE
Fix argument max limit in answers 8 -> 255

### DIFF
--- a/note/answers/chapter12_classes.md
+++ b/note/answers/chapter12_classes.md
@@ -145,8 +145,8 @@
         parameters = new ArrayList<>();
         if (!check(RIGHT_PAREN)) {
           do {
-            if (parameters.size() >= 8) {
-              error(peek(), "Can't have more than 8 parameters.");
+            if (parameters.size() >= 255) {
+              error(peek(), "Can't have more than 255 parameters.");
             }
 
             parameters.add(consume(IDENTIFIER, "Expect parameter name."));


### PR DESCRIPTION
I guess older drafts of the book had 8 arguments limit.. In the "getters" challenge answer code, which I have been comparing with my implementation, has different argument limit.