### PR TITLE
Fixes munificent/craftinginterpreters#1000

### DIFF
--- a/java/com/craftinginterpreters/lox/Lox.java
+++ b/java/com/craftinginterpreters/lox/Lox.java
@@ -27,6 +27,7 @@ public class Lox {
     } else if (args.length == 1) {
       runFile(args[0]);
     } else {
+      ReplStatus.getInstance().setRepl();
       runPrompt();
     }
   }

--- a/java/com/craftinginterpreters/lox/ReplStatus.java
+++ b/java/com/craftinginterpreters/lox/ReplStatus.java
@@ -1,0 +1,32 @@
+package com.craftinginterpreters.lox;
+
+public final class ReplStatus {
+    private static ReplStatus shared;
+    private boolean isRepl;
+    private boolean insideFunBody;
+    private Object current_expr;
+    private ReplStatus() { }
+
+    // Initializer
+    public static ReplStatus getInstance() {
+        if (shared == null)
+            shared = new ReplStatus();
+        return shared;
+    }
+
+    public void push(Object expr) {
+        current_expr = expr;
+        if (!insideFunBody)
+            print(expr);
+    }
+    public void print(Object expr) {
+        if (isRepl) System.out.println(expr);
+    }
+
+    // Setters
+    public void setRepl() { isRepl = true; }
+    public void confirmFunBody(boolean inout) { insideFunBody = inout; }
+
+
+
+}


### PR DESCRIPTION
Initial implementaion Scope-like solution for repl-mode expression
result.
Previously:

">" 10 + 10;
">"..
">" fun foo() { return 10; }
">" foo();
">" ....


Saving Expression with respect to their scope and print them out to
console for every line will be very interactive to see immediate
result, However, In this commit we just solved it for binaryExpression
'including within varDeclaration' and function calls.

Currently:

">" 299 + 1;
300.0
">" ..
">" fun foobar() { 10 + 10; return 8; }
8.0
">" var x = 10 + 10;
20
">" ..

Warning:
var statement shouldn't produce immediate values til asked for. We will
try to solve it.