### PR TITLE
Fix typo in chapter 11

### DIFF
--- a/book/resolving-and-binding.md
+++ b/book/resolving-and-binding.md
@@ -600,7 +600,7 @@ into that inner function scope.
 
 ^code visit-function-stmt
 
-Similar to `visitVariableStmt()`, we declare and define the name of the function
+Similar to `visitVarStmt()`, we declare and define the name of the function
 in the current scope. Unlike variables, though, we define the name eagerly,
 before resolving the function's body. This lets a function recursively refer to
 itself inside its own body.


### PR DESCRIPTION
Thanks for such a great book!

The prose mentioned a nonexistent `visitVariableStmt`. There's a `visitVarStmt` and a `visitVariableExpr`; from context I believe it referred to the former.