### PR TITLE
Improve test case.

### DIFF
--- a/test/scanning/punctuators.lox
+++ b/test/scanning/punctuators.lox
@@ -1,4 +1,4 @@
-(){};,+-*!===<=>=!=<>/.
+(){};,+-*!===<=>==!<>/.
 
 // expect: LEFT_PAREN ( null
 // expect: RIGHT_PAREN ) null
@@ -13,7 +13,8 @@
 // expect: EQUAL_EQUAL == null
 // expect: LESS_EQUAL <= null
 // expect: GREATER_EQUAL >= null
-// expect: BANG_EQUAL != null
+// expect: EQUAL != null
+// expect: BANG != null
 // expect: LESS < null
 // expect: GREATER > null
 // expect: SLASH / null


### PR DESCRIPTION
`BANG_EQUAL` is tested twice but `BANG` and `EQUAL` are not tested individually. This change swaps the `!` and the `=` near the end of the source string, and replaces the second `BANG_EQUAL` expectation with expectations for `EQUAL` and `BANG`.