### PR TITLE
Do not translate code block in the book when using Google translator (#1020)

### DIFF
--- a/book/introduction.md
+++ b/book/introduction.md
@@ -247,7 +247,7 @@ add temporary code that gets replaced in later snippets.
 
 A snippet with all the bells and whistles looks like this:
 
-<div class="codehilite"><pre class="insert-before">
+<div class="codehilite" translate="no"><pre class="insert-before">
       default:
 </pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()<br>

--- a/site/a-map-of-the-territory.html
+++ b/site/a-map-of-the-territory.html
@@ -268,10 +268,10 @@ efficiently<span class="em">&mdash;</span>we can <strong>optimize</strong> it.</
 <p>A simple example is <strong>constant folding</strong>: if some expression always evaluates to
 the exact same value, we can do the evaluation at compile time and replace the
 code for the expression with its result. If the user typed in this:</p>
-<div class="codehilite"><pre><span class="i">pennyArea</span> = <span class="n">3.14159</span> * (<span class="n">0.75</span> / <span class="n">2</span>) * (<span class="n">0.75</span> / <span class="n">2</span>);
+<div class="codehilite" translate="no"><pre><span class="i">pennyArea</span> = <span class="n">3.14159</span> * (<span class="n">0.75</span> / <span class="n">2</span>) * (<span class="n">0.75</span> / <span class="n">2</span>);
 </pre></div>
 <p>we could do all of that arithmetic in the compiler and change the code to:</p>
-<div class="codehilite"><pre><span class="i">pennyArea</span> = <span class="n">0.4417860938</span>;
+<div class="codehilite" translate="no"><pre><span class="i">pennyArea</span> = <span class="n">0.4417860938</span>;
 </pre></div>
 <p>Optimization is a huge part of the programming language business. Many language
 hackers spend their entire careers here, squeezing every drop of performance

--- a/site/a-virtual-machine.html
+++ b/site/a-virtual-machine.html
@@ -112,7 +112,7 @@ series of them.</p>
 <p>The virtual machine is one part of our interpreter&rsquo;s internal architecture. You
 hand it a chunk of code<span class="em">&mdash;</span>literally a Chunk<span class="em">&mdash;</span>and it runs it. The code and
 data structures for the VM reside in a new module.</p>
-<div class="codehilite"><div class="source-file"><em>vm.h</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.h</em><br>
 create new file</div>
 <pre><span class="a">#ifndef clox_vm_h</span>
 <span class="a">#define clox_vm_h</span>
@@ -135,7 +135,7 @@ it needs to keep track of, so we define a struct now to stuff that all in.
 Currently, all we store is the chunk that it executes.</p>
 <p>Like we do with most of the data structures we create, we also define functions
 to create and tear down a VM. Here&rsquo;s the implementation:</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 create new file</div>
 <pre><span class="a">#include &quot;common.h&quot;</span>
 <span class="a">#include &quot;vm.h&quot;</span>
@@ -172,7 +172,7 @@ keeping things small for a book<span class="ellipse">&thinsp;.&thinsp;.&thinsp;.
 </aside>
 <p>Before we start pumping fun code into our VM, let&rsquo;s go ahead and wire it up to
 the interpreter&rsquo;s main entrypoint.</p>
-<div class="codehilite"><pre class="insert-before">int main(int argc, const char* argv[]) {
+<div class="codehilite" translate="no"><pre class="insert-before">int main(int argc, const char* argv[]) {
 </pre><div class="source-file"><em>main.c</em><br>
 in <em>main</em>()</div>
 <pre class="insert">  <span class="i">initVM</span>();
@@ -183,7 +183,7 @@ in <em>main</em>()</div>
 
 <p>We spin up the VM when the interpreter first starts. Then when we&rsquo;re about to
 exit, we wind it down.</p>
-<div class="codehilite"><pre class="insert-before">  disassembleChunk(&amp;chunk, &quot;test chunk&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">  disassembleChunk(&amp;chunk, &quot;test chunk&quot;);
 </pre><div class="source-file"><em>main.c</em><br>
 in <em>main</em>()</div>
 <pre class="insert">  <span class="i">freeVM</span>();
@@ -192,7 +192,7 @@ in <em>main</em>()</div>
 <div class="source-file-narrow"><em>main.c</em>, in <em>main</em>()</div>
 
 <p>One last ceremonial obligation:</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;debug.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;debug.h&quot;
 </pre><div class="source-file"><em>main.c</em></div>
 <pre class="insert"><span class="a">#include &quot;vm.h&quot;</span>
 </pre><pre class="insert-after">
@@ -206,7 +206,7 @@ chunk from the <a href="chunks-of-bytecode.html#disassembling-chunks">last chapt
 to do something.</p>
 <h3><a href="#executing-instructions" id="executing-instructions"><small>15&#8202;.&#8202;1&#8202;.&#8202;1</small>Executing instructions</a></h3>
 <p>The VM springs into action when we command it to interpret a chunk of bytecode.</p>
-<div class="codehilite"><pre class="insert-before">  disassembleChunk(&amp;chunk, &quot;test chunk&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">  disassembleChunk(&amp;chunk, &quot;test chunk&quot;);
 </pre><div class="source-file"><em>main.c</em><br>
 in <em>main</em>()</div>
 <pre class="insert">  <span class="i">interpret</span>(&amp;<span class="i">chunk</span>);
@@ -215,7 +215,7 @@ in <em>main</em>()</div>
 <div class="source-file-narrow"><em>main.c</em>, in <em>main</em>()</div>
 
 <p>This function is the main entrypoint into the VM. It&rsquo;s declared like so:</p>
-<div class="codehilite"><pre class="insert-before">void freeVM();
+<div class="codehilite" translate="no"><pre class="insert-before">void freeVM();
 </pre><div class="source-file"><em>vm.h</em><br>
 add after <em>freeVM</em>()</div>
 <pre class="insert"><span class="t">InterpretResult</span> <span class="i">interpret</span>(<span class="t">Chunk</span>* <span class="i">chunk</span>);
@@ -226,7 +226,7 @@ add after <em>freeVM</em>()</div>
 <div class="source-file-narrow"><em>vm.h</em>, add after <em>freeVM</em>()</div>
 
 <p>The VM runs the chunk and then responds with a value from this enum:</p>
-<div class="codehilite"><pre class="insert-before">} VM;
+<div class="codehilite" translate="no"><pre class="insert-before">} VM;
 
 </pre><div class="source-file"><em>vm.h</em><br>
 add after struct <em>VM</em></div>
@@ -245,7 +245,7 @@ void freeVM();
 errors and a VM that detects runtime errors, the interpreter will use this to
 know how to set the exit code of the process.</p>
 <p>We&rsquo;re inching towards some actual implementation.</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>freeVM</em>()</div>
 <pre><span class="t">InterpretResult</span> <span class="i">interpret</span>(<span class="t">Chunk</span>* <span class="i">chunk</span>) {
   <span class="i">vm</span>.<span class="i">chunk</span> = <span class="i">chunk</span>;
@@ -266,7 +266,7 @@ other functions will need to access it. Instead, we store it as a field in VM.</
 interpreter, we would store <code>ip</code> in a local variable. It gets modified so often
 during execution that we want the C compiler to keep it in a register.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">typedef struct {
+<div class="codehilite" translate="no"><pre class="insert-before">typedef struct {
   Chunk* chunk;
 </pre><div class="source-file"><em>vm.h</em><br>
 in struct <em>VM</em></div>
@@ -291,7 +291,7 @@ haven&rsquo;t executed that instruction yet, so <code>ip</code> points to the in
 to be executed</em>. This will be true during the entire time the VM is running: the
 IP always points to the next instruction, not the one currently being handled.</p>
 <p>The real fun happens in <code>run</code>().</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>freeVM</em>()</div>
 <pre><span class="k">static</span> <span class="t">InterpretResult</span> <span class="i">run</span>() {
 <span class="a">#define READ_BYTE() (*vm.ip++)</span>
@@ -350,7 +350,7 @@ does is exit the loop entirely. Eventually, that instruction will be used to
 return from the current Lox function, but we don&rsquo;t have functions yet, so we&rsquo;ll
 repurpose it temporarily to end the execution.</p>
 <p>Let&rsquo;s go ahead and support our one other instruction.</p>
-<div class="codehilite"><pre class="insert-before">    switch (instruction = READ_BYTE()) {
+<div class="codehilite" translate="no"><pre class="insert-before">    switch (instruction = READ_BYTE()) {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_CONSTANT</span>: {
@@ -366,7 +366,7 @@ in <em>run</em>()</div>
 <p>We don&rsquo;t have enough machinery in place yet to do anything useful with a
 constant. For now, we&rsquo;ll just print it out so we interpreter hackers can see
 what&rsquo;s going on inside our VM. That call to <code>printf()</code> necessitates an include.</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add to top of file</div>
 <pre class="insert"><span class="a">#include &lt;stdio.h&gt;</span>
 
@@ -375,7 +375,7 @@ add to top of file</div>
 <div class="source-file-narrow"><em>vm.c</em>, add to top of file</div>
 
 <p>We also have a new macro to define.</p>
-<div class="codehilite"><pre class="insert-before">#define READ_BYTE() (*vm.ip++)
+<div class="codehilite" translate="no"><pre class="insert-before">#define READ_BYTE() (*vm.ip++)
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert"><span class="a">#define READ_CONSTANT() (vm.chunk-&gt;constants.values[READ_BYTE()])</span>
@@ -393,7 +393,7 @@ refer to constants, so we&rsquo;re setting up this helper macro now.</p>
 <code>run()</code>. To make that scoping more explicit, the macro definitions themselves
 are confined to that function. We <span name="macro">define</span> them at the
 beginning and<span class="em">&mdash;</span>because we care<span class="em">&mdash;</span>undefine them at the end.</p>
-<div class="codehilite"><pre class="insert-before">#undef READ_BYTE
+<div class="codehilite" translate="no"><pre class="insert-before">#undef READ_BYTE
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert"><span class="a">#undef READ_CONSTANT</span>
@@ -416,7 +416,7 @@ black box. That makes our lives as VM implementers harder.</p>
 VM like we did with chunks themselves. In fact, we&rsquo;ll even reuse the same code.
 We don&rsquo;t want this logging enabled all the time<span class="em">&mdash;</span>it&rsquo;s just for us VM hackers,
 not Lox users<span class="em">&mdash;</span>so first we create a flag to hide it behind.</p>
-<div class="codehilite"><pre class="insert-before">#include &lt;stdint.h&gt;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &lt;stdint.h&gt;
 </pre><div class="source-file"><em>common.h</em></div>
 <pre class="insert">
 
@@ -430,7 +430,7 @@ not Lox users<span class="em">&mdash;</span>so first we create a flag to hide it
 <p>When this flag is defined, the VM disassembles and prints each instruction right
 before executing it. Where our previous disassembler walked an entire chunk
 once, statically, this disassembles instructions dynamically, on the fly.</p>
-<div class="codehilite"><pre class="insert-before">  for (;;) {
+<div class="codehilite" translate="no"><pre class="insert-before">  for (;;) {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert"><span class="a">#ifdef DEBUG_TRACE_EXECUTION</span>
@@ -448,7 +448,7 @@ math to convert <code>ip</code> back to a relative offset from the beginning of 
 bytecode. Then we disassemble the instruction that begins at that byte.</p>
 <p>As ever, we need to bring in the declaration of the function before we can call
 it.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;common.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;common.h&quot;
 </pre><div class="source-file"><em>vm.c</em></div>
 <pre class="insert"><span class="a">#include &quot;debug.h&quot;</span>
 </pre><pre class="insert-after">#include &quot;vm.h&quot;
@@ -465,7 +465,7 @@ Visitor pattern for walking the AST.</p>
 <p>In addition to imperative side effects, Lox has expressions that produce,
 modify, and consume values. Thus, our compiled bytecode needs a way to shuttle
 values around between the different instructions that need them. For example:</p>
-<div class="codehilite"><pre><span class="k">print</span> <span class="n">3</span> - <span class="n">2</span>;
+<div class="codehilite" translate="no"><pre><span class="k">print</span> <span class="n">3</span> - <span class="n">2</span>;
 </pre></div>
 <p>We obviously need instructions for the constants 3 and 2, the <code>print</code> statement,
 and the subtraction. But how does the subtraction instruction know that 3 is
@@ -477,7 +477,7 @@ aren&rsquo;t they delightful words? &ldquo;Minuend&rdquo; sounds like a kind of 
 and &ldquo;subtrahend&rdquo; might be some sort of underground Paleolithic monument.</p>
 </aside>
 <p>To put a finer point on it, look at this thing right here:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">echo</span>(<span class="i">n</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">echo</span>(<span class="i">n</span>) {
   <span class="k">print</span> <span class="i">n</span>;
   <span class="k">return</span> <span class="i">n</span>;
 }
@@ -508,7 +508,7 @@ pain to figure out what&rsquo;s going on.</p>
 statement, with numbers marking the order that the nodes are evaluated." /></p>
 <p>Given left-to-right evaluation, and the way the expressions are nested, any
 correct Lox implementation <em>must</em> print these numbers in this order:</p>
-<div class="codehilite"><pre>1  // from echo(1)
+<div class="codehilite" translate="no"><pre>1  // from echo(1)
 2  // from echo(2)
 3  // from echo(1 + 2)
 4  // from echo(4)
@@ -593,7 +593,7 @@ JavaScript all use sophisticated <a href="https://en.wikipedia.org/wiki/Just-in-
 generate <em>much</em> faster native code on the fly.</p>
 </aside>
 <p>Alrighty, it&rsquo;s codin&rsquo; time! Here&rsquo;s the stack:</p>
-<div class="codehilite"><pre class="insert-before">typedef struct {
+<div class="codehilite" translate="no"><pre class="insert-before">typedef struct {
   Chunk* chunk;
   uint8_t* ip;
 </pre><div class="source-file"><em>vm.h</em><br>
@@ -637,7 +637,7 @@ zero." /></p>
 <p>I remember it like this: <code>stackTop</code> points to where the next value to be pushed
 will go. The maximum number of values we can store on the stack (for now, at
 least) is:</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;chunk.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;chunk.h&quot;
 </pre><div class="source-file"><em>vm.h</em></div>
 <pre class="insert">
 
@@ -652,7 +652,7 @@ typedef struct {
 instructions to push too many values and run out of stack space<span class="em">&mdash;</span>the classic
 &ldquo;stack overflow&rdquo;. We could grow the stack dynamically as needed, but for now
 we&rsquo;ll keep it simple. Since VM uses Value, we need to include its declaration.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;chunk.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;chunk.h&quot;
 </pre><div class="source-file"><em>vm.h</em></div>
 <pre class="insert"><span class="a">#include &quot;value.h&quot;</span>
 </pre><pre class="insert-after">
@@ -662,7 +662,7 @@ we&rsquo;ll keep it simple. Since VM uses Value, we need to include its declarat
 <div class="source-file-narrow"><em>vm.h</em></div>
 
 <p>Now that VM has some interesting state, we get to initialize it.</p>
-<div class="codehilite"><pre class="insert-before">void initVM() {
+<div class="codehilite" translate="no"><pre class="insert-before">void initVM() {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>initVM</em>()</div>
 <pre class="insert">  <span class="i">resetStack</span>();
@@ -671,7 +671,7 @@ in <em>initVM</em>()</div>
 <div class="source-file-narrow"><em>vm.c</em>, in <em>initVM</em>()</div>
 
 <p>That uses this helper function:</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after variable <em>vm</em></div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">resetStack</span>() {
   <span class="i">vm</span>.<span class="i">stackTop</span> = <span class="i">vm</span>.<span class="i">stack</span>;
@@ -685,7 +685,7 @@ array<span class="em">&mdash;</span>we simply won&rsquo;t access them until afte
 them. The only initialization we need is to set <code>stackTop</code> to point to the
 beginning of the array to indicate that the stack is empty.</p>
 <p>The stack protocol supports two operations:</p>
-<div class="codehilite"><pre class="insert-before">InterpretResult interpret(Chunk* chunk);
+<div class="codehilite" translate="no"><pre class="insert-before">InterpretResult interpret(Chunk* chunk);
 </pre><div class="source-file"><em>vm.h</em><br>
 add after <em>interpret</em>()</div>
 <pre class="insert"><span class="t">void</span> <span class="i">push</span>(<span class="t">Value</span> <span class="i">value</span>);
@@ -698,7 +698,7 @@ add after <em>interpret</em>()</div>
 
 <p>You can push a new value onto the top of the stack, and you can pop the most
 recently pushed value back off. Here&rsquo;s the first function:</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>freeVM</em>()</div>
 <pre><span class="t">void</span> <span class="i">push</span>(<span class="t">Value</span> <span class="i">value</span>) {
   *<span class="i">vm</span>.<span class="i">stackTop</span> = <span class="i">value</span>;
@@ -714,7 +714,7 @@ available one. This stores the value in that slot. Then we increment the pointer
 itself to point to the next unused slot in the array now that the previous slot
 is occupied.</p>
 <p>Popping is the mirror image.</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>push</em>()</div>
 <pre><span class="t">Value</span> <span class="i">pop</span>() {
   <span class="i">vm</span>.<span class="i">stackTop</span>--;
@@ -734,7 +734,7 @@ of code, we&rsquo;ll end up with a lot of values crammed into that array. It wou
 make our lives as VM hackers easier if we had some visibility into the stack.</p>
 <p>To that end, whenever we&rsquo;re tracing execution, we&rsquo;ll also show the current
 contents of the stack before we interpret each instruction.</p>
-<div class="codehilite"><pre class="insert-before">#ifdef DEBUG_TRACE_EXECUTION
+<div class="codehilite" translate="no"><pre class="insert-before">#ifdef DEBUG_TRACE_EXECUTION
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">    <span class="i">printf</span>(<span class="s">&quot;          &quot;</span>);
@@ -753,7 +753,7 @@ stack) and ending when we reach the top. This lets us observe the effect of each
 instruction on the stack. The output is pretty verbose, but it&rsquo;s useful when
 we&rsquo;re surgically extracting a nasty bug from the bowels of the interpreter.</p>
 <p>Stack in hand, let&rsquo;s revisit our two instructions. First up:</p>
-<div class="codehilite"><pre class="insert-before">      case OP_CONSTANT: {
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_CONSTANT: {
         Value constant = READ_CONSTANT();
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
@@ -766,7 +766,7 @@ replace 2 lines</div>
 <p>In the last chapter, I was hand-wavey about how the <code>OP_CONSTANT</code> instruction
 &ldquo;loads&rdquo; a constant. Now that we have a stack you know what it means to actually
 produce a value: it gets pushed onto the stack.</p>
-<div class="codehilite"><pre class="insert-before">      case OP_RETURN: {
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_RETURN: {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">        <span class="i">printValue</span>(<span class="i">pop</span>());
@@ -786,13 +786,13 @@ The two halves work, but it&rsquo;s hard to get a feel for how cleverly they int
 with only the two rudimentary instructions we have so far. So let&rsquo;s teach our
 interpreter to do arithmetic.</p>
 <p>We&rsquo;ll start with the simplest arithmetic operation, unary negation.</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="n">1.2</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="n">1.2</span>;
 <span class="k">print</span> -<span class="i">a</span>; <span class="c">// -1.2.</span>
 </pre></div>
 <p>The prefix <code>-</code> operator takes one operand, the value to negate. It produces a
 single result. We aren&rsquo;t fussing with a parser yet, but we can add the
 bytecode instruction that the above syntax will compile to.</p>
-<div class="codehilite"><pre class="insert-before">  OP_CONSTANT,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_CONSTANT,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_NEGATE</span>,
@@ -801,7 +801,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>We execute it like so:</p>
-<div class="codehilite"><pre class="insert-before">      }
+<div class="codehilite" translate="no"><pre class="insert-before">      }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_NEGATE</span>:   <span class="i">push</span>(-<span class="i">pop</span>()); <span class="k">break</span>;
@@ -812,7 +812,7 @@ in <em>run</em>()</div>
 <p>The instruction needs a value to operate on, which it gets by popping from the
 stack. It negates that, then pushes the result back on for later instructions to
 use. Doesn&rsquo;t get much easier than that. We can disassemble it too.</p>
-<div class="codehilite"><pre class="insert-before">    case OP_CONSTANT:
+<div class="codehilite" translate="no"><pre class="insert-before">    case OP_CONSTANT:
       return constantInstruction(&quot;OP_CONSTANT&quot;, chunk, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
@@ -823,7 +823,7 @@ in <em>disassembleInstruction</em>()</div>
 <div class="source-file-narrow"><em>debug.c</em>, in <em>disassembleInstruction</em>()</div>
 
 <p>And we can try it out in our test chunk.</p>
-<div class="codehilite"><pre class="insert-before">  writeChunk(&amp;chunk, constant, 123);
+<div class="codehilite" translate="no"><pre class="insert-before">  writeChunk(&amp;chunk, constant, 123);
 </pre><div class="source-file"><em>main.c</em><br>
 in <em>main</em>()</div>
 <pre class="insert">  <span class="i">writeChunk</span>(&amp;<span class="i">chunk</span>, <span class="a">OP_NEGATE</span>, <span class="n">123</span>);
@@ -836,7 +836,7 @@ in <em>main</em>()</div>
 <p>After loading the constant, but before returning, we execute the negate
 instruction. That replaces the constant on the stack with its negation. Then the
 return instruction prints that out:</p>
-<div class="codehilite"><pre>-1.2
+<div class="codehilite" translate="no"><pre>-1.2
 </pre></div>
 <p>Magical!</p>
 <h3><a href="#binary-operators" id="binary-operators"><small>15&#8202;.&#8202;3&#8202;.&#8202;1</small>Binary operators</a></h3>
@@ -849,7 +849,7 @@ time.</p>
 <p>Lox has some other binary operators<span class="em">&mdash;</span>comparison and equality<span class="em">&mdash;</span>but those
 don&rsquo;t produce numbers as a result, so we aren&rsquo;t ready for them yet.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">  OP_CONSTANT,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_CONSTANT,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_ADD</span>,
@@ -861,7 +861,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>Back in the bytecode loop, they are executed like this:</p>
-<div class="codehilite"><pre class="insert-before">      }
+<div class="codehilite" translate="no"><pre class="insert-before">      }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_ADD</span>:      <span class="a">BINARY_OP</span>(+); <span class="k">break</span>;
@@ -877,7 +877,7 @@ operator they ultimately use to combine the two operands. Surrounding that core
 arithmetic expression is some boilerplate code to pull values off the stack and
 push the result. When we later add dynamic typing, that boilerplate will grow.
 To avoid repeating that code four times, I wrapped it up in a macro.</p>
-<div class="codehilite"><pre class="insert-before">#define READ_CONSTANT() (vm.chunk-&gt;constants.values[READ_BYTE()])
+<div class="codehilite" translate="no"><pre class="insert-before">#define READ_CONSTANT() (vm.chunk-&gt;constants.values[READ_BYTE()])
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert"><span class="a">#define BINARY_OP(op) \</span>
@@ -906,21 +906,21 @@ as it&rsquo;s concerned, it&rsquo;s all just text tokens.</p>
 probably looks really weird. This macro needs to expand to a series of
 statements. To be careful macro authors, we want to ensure those statements all
 end up in the same scope when the macro is expanded. Imagine if you defined:</p>
-<div class="codehilite"><pre><span class="a">#define WAKE_UP() makeCoffee(); drinkCoffee();</span>
+<div class="codehilite" translate="no"><pre><span class="a">#define WAKE_UP() makeCoffee(); drinkCoffee();</span>
 </pre></div>
 <p>And then used it like:</p>
-<div class="codehilite"><pre><span class="k">if</span> (<span class="i">morning</span>) <span class="a">WAKE_UP</span>();
+<div class="codehilite" translate="no"><pre><span class="k">if</span> (<span class="i">morning</span>) <span class="a">WAKE_UP</span>();
 </pre></div>
 <p>The intent is to execute both statements of the macro body only if <code>morning</code> is
 true. But it expands to:</p>
-<div class="codehilite"><pre><span class="k">if</span> (<span class="i">morning</span>) <span class="i">makeCoffee</span>(); <span class="i">drinkCoffee</span>();;
+<div class="codehilite" translate="no"><pre><span class="k">if</span> (<span class="i">morning</span>) <span class="i">makeCoffee</span>(); <span class="i">drinkCoffee</span>();;
 </pre></div>
 <p>Oops. The <code>if</code> attaches only to the <em>first</em> statement. You might think you could
 fix this using a block.</p>
-<div class="codehilite"><pre><span class="a">#define WAKE_UP() { makeCoffee(); drinkCoffee(); }</span>
+<div class="codehilite" translate="no"><pre><span class="a">#define WAKE_UP() { makeCoffee(); drinkCoffee(); }</span>
 </pre></div>
 <p>That&rsquo;s better, but you still risk:</p>
-<div class="codehilite"><pre><span class="k">if</span> (<span class="i">morning</span>)
+<div class="codehilite" translate="no"><pre><span class="k">if</span> (<span class="i">morning</span>)
   <span class="a">WAKE_UP</span>();
 <span class="k">else</span>
   <span class="i">sleepIn</span>();
@@ -944,7 +944,7 @@ with the stack for each showing how pushing and then popping values reverses
 their order." /></p>
 <p>As we did with the other macros inside <code>run()</code>, we clean up after ourselves at
 the end of the function.</p>
-<div class="codehilite"><pre class="insert-before">#undef READ_CONSTANT
+<div class="codehilite" translate="no"><pre class="insert-before">#undef READ_CONSTANT
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert"><span class="a">#undef BINARY_OP</span>
@@ -953,7 +953,7 @@ in <em>run</em>()</div>
 <div class="source-file-narrow"><em>vm.c</em>, in <em>run</em>()</div>
 
 <p>Last is disassembler support.</p>
-<div class="codehilite"><pre class="insert-before">    case OP_CONSTANT:
+<div class="codehilite" translate="no"><pre class="insert-before">    case OP_CONSTANT:
       return constantInstruction(&quot;OP_CONSTANT&quot;, chunk, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
@@ -978,7 +978,7 @@ larger expression:</p>
 evaluated: -((1.2 + 3.4) / 5.6)" /></p>
 <p>Building on our existing example chunk, here&rsquo;s the additional instructions we
 need to hand-compile that AST to bytecode.</p>
-<div class="codehilite"><pre class="insert-before">  int constant = addConstant(&amp;chunk, 1.2);
+<div class="codehilite" translate="no"><pre class="insert-before">  int constant = addConstant(&amp;chunk, 1.2);
   writeChunk(&amp;chunk, OP_CONSTANT, 123);
   writeChunk(&amp;chunk, constant, 123);
 </pre><div class="source-file"><em>main.c</em><br>
@@ -1026,7 +1026,7 @@ generate it for us.</p>
 <li>
 <p>What bytecode instruction sequences would you generate for the following
 expressions:</p>
-<div class="codehilite"><pre><span class="n">1</span> * <span class="n">2</span> + <span class="n">3</span>
+<div class="codehilite" translate="no"><pre><span class="n">1</span> * <span class="n">2</span> + <span class="n">3</span>
 <span class="n">1</span> + <span class="n">2</span> * <span class="n">3</span>
 <span class="n">3</span> - <span class="n">2</span> - <span class="n">1</span>
 <span class="n">1</span> + <span class="n">2</span> * <span class="n">3</span> - <span class="n">4</span> / -<span class="n">5</span>
@@ -1038,7 +1038,7 @@ the <code>-5</code> is negating the number 5.)</p>
 <p>If we really wanted a minimal instruction set, we could eliminate either
 <code>OP_NEGATE</code> or <code>OP_SUBTRACT</code>. Show the bytecode instruction sequence you
 would generate for:</p>
-<div class="codehilite"><pre><span class="n">4</span> - <span class="n">3</span> * -<span class="n">2</span>
+<div class="codehilite" translate="no"><pre><span class="n">4</span> - <span class="n">3</span> * -<span class="n">2</span>
 </pre></div>
 <p>First, without using <code>OP_NEGATE</code>. Then, without using <code>OP_SUBTRACT</code>.</p>
 <p>Given the above, do you think it makes sense to have both instructions? Why
@@ -1082,12 +1082,12 @@ pushed onto it and popped when no longer needed. The main difference is that
 instructions can read their inputs from anywhere in the stack and can store
 their outputs into specific stack slots.</p>
 <p>Take this little Lox script:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>;
 <span class="k">var</span> <span class="i">b</span> = <span class="n">2</span>;
 <span class="k">var</span> <span class="i">c</span> = <span class="i">a</span> + <span class="i">b</span>;
 </pre></div>
 <p>In our stack-based VM, the last statement will get compiled to something like:</p>
-<div class="codehilite"><pre><span class="i">load</span> &lt;<span class="i">a</span>&gt;  <span class="c">// Read local variable a and push onto stack.</span>
+<div class="codehilite" translate="no"><pre><span class="i">load</span> &lt;<span class="i">a</span>&gt;  <span class="c">// Read local variable a and push onto stack.</span>
 <span class="i">load</span> &lt;<span class="i">b</span>&gt;  <span class="c">// Read local variable b and push onto stack.</span>
 <span class="i">add</span>       <span class="c">// Pop two values, add, push result.</span>
 <span class="i">store</span> &lt;<span class="i">c</span>&gt; <span class="c">// Pop value and store in local variable c.</span>
@@ -1102,7 +1102,7 @@ and three pops. A lot of work!</p>
 <p>In a register-based instruction set, instructions can read from and store
 directly into local variables. The bytecode for the last statement above looks
 like:</p>
-<div class="codehilite"><pre><span class="i">add</span> &lt;<span class="i">a</span>&gt; &lt;<span class="i">b</span>&gt; &lt;<span class="i">c</span>&gt; <span class="c">// Read values from a and b, add, store in c.</span>
+<div class="codehilite" translate="no"><pre><span class="i">add</span> &lt;<span class="i">a</span>&gt; &lt;<span class="i">b</span>&gt; &lt;<span class="i">c</span>&gt; <span class="c">// Read values from a and b, add, store in c.</span>
 </pre></div>
 <p>The add instruction is bigger<span class="em">&mdash;</span>it has three instruction operands that define
 where in the stack it reads its inputs from and writes the result to. But since

--- a/site/appendix-i.html
+++ b/site/appendix-i.html
@@ -89,12 +89,12 @@ place.</p>
 <p>The syntactic grammar is used to parse the linear sequence of tokens into the
 nested syntax tree structure. It starts with the first rule that matches an
 entire Lox program (or a single REPL entry).</p>
-<div class="codehilite"><pre><span class="i">program</span>        → <span class="i">declaration</span>* <span class="t">EOF</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">program</span>        → <span class="i">declaration</span>* <span class="t">EOF</span> ;
 </pre></div>
 <h3><a href="#declarations" id="declarations"><small>A1&#8202;.&#8202;1&#8202;.&#8202;1</small>Declarations</a></h3>
 <p>A program is a series of declarations, which are the statements that bind new
 identifiers or any of the other statement types.</p>
-<div class="codehilite"><pre><span class="i">declaration</span>    → <span class="i">classDecl</span>
+<div class="codehilite" translate="no"><pre><span class="i">declaration</span>    → <span class="i">classDecl</span>
                | <span class="i">funDecl</span>
                | <span class="i">varDecl</span>
                | <span class="i">statement</span> ;
@@ -107,7 +107,7 @@ identifiers or any of the other statement types.</p>
 <h3><a href="#statements" id="statements"><small>A1&#8202;.&#8202;1&#8202;.&#8202;2</small>Statements</a></h3>
 <p>The remaining statement rules produce side effects, but do not introduce
 bindings.</p>
-<div class="codehilite"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
+<div class="codehilite" translate="no"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
                | <span class="i">forStmt</span>
                | <span class="i">ifStmt</span>
                | <span class="i">printStmt</span>
@@ -133,7 +133,7 @@ couple of other rules for things like function bodies.</p>
 different levels of precedence. Some grammars for languages do not directly
 encode the precedence relationships and specify that elsewhere. Here, we use a
 separate rule for each precedence level to make it explicit.</p>
-<div class="codehilite"><pre><span class="i">expression</span>     → <span class="i">assignment</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">expression</span>     → <span class="i">assignment</span> ;
 
 <span class="i">assignment</span>     → ( <span class="i">call</span> <span class="s">&quot;.&quot;</span> )? <span class="t">IDENTIFIER</span> <span class="s">&quot;=&quot;</span> <span class="i">assignment</span>
                | <span class="i">logic_or</span> ;
@@ -154,7 +154,7 @@ separate rule for each precedence level to make it explicit.</p>
 <h3><a href="#utility-rules" id="utility-rules"><small>A1&#8202;.&#8202;1&#8202;.&#8202;4</small>Utility rules</a></h3>
 <p>In order to keep the above rules a little cleaner, some of the grammar is
 split out into a few reused helper rules.</p>
-<div class="codehilite"><pre><span class="i">function</span>       → <span class="t">IDENTIFIER</span> <span class="s">&quot;(&quot;</span> <span class="i">parameters</span>? <span class="s">&quot;)&quot;</span> <span class="i">block</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">function</span>       → <span class="t">IDENTIFIER</span> <span class="s">&quot;(&quot;</span> <span class="i">parameters</span>? <span class="s">&quot;)&quot;</span> <span class="i">block</span> ;
 <span class="i">parameters</span>     → <span class="t">IDENTIFIER</span> ( <span class="s">&quot;,&quot;</span> <span class="t">IDENTIFIER</span> )* ;
 <span class="i">arguments</span>      → <span class="i">expression</span> ( <span class="s">&quot;,&quot;</span> <span class="i">expression</span> )* ;
 </pre></div>
@@ -162,7 +162,7 @@ split out into a few reused helper rules.</p>
 <p>The lexical grammar is used by the scanner to group characters into tokens.
 Where the syntax is <a href="https://en.wikipedia.org/wiki/Context-free_grammar">context free</a>, the lexical grammar is <a href="https://en.wikipedia.org/wiki/Regular_grammar">regular</a><span class="em">&mdash;</span>note
 that there are no recursive rules.</p>
-<div class="codehilite"><pre><span class="t">NUMBER</span>         → <span class="t">DIGIT</span>+ ( <span class="s">&quot;.&quot;</span> <span class="t">DIGIT</span>+ )? ;
+<div class="codehilite" translate="no"><pre><span class="t">NUMBER</span>         → <span class="t">DIGIT</span>+ ( <span class="s">&quot;.&quot;</span> <span class="t">DIGIT</span>+ )? ;
 <span class="t">STRING</span>         → <span class="s">&quot;</span><span class="e">\&quot;</span><span class="s">&quot;</span> &lt;<span class="i">any</span> <span class="i">char</span> <span class="i">except</span> <span class="s">&quot;</span><span class="e">\&quot;</span><span class="s">&quot;</span>&gt;* <span class="s">&quot;</span><span class="e">\&quot;</span><span class="s">&quot;</span> ;
 <span class="t">IDENTIFIER</span>     → <span class="t">ALPHA</span> ( <span class="t">ALPHA</span> | <span class="t">DIGIT</span> )* ;
 <span class="t">ALPHA</span>          → <span class="s">&quot;a&quot;</span> ... <span class="s">&quot;z&quot;</span> | <span class="s">&quot;A&quot;</span> ... <span class="s">&quot;Z&quot;</span> | <span class="s">&quot;_&quot;</span> ;

--- a/site/appendix-ii.html
+++ b/site/appendix-ii.html
@@ -86,7 +86,7 @@ we built</a> to automate generating the syntax tree classes for jlox.</p>
 Code</a>&rdquo;. The main Expr class defines the visitor
 interface used to dispatch against the specific expression types, and contains
 the other expression subclasses as nested classes.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Expr.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -118,7 +118,7 @@ create new file</div>
 <h3><a href="#assign-expression" id="assign-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;1</small>Assign expression</a></h3>
 <p>Variable assignment is introduced in &ldquo;<a href="statements-and-state.html#assignment">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Assign</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Assign</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">Expr</span> <span class="i">value</span>) {
@@ -140,7 +140,7 @@ nest inside class <em>Expr</em></div>
 <h3><a href="#binary-expression" id="binary-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;2</small>Binary expression</a></h3>
 <p>Binary operators are introduced in &ldquo;<a href="representing-code.html">Representing
 Code</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Binary</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Binary</span>(<span class="t">Expr</span> <span class="i">left</span>, <span class="t">Token</span> <span class="i">operator</span>, <span class="t">Expr</span> <span class="i">right</span>) {
@@ -164,7 +164,7 @@ nest inside class <em>Expr</em></div>
 <h3><a href="#call-expression" id="call-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;3</small>Call expression</a></h3>
 <p>Function call expressions are introduced in
 &ldquo;<a href="functions.html#function-calls">Functions</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Call</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Call</span>(<span class="t">Expr</span> <span class="i">callee</span>, <span class="t">Token</span> <span class="i">paren</span>, <span class="t">List</span>&lt;<span class="t">Expr</span>&gt; <span class="i">arguments</span>) {
@@ -188,7 +188,7 @@ nest inside class <em>Expr</em></div>
 <h3><a href="#get-expression" id="get-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;4</small>Get expression</a></h3>
 <p>Property access, or &ldquo;get&rdquo; expressions are introduced in
 &ldquo;<a href="classes.html#properties-on-instances">Classes</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Get</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Get</span>(<span class="t">Expr</span> <span class="i">object</span>, <span class="t">Token</span> <span class="i">name</span>) {
@@ -210,7 +210,7 @@ nest inside class <em>Expr</em></div>
 <h3><a href="#grouping-expression" id="grouping-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;5</small>Grouping expression</a></h3>
 <p>Using parentheses to group expressions is introduced in &ldquo;<a href="representing-code.html">Representing
 Code</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Grouping</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Grouping</span>(<span class="t">Expr</span> <span class="i">expression</span>) {
@@ -230,7 +230,7 @@ nest inside class <em>Expr</em></div>
 <h3><a href="#literal-expression" id="literal-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;6</small>Literal expression</a></h3>
 <p>Literal value expressions are introduced in &ldquo;<a href="representing-code.html">Representing
 Code</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Literal</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Literal</span>(<span class="t">Object</span> <span class="i">value</span>) {
@@ -250,7 +250,7 @@ nest inside class <em>Expr</em></div>
 <h3><a href="#logical-expression" id="logical-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;7</small>Logical expression</a></h3>
 <p>The logical <code>and</code> and <code>or</code> operators are introduced in &ldquo;<a href="control-flow.html#logical-operators">Control
 Flow</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Logical</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Logical</span>(<span class="t">Expr</span> <span class="i">left</span>, <span class="t">Token</span> <span class="i">operator</span>, <span class="t">Expr</span> <span class="i">right</span>) {
@@ -274,7 +274,7 @@ nest inside class <em>Expr</em></div>
 <h3><a href="#set-expression" id="set-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;8</small>Set expression</a></h3>
 <p>Property assignment, or &ldquo;set&rdquo; expressions are introduced in
 &ldquo;<a href="classes.html#properties-on-instances">Classes</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Set</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Set</span>(<span class="t">Expr</span> <span class="i">object</span>, <span class="t">Token</span> <span class="i">name</span>, <span class="t">Expr</span> <span class="i">value</span>) {
@@ -298,7 +298,7 @@ nest inside class <em>Expr</em></div>
 <h3><a href="#super-expression" id="super-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;9</small>Super expression</a></h3>
 <p>The <code>super</code> expression is introduced in
 &ldquo;<a href="inheritance.html#calling-superclass-methods">Inheritance</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Super</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Super</span>(<span class="t">Token</span> <span class="i">keyword</span>, <span class="t">Token</span> <span class="i">method</span>) {
@@ -319,7 +319,7 @@ nest inside class <em>Expr</em></div>
 
 <h3><a href="#this-expression" id="this-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;10</small>This expression</a></h3>
 <p>The <code>this</code> expression is introduced in &ldquo;<a href="classes.html#this">Classes</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">This</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">This</span>(<span class="t">Token</span> <span class="i">keyword</span>) {
@@ -338,7 +338,7 @@ nest inside class <em>Expr</em></div>
 
 <h3><a href="#unary-expression" id="unary-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;11</small>Unary expression</a></h3>
 <p>Unary operators are introduced in &ldquo;<a href="representing-code.html">Representing Code</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Unary</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Unary</span>(<span class="t">Token</span> <span class="i">operator</span>, <span class="t">Expr</span> <span class="i">right</span>) {
@@ -360,7 +360,7 @@ nest inside class <em>Expr</em></div>
 <h3><a href="#variable-expression" id="variable-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;12</small>Variable expression</a></h3>
 <p>Variable access expressions are introduced in &ldquo;<a href="statements-and-state.html#variable-syntax">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Variable</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Variable</span>(<span class="t">Token</span> <span class="i">name</span>) {
@@ -381,7 +381,7 @@ nest inside class <em>Expr</em></div>
 <p>Statements form a second hierarchy of syntax tree nodes independent of
 expressions. We add the first couple of them in &ldquo;<a href="statements-and-state.html">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Stmt.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -410,7 +410,7 @@ create new file</div>
 <h3><a href="#block-statement" id="block-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;1</small>Block statement</a></h3>
 <p>The curly-braced block statement that defines a local scope is introduced in
 &ldquo;<a href="statements-and-state.html#block-syntax-and-semantics">Statements and State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Block</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Block</span>(<span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span>) {
@@ -430,7 +430,7 @@ nest inside class <em>Stmt</em></div>
 <h3><a href="#class-statement" id="class-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;2</small>Class statement</a></h3>
 <p>Class declarations are introduced in, unsurprisingly,
 &ldquo;<a href="classes.html#class-declarations">Classes</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Class</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Class</span>(<span class="t">Token</span> <span class="i">name</span>,
@@ -456,7 +456,7 @@ nest inside class <em>Stmt</em></div>
 <h3><a href="#expression-statement" id="expression-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;3</small>Expression statement</a></h3>
 <p>The expression statement is introduced in &ldquo;<a href="statements-and-state.html#statements">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Expression</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Expression</span>(<span class="t">Expr</span> <span class="i">expression</span>) {
@@ -476,7 +476,7 @@ nest inside class <em>Stmt</em></div>
 <h3><a href="#function-statement" id="function-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;4</small>Function statement</a></h3>
 <p>Function declarations are introduced in, you guessed it,
 &ldquo;<a href="functions.html#function-declarations">Functions</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Function</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Function</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">List</span>&lt;<span class="t">Token</span>&gt; <span class="i">params</span>, <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">body</span>) {
@@ -500,7 +500,7 @@ nest inside class <em>Stmt</em></div>
 <h3><a href="#if-statement" id="if-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;5</small>If statement</a></h3>
 <p>The <code>if</code> statement is introduced in &ldquo;<a href="control-flow.html#conditional-execution">Control
 Flow</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">If</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">If</span>(<span class="t">Expr</span> <span class="i">condition</span>, <span class="t">Stmt</span> <span class="i">thenBranch</span>, <span class="t">Stmt</span> <span class="i">elseBranch</span>) {
@@ -524,7 +524,7 @@ nest inside class <em>Stmt</em></div>
 <h3><a href="#print-statement" id="print-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;6</small>Print statement</a></h3>
 <p>The <code>print</code> statement is introduced in &ldquo;<a href="statements-and-state.html#statements">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Print</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Print</span>(<span class="t">Expr</span> <span class="i">expression</span>) {
@@ -544,7 +544,7 @@ nest inside class <em>Stmt</em></div>
 <h3><a href="#return-statement" id="return-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;7</small>Return statement</a></h3>
 <p>You need a function to return from, so <code>return</code> statements are introduced in
 &ldquo;<a href="functions.html#return-statements">Functions</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Return</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Return</span>(<span class="t">Token</span> <span class="i">keyword</span>, <span class="t">Expr</span> <span class="i">value</span>) {
@@ -566,7 +566,7 @@ nest inside class <em>Stmt</em></div>
 <h3><a href="#variable-statement" id="variable-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;8</small>Variable statement</a></h3>
 <p>Variable declarations are introduced in &ldquo;<a href="statements-and-state.html#variable-syntax">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Var</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Var</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">Expr</span> <span class="i">initializer</span>) {
@@ -588,7 +588,7 @@ nest inside class <em>Stmt</em></div>
 <h3><a href="#while-statement" id="while-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;9</small>While statement</a></h3>
 <p>The <code>while</code> statement is introduced in &ldquo;<a href="control-flow.html#while-loops">Control
 Flow</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">While</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">While</span>(<span class="t">Expr</span> <span class="i">condition</span>, <span class="t">Stmt</span> <span class="i">body</span>) {

--- a/site/calls-and-functions.html
+++ b/site/calls-and-functions.html
@@ -128,7 +128,7 @@ solid blob of machine code. But for our bytecode VM, we can do something a
 little higher level. I think a cleaner model is to give each function its own
 Chunk. We&rsquo;ll want some other metadata too, so let&rsquo;s go ahead and stuff it all in
 a struct now.</p>
-<div class="codehilite"><pre class="insert-before">  struct Obj* next;
+<div class="codehilite" translate="no"><pre class="insert-before">  struct Obj* next;
 };
 </pre><div class="source-file"><em>object.h</em><br>
 add after struct <em>Obj</em></div>
@@ -157,7 +157,7 @@ crash dumps.</p>
 </aside>
 <p>This is the first time the &ldquo;object&rdquo; module has needed to reference Chunk, so we
 get an include.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;common.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;common.h&quot;
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert"><span class="a">#include &quot;chunk.h&quot;</span>
 </pre><pre class="insert-after">#include &quot;value.h&quot;
@@ -167,7 +167,7 @@ get an include.</p>
 <p>Like we did with strings, we define some accessories to make Lox functions
 easier to work with in C. Sort of a poor man&rsquo;s object orientation. First, we&rsquo;ll
 declare a C function to create a new Lox function.</p>
-<div class="codehilite"><pre class="insert-before">  uint32_t hash;
+<div class="codehilite" translate="no"><pre class="insert-before">  uint32_t hash;
 };
 
 </pre><div class="source-file"><em>object.h</em><br>
@@ -178,7 +178,7 @@ add after struct <em>ObjString</em></div>
 <div class="source-file-narrow"><em>object.h</em>, add after struct <em>ObjString</em></div>
 
 <p>The implementation is over here:</p>
-<div class="codehilite"><div class="source-file"><em>object.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.c</em><br>
 add after <em>allocateObject</em>()</div>
 <pre><span class="t">ObjFunction</span>* <span class="i">newFunction</span>() {
   <span class="t">ObjFunction</span>* <span class="i">function</span> = <span class="a">ALLOCATE_OBJ</span>(<span class="t">ObjFunction</span>, <span class="a">OBJ_FUNCTION</span>);
@@ -196,7 +196,7 @@ passing in arguments to initialize the function like we did with ObjString, we
 set the function up in a sort of blank state<span class="em">&mdash;</span>zero arity, no name, and no
 code. That will get filled in later after the function is created.</p>
 <p>Since we have a new kind of object, we need a new object type in the enum.</p>
-<div class="codehilite"><pre class="insert-before">typedef enum {
+<div class="codehilite" translate="no"><pre class="insert-before">typedef enum {
 </pre><div class="source-file"><em>object.h</em><br>
 in enum <em>ObjType</em></div>
 <pre class="insert">  <span class="a">OBJ_FUNCTION</span>,
@@ -207,7 +207,7 @@ in enum <em>ObjType</em></div>
 
 <p>When we&rsquo;re done with a function object, we must return the bits it borrowed back
 to the operating system.</p>
-<div class="codehilite"><pre class="insert-before">  switch (object-&gt;type) {
+<div class="codehilite" translate="no"><pre class="insert-before">  switch (object-&gt;type) {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>freeObject</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OBJ_FUNCTION</span>: {
@@ -230,7 +230,7 @@ least, we&rsquo;ll be able to once we <a href="garbage-collection.html">implemen
 </aside>
 <p>Lox lets you print any object, and functions are first-class objects, so we
 need to handle them too.</p>
-<div class="codehilite"><pre class="insert-before">  switch (OBJ_TYPE(value)) {
+<div class="codehilite" translate="no"><pre class="insert-before">  switch (OBJ_TYPE(value)) {
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>printObject</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OBJ_FUNCTION</span>:
@@ -241,7 +241,7 @@ in <em>printObject</em>()</div>
 <div class="source-file-narrow"><em>object.c</em>, in <em>printObject</em>()</div>
 
 <p>This calls out to:</p>
-<div class="codehilite"><div class="source-file"><em>object.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.c</em><br>
 add after <em>copyString</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">printFunction</span>(<span class="t">ObjFunction</span>* <span class="i">function</span>) {
   <span class="i">printf</span>(<span class="s">&quot;&lt;fn %s&gt;&quot;</span>, <span class="i">function</span>-&gt;<span class="i">name</span>-&gt;<span class="i">chars</span>);
@@ -252,7 +252,7 @@ add after <em>copyString</em>()</div>
 <p>Since a function knows its name, it may as well say it.</p>
 <p>Finally, we have a couple of macros for converting values to functions. First,
 make sure your value actually <em>is</em> a function.</p>
-<div class="codehilite"><pre class="insert-before">#define OBJ_TYPE(value)        (AS_OBJ(value)-&gt;type)
+<div class="codehilite" translate="no"><pre class="insert-before">#define OBJ_TYPE(value)        (AS_OBJ(value)-&gt;type)
 
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert"><span class="a">#define IS_FUNCTION(value)     isObjType(value, OBJ_FUNCTION)</span>
@@ -262,7 +262,7 @@ make sure your value actually <em>is</em> a function.</p>
 
 <p>Assuming that evaluates to true, you can then safely cast the Value to an
 ObjFunction pointer using this:</p>
-<div class="codehilite"><pre class="insert-before">#define IS_STRING(value)       isObjType(value, OBJ_STRING)
+<div class="codehilite" translate="no"><pre class="insert-before">#define IS_STRING(value)       isObjType(value, OBJ_STRING)
 
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert"><span class="a">#define AS_FUNCTION(value)     ((ObjFunction*)AS_OBJ(value))</span>
@@ -294,7 +294,7 @@ top level of a script isn&rsquo;t like a function body.</p>
 support that implicit top-level function. It starts with the Compiler struct.
 Instead of pointing directly to a Chunk that the compiler writes to, it instead
 has a reference to the function object being built.</p>
-<div class="codehilite"><pre class="insert-before">typedef struct {
+<div class="codehilite" translate="no"><pre class="insert-before">typedef struct {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in struct <em>Compiler</em></div>
 <pre class="insert">  <span class="t">ObjFunction</span>* <span class="i">function</span>;
@@ -308,7 +308,7 @@ in struct <em>Compiler</em></div>
 compiling top-level code versus the body of a function. Most of the compiler
 doesn&rsquo;t care about this<span class="em">&mdash;</span>that&rsquo;s why it&rsquo;s a useful abstraction<span class="em">&mdash;</span>but in one or
 two places the distinction is meaningful. We&rsquo;ll get to one later.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after struct <em>Local</em></div>
 <pre><span class="k">typedef</span> <span class="k">enum</span> {
   <span class="a">TYPE_FUNCTION</span>,
@@ -327,7 +327,7 @@ is happy.</p>
 we&rsquo;d need to change the code later. But, really, it&rsquo;s because I wrote all the
 code for the book before any of the text.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">Compiler* current = NULL;
+<div class="codehilite" translate="no"><pre class="insert-before">Compiler* current = NULL;
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after variable <em>current</em><br>
 replace 5 lines</div>
@@ -349,7 +349,7 @@ will create and return a function that contains the compiled top-level code<span
 <h3><a href="#creating-functions-at-compile-time" id="creating-functions-at-compile-time"><small>24&#8202;.&#8202;2&#8202;.&#8202;1</small>Creating functions at compile time</a></h3>
 <p>We start threading this through in <code>compile()</code>, which is the main entry point
 into the compiler.</p>
-<div class="codehilite"><pre class="insert-before">  Compiler compiler;
+<div class="codehilite" translate="no"><pre class="insert-before">  Compiler compiler;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>compile</em>()<br>
 replace 2 lines</div>
@@ -362,7 +362,7 @@ replace 2 lines</div>
 
 <p>There are a bunch of changes in how the compiler is initialized. First, we
 initialize the new Compiler fields.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 function <em>initCompiler</em>()<br>
 replace 1 line</div>
 <pre class="insert"><span class="k">static</span> <span class="t">void</span> <span class="i">initCompiler</span>(<span class="t">Compiler</span>* <span class="i">compiler</span>, <span class="t">FunctionType</span> <span class="i">type</span>) {
@@ -373,7 +373,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, function <em>initCompiler</em>(), replace 1 line</div>
 
 <p>Then we allocate a new function object to compile into.</p>
-<div class="codehilite"><pre class="insert-before">  compiler-&gt;scopeDepth = 0;
+<div class="codehilite" translate="no"><pre class="insert-before">  compiler-&gt;scopeDepth = 0;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>initCompiler</em>()</div>
 <pre class="insert">  <span class="i">compiler</span>-&gt;<span class="i">function</span> = <span class="i">newFunction</span>();
@@ -400,7 +400,7 @@ closures in the <a href="closures.html">next chapter</a>, which capture variable
 the story gets more complex.</p>
 </aside>
 <p>Here is another strange piece of code:</p>
-<div class="codehilite"><pre class="insert-before">  current = compiler;
+<div class="codehilite" translate="no"><pre class="insert-before">  current = compiler;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>initCompiler</em>()</div>
 <pre class="insert">
@@ -420,7 +420,7 @@ empty name so that the user can&rsquo;t write an identifier that refers to it. I
 explain what this is about when it becomes useful.</p>
 <p>That&rsquo;s the initialization side. We also need a couple of changes on the other
 end when we finish compiling some code.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 function <em>endCompiler</em>()<br>
 replace 1 line</div>
 <pre class="insert"><span class="k">static</span> <span class="t">ObjFunction</span>* <span class="i">endCompiler</span>() {
@@ -431,7 +431,7 @@ replace 1 line</div>
 <p>Previously, when <code>interpret()</code> called into the compiler, it passed in a Chunk to
 be written to. Now that the compiler creates the function object itself, we
 return that function. We grab it from the current compiler here:</p>
-<div class="codehilite"><pre class="insert-before">  emitReturn();
+<div class="codehilite" translate="no"><pre class="insert-before">  emitReturn();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>endCompiler</em>()</div>
 <pre class="insert">  <span class="t">ObjFunction</span>* <span class="i">function</span> = <span class="i">current</span>-&gt;<span class="i">function</span>;
@@ -441,7 +441,7 @@ in <em>endCompiler</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>endCompiler</em>()</div>
 
 <p>And then return it to <code>compile()</code> like so:</p>
-<div class="codehilite"><pre class="insert-before">#endif
+<div class="codehilite" translate="no"><pre class="insert-before">#endif
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>endCompiler</em>()</div>
 <pre class="insert">
@@ -455,7 +455,7 @@ in <em>endCompiler</em>()</div>
 some diagnostic code to have the VM dump the disassembled bytecode so we could
 debug the compiler. We should fix that to keep working now that the generated
 chunk is wrapped in a function.</p>
-<div class="codehilite"><pre class="insert-before">#ifdef DEBUG_PRINT_CODE
+<div class="codehilite" translate="no"><pre class="insert-before">#ifdef DEBUG_PRINT_CODE
   if (!parser.hadError) {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>endCompiler</em>()<br>
@@ -471,7 +471,7 @@ replace 1 line</div>
 functions have names, but the implicit function we create for the top-level code
 does not, and we need to handle that gracefully even in our own diagnostic code.
 Speaking of which:</p>
-<div class="codehilite"><pre class="insert-before">static void printFunction(ObjFunction* function) {
+<div class="codehilite" translate="no"><pre class="insert-before">static void printFunction(ObjFunction* function) {
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>printFunction</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">function</span>-&gt;<span class="i">name</span> == <span class="a">NULL</span>) {
@@ -490,7 +490,7 @@ name="debug">diagnostic</span> code that prints the entire stack can and does.</
 segfault!</p>
 </aside>
 <p>Bumping up a level to <code>compile()</code>, we adjust its signature.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;vm.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;vm.h&quot;
 
 </pre><div class="source-file"><em>compiler.h</em><br>
 function <em>compile</em>()<br>
@@ -504,7 +504,7 @@ replace 1 line</div>
 
 <p>Instead of taking a chunk, now it returns a function. Over in the
 implementation:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 function <em>compile</em>()<br>
 replace 1 line</div>
 <pre class="insert"><span class="t">ObjFunction</span>* <span class="i">compile</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">source</span>) {
@@ -514,7 +514,7 @@ replace 1 line</div>
 
 <p>Finally we get to some actual code. We change the very end of the function to
 this:</p>
-<div class="codehilite"><pre class="insert-before">  while (!match(TOKEN_EOF)) {
+<div class="codehilite" translate="no"><pre class="insert-before">  while (!match(TOKEN_EOF)) {
     declaration();
   }
 
@@ -569,7 +569,7 @@ jlox&rsquo;s dynamic approach. The value stack in the VM works on the observatio
 local variables and temporaries behave in a last-in first-out fashion.
 Fortunately for us, that&rsquo;s still true even when you add function calls into the
 mix. Here&rsquo;s an example:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">first</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">first</span>() {
   <span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>;
   <span class="i">second</span>();
   <span class="k">var</span> <span class="i">b</span> = <span class="n">2</span>;
@@ -599,7 +599,7 @@ doesn&rsquo;t always work out. Consider:</p>
 functions are first class in Lox, we can&rsquo;t determine which functions call which
 others at compile time.</p>
 </aside>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">first</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">first</span>() {
   <span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>;
   <span class="i">second</span>();
   <span class="k">var</span> <span class="i">b</span> = <span class="n">2</span>;
@@ -666,7 +666,7 @@ line between genius and madness is hair thin.</p>
 need to track where on the stack that function&rsquo;s locals begin, and where the
 caller should resume. We&rsquo;ll put this, along with some other stuff, in a new
 struct.</p>
-<div class="codehilite"><pre class="insert-before">#define STACK_MAX 256
+<div class="codehilite" translate="no"><pre class="insert-before">#define STACK_MAX 256
 </pre><div class="source-file"><em>vm.h</em></div>
 <pre class="insert">
 
@@ -704,7 +704,7 @@ continuations, then function calls do <em>not</em> always have stack semantics.<
 </aside>
 <p>So over in the VM, we create an array of these CallFrame structs up front and
 treat it as a stack, like we do with the value array.</p>
-<div class="codehilite"><pre class="insert-before">typedef struct {
+<div class="codehilite" translate="no"><pre class="insert-before">typedef struct {
 </pre><div class="source-file"><em>vm.h</em><br>
 in struct <em>VM</em><br>
 replace 2 lines</div>
@@ -722,7 +722,7 @@ that it&rsquo;s executing. From there, we can get to the function&rsquo;s chunk.
 stack<span class="em">&mdash;</span>the number of ongoing function calls. To keep clox simple, the array&rsquo;s
 capacity is fixed. This means, as in many language implementations, there is a
 maximum call depth we can handle. For clox, it&rsquo;s defined here:</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;value.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;value.h&quot;
 
 </pre><div class="source-file"><em>vm.h</em><br>
 replace 1 line</div>
@@ -742,7 +742,7 @@ When the VM starts up, the CallFrame stack is empty.</p>
 temporaries in addition to locals. A robust implementation would guard against
 this, but I&rsquo;m trying to keep things simple.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">  vm.stackTop = vm.stack;
+<div class="codehilite" translate="no"><pre class="insert-before">  vm.stackTop = vm.stack;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>resetStack</em>()</div>
 <pre class="insert">  <span class="i">vm</span>.<span class="i">frameCount</span> = <span class="n">0</span>;
@@ -751,7 +751,7 @@ in <em>resetStack</em>()</div>
 <div class="source-file-narrow"><em>vm.c</em>, in <em>resetStack</em>()</div>
 
 <p>The &ldquo;vm.h&rdquo; header needs access to ObjFunction, so we add an include.</p>
-<div class="codehilite"><pre class="insert-before">#define clox_vm_h
+<div class="codehilite" translate="no"><pre class="insert-before">#define clox_vm_h
 
 </pre><div class="source-file"><em>vm.h</em><br>
 replace 1 line</div>
@@ -766,7 +766,7 @@ CallFrame. We need to fix every line of code in the VM that touches <code>ip</co
 handle that. Also, the instructions that access local variables by stack slot
 need to be updated to do so relative to the current CallFrame&rsquo;s <code>slots</code> field.</p>
 <p>We&rsquo;ll start at the top and plow through it.</p>
-<div class="codehilite"><pre class="insert-before">static InterpretResult run() {
+<div class="codehilite" translate="no"><pre class="insert-before">static InterpretResult run() {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
 replace 4 lines</div>
@@ -797,7 +797,7 @@ speeds up access to the frame&rsquo;s <code>ip</code>. There&rsquo;s no <em>guar
 will do this, but there&rsquo;s a good chance it will.</p>
 </aside>
 <p>Now onto each instruction that needs a little tender loving care.</p>
-<div class="codehilite"><pre class="insert-before">      case OP_GET_LOCAL: {
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_GET_LOCAL: {
         uint8_t slot = READ_BYTE();
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
@@ -812,7 +812,7 @@ stack array, which meant it indexed the slot starting from the bottom of the
 stack. Now, it accesses the current frame&rsquo;s <code>slots</code> array, which means it
 accesses the given numbered slot relative to the beginning of that frame.</p>
 <p>Setting a local variable works the same way.</p>
-<div class="codehilite"><pre class="insert-before">      case OP_SET_LOCAL: {
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_SET_LOCAL: {
         uint8_t slot = READ_BYTE();
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
@@ -824,7 +824,7 @@ replace 1 line</div>
 
 <p>The jump instructions used to modify the VM&rsquo;s <code>ip</code> field. Now, they do the same
 for the current frame&rsquo;s <code>ip</code>.</p>
-<div class="codehilite"><pre class="insert-before">      case OP_JUMP: {
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_JUMP: {
         uint16_t offset = READ_SHORT();
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
@@ -835,7 +835,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>vm.c</em>, in <em>run</em>(), replace 1 line</div>
 
 <p>Same with the conditional jump:</p>
-<div class="codehilite"><pre class="insert-before">      case OP_JUMP_IF_FALSE: {
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_JUMP_IF_FALSE: {
         uint16_t offset = READ_SHORT();
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
@@ -846,7 +846,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>vm.c</em>, in <em>run</em>(), replace 1 line</div>
 
 <p>And our backward-jumping loop instruction:</p>
-<div class="codehilite"><pre class="insert-before">      case OP_LOOP: {
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_LOOP: {
         uint16_t offset = READ_SHORT();
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
@@ -858,7 +858,7 @@ replace 1 line</div>
 
 <p>We have some diagnostic code that prints each instruction as it executes to help
 us debug our VM. That needs to work with the new structure too.</p>
-<div class="codehilite"><pre class="insert-before">    printf(&quot;\n&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">    printf(&quot;\n&quot;);
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
 replace 2 lines</div>
@@ -873,7 +873,7 @@ current CallFrame.</p>
 <p>You know, that wasn&rsquo;t too bad, actually. Most instructions just use the macros
 so didn&rsquo;t need to be touched. Next, we jump up a level to the code that calls
 <code>run()</code>.</p>
-<div class="codehilite"><pre class="insert-before">InterpretResult interpret(const char* source) {
+<div class="codehilite" translate="no"><pre class="insert-before">InterpretResult interpret(const char* source) {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>interpret</em>()<br>
 replace 10 lines</div>
@@ -904,7 +904,7 @@ value stack.</p>
 <p>This gets the interpreter ready to start executing code. After finishing, the VM
 used to free the hardcoded chunk. Now that the ObjFunction owns that code, we
 don&rsquo;t need to do that anymore, so the end of <code>interpret()</code> is simply this:</p>
-<div class="codehilite"><pre class="insert-before">  frame-&gt;slots = vm.stack;
+<div class="codehilite" translate="no"><pre class="insert-before">  frame-&gt;slots = vm.stack;
 
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>interpret</em>()<br>
@@ -916,7 +916,7 @@ replace 4 lines</div>
 
 <p>The last piece of code referring to the old VM fields is <code>runtimeError()</code>. We&rsquo;ll
 revisit that later in the chapter, but for now let&rsquo;s change it to this:</p>
-<div class="codehilite"><pre class="insert-before">  fputs(&quot;\n&quot;, stderr);
+<div class="codehilite" translate="no"><pre class="insert-before">  fputs(&quot;\n&quot;, stderr);
 
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>runtimeError</em>()<br>
@@ -943,7 +943,7 @@ keyword.</p>
 <p>Yes, I am going to make a dumb joke about the <code>fun</code> keyword every time it
 comes up.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">static void declaration() {
+<div class="codehilite" translate="no"><pre class="insert-before">static void declaration() {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>declaration</em>()<br>
 replace 1 line</div>
@@ -955,7 +955,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>declaration</em>(), replace 1 line</div>
 
 <p>That passes control to here:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>block</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">funDeclaration</span>() {
   <span class="t">uint8_t</span> <span class="i">global</span> = <span class="i">parseVariable</span>(<span class="s">&quot;Expect function name.&quot;</span>);
@@ -984,7 +984,7 @@ support recursive local functions.</p>
 soon as we compile the name, before we compile the body. That way the name can
 be referenced inside the body without generating an error.</p>
 <p>We do need one check, though.</p>
-<div class="codehilite"><pre class="insert-before">static void markInitialized() {
+<div class="codehilite" translate="no"><pre class="insert-before">static void markInitialized() {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>markInitialized</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">current</span>-&gt;<span class="i">scopeDepth</span> == <span class="n">0</span>) <span class="k">return</span>;
@@ -1004,7 +1004,7 @@ it.</p>
 <p>I split out the code to compile the parameters and body because we&rsquo;ll reuse it
 later for parsing method declarations inside classes. Let&rsquo;s build it
 incrementally, starting with this:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>block</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">function</span>(<span class="t">FunctionType</span> <span class="i">type</span>) {
   <span class="t">Compiler</span> <span class="i">compiler</span>;
@@ -1056,7 +1056,7 @@ compiler pointer.</p>
 the Value and CallFrame stacks in the VM, we won&rsquo;t use an array. Instead, we use
 a linked list. Each Compiler points back to the Compiler for the function that
 encloses it, all the way back to the root Compiler for the top-level code.</p>
-<div class="codehilite"><pre class="insert-before">} FunctionType;
+<div class="codehilite" translate="no"><pre class="insert-before">} FunctionType;
 
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after enum <em>FunctionType</em><br>
@@ -1072,7 +1072,7 @@ declaration hasn&rsquo;t finished yet. Instead, we give a name to the struct its
 and use that for the field&rsquo;s type. C is weird.</p>
 <p>When initializing a new Compiler, we capture the about-to-no-longer-be-current
 one in that pointer.</p>
-<div class="codehilite"><pre class="insert-before">static void initCompiler(Compiler* compiler, FunctionType type) {
+<div class="codehilite" translate="no"><pre class="insert-before">static void initCompiler(Compiler* compiler, FunctionType type) {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>initCompiler</em>()</div>
 <pre class="insert">  <span class="i">compiler</span>-&gt;<span class="i">enclosing</span> = <span class="i">current</span>;
@@ -1082,7 +1082,7 @@ in <em>initCompiler</em>()</div>
 
 <p>Then when a Compiler finishes, it pops itself off the stack by restoring the
 previous compiler to be the new current one.</p>
-<div class="codehilite"><pre class="insert-before">#endif
+<div class="codehilite" translate="no"><pre class="insert-before">#endif
 
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>endCompiler</em>()</div>
@@ -1107,7 +1107,7 @@ amount of function nesting it permits.</p>
 <h3><a href="#function-parameters" id="function-parameters"><small>24&#8202;.&#8202;4&#8202;.&#8202;2</small>Function parameters</a></h3>
 <p>Functions aren&rsquo;t very useful if you can&rsquo;t pass arguments to them, so let&rsquo;s do
 parameters next.</p>
-<div class="codehilite"><pre class="insert-before">  consume(TOKEN_LEFT_PAREN, &quot;Expect '(' after function name.&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">  consume(TOKEN_LEFT_PAREN, &quot;Expect '(' after function name.&quot;);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>function</em>()</div>
 <pre class="insert">  <span class="k">if</span> (!<span class="i">check</span>(<span class="a">TOKEN_RIGHT_PAREN</span>)) {
@@ -1135,7 +1135,7 @@ we parse. The other piece of metadata we store with a function is its name. When
 compiling a function declaration, we call <code>initCompiler()</code> right after we parse
 the function&rsquo;s name. That means we can grab the name right then from the
 previous token.</p>
-<div class="codehilite"><pre class="insert-before">  current = compiler;
+<div class="codehilite" translate="no"><pre class="insert-before">  current = compiler;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>initCompiler</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">type</span> != <span class="a">TYPE_SCRIPT</span>) {
@@ -1154,7 +1154,7 @@ freed once the code is finished compiling. The function object we create in the
 compiler outlives the compiler and persists until runtime. So it needs its own
 heap-allocated name string that it can keep around.</p>
 <p>Rad. Now we can compile function declarations, like this:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">areWeHavingItYet</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">areWeHavingItYet</span>() {
   <span class="k">print</span> <span class="s">&quot;Yes we are!&quot;</span>;
 }
 
@@ -1173,7 +1173,7 @@ just a single identifier. Then the <code>(</code> in the middle, followed by the
 expressions separated by commas, and a final <code>)</code> to wrap it up at the end.</p>
 <p>That odd grammatical perspective explains how to hook the syntax into our
 parsing table.</p>
-<div class="codehilite"><pre class="insert-before">ParseRule rules[] = {
+<div class="codehilite" translate="no"><pre class="insert-before">ParseRule rules[] = {
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after <em>unary</em>()<br>
 replace 1 line</div>
@@ -1184,7 +1184,7 @@ replace 1 line</div>
 
 <p>When the parser encounters a left parenthesis following an expression, it
 dispatches to a new parser function.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>binary</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">call</span>(<span class="t">bool</span> <span class="i">canAssign</span>) {
   <span class="t">uint8_t</span> <span class="i">argCount</span> = <span class="i">argumentList</span>();
@@ -1199,7 +1199,7 @@ it compiled. Each argument expression generates code that leaves its value on
 the stack in preparation for the call. After that, we emit a new <code>OP_CALL</code>
 instruction to invoke the function, using the argument count as an operand.</p>
 <p>We compile the arguments using this friend:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>defineVariable</em>()</div>
 <pre><span class="k">static</span> <span class="t">uint8_t</span> <span class="i">argumentList</span>() {
   <span class="t">uint8_t</span> <span class="i">argCount</span> = <span class="n">0</span>;
@@ -1223,7 +1223,7 @@ more than 255 arguments to a call. At the time, I said that was because clox
 would need a similar limit. Now you can see why<span class="em">&mdash;</span>since we stuff the argument
 count into the bytecode as a single-byte operand, we can only go up to 255. We
 need to verify that in this compiler too.</p>
-<div class="codehilite"><pre class="insert-before">      expression();
+<div class="codehilite" translate="no"><pre class="insert-before">      expression();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>argumentList</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">argCount</span> == <span class="n">255</span>) {
@@ -1235,7 +1235,7 @@ in <em>argumentList</em>()</div>
 
 <p>That&rsquo;s the front end. Let&rsquo;s skip over to the back end, with a quick stop in the
 middle to declare the new instruction.</p>
-<div class="codehilite"><pre class="insert-before">  OP_LOOP,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_LOOP,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_CALL</span>,
@@ -1248,7 +1248,7 @@ in enum <em>OpCode</em></div>
 like at the point of a call and what we need to do from there. When we reach the
 call instruction, we have already executed the expression for the function being
 called, followed by its arguments. Say our program looks like this:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">sum</span>(<span class="i">a</span>, <span class="i">b</span>, <span class="i">c</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">sum</span>(<span class="i">a</span>, <span class="i">b</span>, <span class="i">c</span>) {
   <span class="k">return</span> <span class="i">a</span> + <span class="i">b</span> + <span class="i">c</span>;
 }
 
@@ -1287,7 +1287,7 @@ parameter&rdquo;. There&rsquo;s no copying values between slots or across enviro
 arguments are already exactly where they need to be. It&rsquo;s hard to beat that for
 performance.</p>
 <p>Time to implement the call instruction.</p>
-<div class="codehilite"><pre class="insert-before">      }
+<div class="codehilite" translate="no"><pre class="insert-before">      }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_CALL</span>: {
@@ -1310,7 +1310,7 @@ that happens, we abort the interpreter.</p>
 <p>If <code>callValue()</code> is successful, there will be a new frame on the CallFrame stack
 for the called function. The <code>run()</code> function has its own cached pointer to the
 current frame, so we need to update that.</p>
-<div class="codehilite"><pre class="insert-before">          return INTERPRET_RUNTIME_ERROR;
+<div class="codehilite" translate="no"><pre class="insert-before">          return INTERPRET_RUNTIME_ERROR;
         }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
@@ -1323,7 +1323,7 @@ in <em>run</em>()</div>
 goes to execute the next instruction, it will read the <code>ip</code> from the newly
 called function&rsquo;s CallFrame and jump to its code. The work for executing that
 call begins here:</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>peek</em>()</div>
 <pre><span class="k">static</span> <span class="t">bool</span> <span class="i">callValue</span>(<span class="t">Value</span> <span class="i">callee</span>, <span class="t">int</span> <span class="i">argCount</span>) {
   <span class="k">if</span> (<span class="a">IS_OBJ</span>(<span class="i">callee</span>)) {
@@ -1347,13 +1347,13 @@ sense when we add cases to handle other callable types.</p>
 <p>There&rsquo;s more going on here than just initializing a new CallFrame. Because Lox
 is dynamically typed, there&rsquo;s nothing to prevent a user from writing bad code
 like:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">notAFunction</span> = <span class="n">123</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">notAFunction</span> = <span class="n">123</span>;
 <span class="i">notAFunction</span>();
 </pre></div>
 <p>If that happens, the runtime needs to safely report an error and halt. So the
 first thing we do is check the type of the value that we&rsquo;re trying to call. If
 it&rsquo;s not a function, we error out. Otherwise, the actual call happens here:</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>peek</em>()</div>
 <pre><span class="k">static</span> <span class="t">bool</span> <span class="i">call</span>(<span class="t">ObjFunction</span>* <span class="i">function</span>, <span class="t">int</span> <span class="i">argCount</span>) {
   <span class="t">CallFrame</span>* <span class="i">frame</span> = &amp;<span class="i">vm</span>.<span class="i">frames</span>[<span class="i">vm</span>.<span class="i">frameCount</span>++];
@@ -1374,7 +1374,7 @@ already on the stack line up with the function&rsquo;s parameters:</p><img src="
 aside for when we add methods later. The parameters start at slot one so we
 make the window start one slot earlier to align them with the arguments.</p>
 <p>Before we move on, let&rsquo;s add the new instruction to our disassembler.</p>
-<div class="codehilite"><pre class="insert-before">      return jumpInstruction(&quot;OP_LOOP&quot;, -1, chunk, offset);
+<div class="codehilite" translate="no"><pre class="insert-before">      return jumpInstruction(&quot;OP_LOOP&quot;, -1, chunk, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OP_CALL</span>:
@@ -1386,7 +1386,7 @@ in <em>disassembleInstruction</em>()</div>
 <p>And one more quick side trip. Now that we have a handy function for initiating a
 CallFrame, we may as well use it to set up the first frame for executing the
 top-level code.</p>
-<div class="codehilite"><pre class="insert-before">  push(OBJ_VAL(function));
+<div class="codehilite" translate="no"><pre class="insert-before">  push(OBJ_VAL(function));
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>interpret</em>()<br>
 replace 4 lines</div>
@@ -1404,7 +1404,7 @@ exactly one argument for each of the function&rsquo;s parameters. But, again, be
 Lox ain&rsquo;t statically typed, a foolish user could pass too many or too few
 arguments. In Lox, we&rsquo;ve defined that to be a runtime error, which we report
 like so:</p>
-<div class="codehilite"><pre class="insert-before">static bool call(ObjFunction* function, int argCount) {
+<div class="codehilite" translate="no"><pre class="insert-before">static bool call(ObjFunction* function, int argCount) {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>call</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">argCount</span> != <span class="i">function</span>-&gt;<span class="i">arity</span>) {
@@ -1422,7 +1422,7 @@ the ObjFunction for it.</p>
 <p>There&rsquo;s another error we need to report that&rsquo;s less to do with the user&rsquo;s
 foolishness than our own. Because the CallFrame array has a fixed size, we need
 to ensure a deep call chain doesn&rsquo;t overflow it.</p>
-<div class="codehilite"><pre class="insert-before">  }
+<div class="codehilite" translate="no"><pre class="insert-before">  }
 
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>call</em>()</div>
@@ -1448,7 +1448,7 @@ where the execution was at the point that it died. Now that we have a call stack
 and we&rsquo;ve conveniently stored each function&rsquo;s name, we can show that entire
 stack when a runtime error disrupts the harmony of the user&rsquo;s existence. It
 looks like this:</p>
-<div class="codehilite"><pre class="insert-before">  fputs(&quot;\n&quot;, stderr);
+<div class="codehilite" translate="no"><pre class="insert-before">  fputs(&quot;\n&quot;, stderr);
 
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>runtimeError</em>()<br>
@@ -1495,7 +1495,7 @@ function where the error actually occurred. Most other language implementations
 do that.</p>
 </aside>
 <p>For example, if you run this broken program:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">a</span>() { <span class="i">b</span>(); }
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">a</span>() { <span class="i">b</span>(); }
 <span class="k">fun</span> <span class="i">b</span>() { <span class="i">c</span>(); }
 <span class="k">fun</span> <span class="i">c</span>() {
   <span class="i">c</span>(<span class="s">&quot;too&quot;</span>, <span class="s">&quot;many&quot;</span>);
@@ -1504,7 +1504,7 @@ do that.</p>
 <span class="i">a</span>();
 </pre></div>
 <p>It prints out:</p>
-<div class="codehilite"><pre>Expected 0 arguments but got 2.
+<div class="codehilite" translate="no"><pre>Expected 0 arguments but got 2.
 [line 4] in c()
 [line 2] in b()
 [line 1] in a()
@@ -1517,7 +1517,7 @@ can&rsquo;t <em>return</em> from them yet. We&rsquo;ve had an <code>OP_RETURN</c
 some time, but it&rsquo;s always had some kind of temporary code hanging out in it
 just to get us out of the bytecode loop. The time has arrived for a real
 implementation.</p>
-<div class="codehilite"><pre class="insert-before">      case OP_RETURN: {
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_RETURN: {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
 replace 2 lines</div>
@@ -1554,7 +1554,7 @@ VM will read <code>ip</code> from that frame, and execution will jump back to th
 right where it left off, immediately after the <code>OP_CALL</code> instruction.</p><img src="image/calls-and-functions/return.png" alt="Each step of the return process: popping the return value, discarding the call frame, pushing the return value." />
 <p>Note that we assume here that the function <em>did</em> actually return a value, but
 a function can implicitly return by reaching the end of its body:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">noReturn</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">noReturn</span>() {
   <span class="k">print</span> <span class="s">&quot;Do stuff&quot;</span>;
   <span class="c">// No return here.</span>
 }
@@ -1563,7 +1563,7 @@ a function can implicitly return by reaching the end of its body:</p>
 </pre></div>
 <p>We need to handle that correctly too. The language is specified to implicitly
 return <code>nil</code> in that case. To make that happen, we add this:</p>
-<div class="codehilite"><pre class="insert-before">static void emitReturn() {
+<div class="codehilite" translate="no"><pre class="insert-before">static void emitReturn() {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>emitReturn</em>()</div>
 <pre class="insert">  <span class="i">emitByte</span>(<span class="a">OP_NIL</span>);
@@ -1579,7 +1579,7 @@ take parameters! It almost looks like we know what we&rsquo;re doing here.</p>
 <h2><a href="#return-statements" id="return-statements"><small>24&#8202;.&#8202;6</small>Return Statements</a></h2>
 <p>If you want a function that returns something other than the implicit <code>nil</code>, you
 need a <code>return</code> statement. Let&rsquo;s get that working.</p>
-<div class="codehilite"><pre class="insert-before">    ifStatement();
+<div class="codehilite" translate="no"><pre class="insert-before">    ifStatement();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">  } <span class="k">else</span> <span class="k">if</span> (<span class="i">match</span>(<span class="a">TOKEN_RETURN</span>)) {
@@ -1589,7 +1589,7 @@ in <em>statement</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>statement</em>()</div>
 
 <p>When the compiler sees a <code>return</code> keyword, it goes here:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>printStatement</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">returnStatement</span>() {
   <span class="k">if</span> (<span class="i">match</span>(<span class="a">TOKEN_SEMICOLON</span>)) {
@@ -1623,7 +1623,7 @@ the function&rsquo;s body.</p>
 compile error to worry about. Returns are useful for returning from functions
 but the top level of a Lox program is imperative code too. You shouldn&rsquo;t be able
 to <span name="worst">return</span> from there.</p>
-<div class="codehilite"><pre><span class="k">return</span> <span class="s">&quot;What?!&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">return</span> <span class="s">&quot;What?!&quot;</span>;
 </pre></div>
 <aside name="worst">
 <p>Allowing <code>return</code> at the top level isn&rsquo;t the worst idea in the world. It would
@@ -1632,7 +1632,7 @@ returned number to indicate the process&rsquo;s exit code.</p>
 </aside>
 <p>We&rsquo;ve specified that it&rsquo;s a compile error to have a <code>return</code> statement outside
 of any function, which we implement like so:</p>
-<div class="codehilite"><pre class="insert-before">static void returnStatement() {
+<div class="codehilite" translate="no"><pre class="insert-before">static void returnStatement() {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>returnStatement</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">current</span>-&gt;<span class="i">type</span> == <span class="a">TYPE_SCRIPT</span>) {
@@ -1672,7 +1672,7 @@ frame to point to. They have no bytecode chunk. Instead, they somehow reference
 a piece of native C code.</p>
 <p>We handle this in clox by defining native functions as an entirely different
 object type.</p>
-<div class="codehilite"><pre class="insert-before">} ObjFunction;
+<div class="codehilite" translate="no"><pre class="insert-before">} ObjFunction;
 </pre><div class="source-file"><em>object.h</em><br>
 add after struct <em>ObjFunction</em></div>
 <pre class="insert">
@@ -1696,7 +1696,7 @@ stack. It accesses the arguments through that pointer. Once it&rsquo;s done, it
 returns the result value.</p>
 <p>As always, a new object type carries some accoutrements with it. To create an
 ObjNative, we declare a constructor-like function.</p>
-<div class="codehilite"><pre class="insert-before">ObjFunction* newFunction();
+<div class="codehilite" translate="no"><pre class="insert-before">ObjFunction* newFunction();
 </pre><div class="source-file"><em>object.h</em><br>
 add after <em>newFunction</em>()</div>
 <pre class="insert"><span class="t">ObjNative</span>* <span class="i">newNative</span>(<span class="t">NativeFn</span> <span class="i">function</span>);
@@ -1705,7 +1705,7 @@ add after <em>newFunction</em>()</div>
 <div class="source-file-narrow"><em>object.h</em>, add after <em>newFunction</em>()</div>
 
 <p>We implement that like so:</p>
-<div class="codehilite"><div class="source-file"><em>object.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.c</em><br>
 add after <em>newFunction</em>()</div>
 <pre><span class="t">ObjNative</span>* <span class="i">newNative</span>(<span class="t">NativeFn</span> <span class="i">function</span>) {
   <span class="t">ObjNative</span>* <span class="i">native</span> = <span class="a">ALLOCATE_OBJ</span>(<span class="t">ObjNative</span>, <span class="a">OBJ_NATIVE</span>);
@@ -1718,7 +1718,7 @@ add after <em>newFunction</em>()</div>
 <p>The constructor takes a C function pointer to wrap in an ObjNative. It sets up
 the object header and stores the function. For the header, we need a new object
 type.</p>
-<div class="codehilite"><pre class="insert-before">typedef enum {
+<div class="codehilite" translate="no"><pre class="insert-before">typedef enum {
   OBJ_FUNCTION,
 </pre><div class="source-file"><em>object.h</em><br>
 in enum <em>ObjType</em></div>
@@ -1729,7 +1729,7 @@ in enum <em>ObjType</em></div>
 <div class="source-file-narrow"><em>object.h</em>, in enum <em>ObjType</em></div>
 
 <p>The VM also needs to know how to deallocate a native function object.</p>
-<div class="codehilite"><pre class="insert-before">    }
+<div class="codehilite" translate="no"><pre class="insert-before">    }
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>freeObject</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OBJ_NATIVE</span>:
@@ -1741,7 +1741,7 @@ in <em>freeObject</em>()</div>
 
 <p>There isn&rsquo;t much here since ObjNative doesn&rsquo;t own any extra memory. The other
 capability all Lox objects support is being printed.</p>
-<div class="codehilite"><pre class="insert-before">      break;
+<div class="codehilite" translate="no"><pre class="insert-before">      break;
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>printObject</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OBJ_NATIVE</span>:
@@ -1753,7 +1753,7 @@ in <em>printObject</em>()</div>
 
 <p>In order to support dynamic typing, we have a macro to see if a value is a
 native function.</p>
-<div class="codehilite"><pre class="insert-before">#define IS_FUNCTION(value)     isObjType(value, OBJ_FUNCTION)
+<div class="codehilite" translate="no"><pre class="insert-before">#define IS_FUNCTION(value)     isObjType(value, OBJ_FUNCTION)
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert"><span class="a">#define IS_NATIVE(value)       isObjType(value, OBJ_NATIVE)</span>
 </pre><pre class="insert-after">#define IS_STRING(value)       isObjType(value, OBJ_STRING)
@@ -1762,7 +1762,7 @@ native function.</p>
 
 <p>Assuming that returns true, this macro extracts the C function pointer from a
 Value representing a native function:</p>
-<div class="codehilite"><pre class="insert-before">#define AS_FUNCTION(value)     ((ObjFunction*)AS_OBJ(value))
+<div class="codehilite" translate="no"><pre class="insert-before">#define AS_FUNCTION(value)     ((ObjFunction*)AS_OBJ(value))
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert"><span class="a">#define AS_NATIVE(value) \</span>
 <span class="a">    (((ObjNative*)AS_OBJ(value))-&gt;function)</span>
@@ -1775,7 +1775,7 @@ You can store them in variables, pass them around, throw them birthday parties,
 etc. Of course, the operation we actually care about is <em>calling</em> them<span class="em">&mdash;</span>using
 one as the left-hand operand in a call expression.</p>
 <p>Over in <code>callValue()</code> we add another type case.</p>
-<div class="codehilite"><pre class="insert-before">      case OBJ_FUNCTION:<span name="switch"> </span>
+<div class="codehilite" translate="no"><pre class="insert-before">      case OBJ_FUNCTION:<span name="switch"> </span>
         return call(AS_FUNCTION(callee), argCount);
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>callValue</em>()</div>
@@ -1798,7 +1798,7 @@ functions as fast as we can get.</p>
 to call. Without something like a foreign function interface, users can&rsquo;t define
 their own native functions. That&rsquo;s our job as VM implementers. We&rsquo;ll start with
 a helper to define a new native function exposed to Lox programs.</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>runtimeError</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">defineNative</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">name</span>, <span class="t">NativeFn</span> <span class="i">function</span>) {
   <span class="i">push</span>(<span class="a">OBJ_VAL</span>(<span class="i">copyString</span>(<span class="i">name</span>, (<span class="t">int</span>)<span class="i">strlen</span>(<span class="i">name</span>))));
@@ -1827,7 +1827,7 @@ get around to <a href="garbage-collection.html">implementing the GC</a>.</p>
 </aside>
 <p>It feels silly, but after all of that work, we&rsquo;re going to add only one
 little native function.</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after variable <em>vm</em></div>
 <pre><span class="k">static</span> <span class="t">Value</span> <span class="i">clockNative</span>(<span class="t">int</span> <span class="i">argCount</span>, <span class="t">Value</span>* <span class="i">args</span>) {
   <span class="k">return</span> <span class="a">NUMBER_VAL</span>((<span class="t">double</span>)<span class="i">clock</span>() / <span class="a">CLOCKS_PER_SEC</span>);
@@ -1837,7 +1837,7 @@ add after variable <em>vm</em></div>
 
 <p>This returns the elapsed time since the program started running, in seconds. It&rsquo;s
 handy for benchmarking Lox programs. In Lox, we&rsquo;ll name it <code>clock()</code>.</p>
-<div class="codehilite"><pre class="insert-before">  initTable(&amp;vm.strings);
+<div class="codehilite" translate="no"><pre class="insert-before">  initTable(&amp;vm.strings);
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>initVM</em>()</div>
 <pre class="insert">
@@ -1849,7 +1849,7 @@ in <em>initVM</em>()</div>
 
 <p>To get to the C standard library <code>clock()</code> function, the &ldquo;vm&rdquo; module needs an
 include.</p>
-<div class="codehilite"><pre class="insert-before">#include &lt;string.h&gt;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &lt;string.h&gt;
 </pre><div class="source-file"><em>vm.c</em></div>
 <pre class="insert"><span class="a">#include &lt;time.h&gt;</span>
 </pre><pre class="insert-after">
@@ -1860,7 +1860,7 @@ include.</p>
 
 <p>That was a lot of material to work through, but we did it! Type this in and try
 it out:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">fib</span>(<span class="i">n</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">fib</span>(<span class="i">n</span>) {
   <span class="k">if</span> (<span class="i">n</span> &lt; <span class="n">2</span>) <span class="k">return</span> <span class="i">n</span>;
   <span class="k">return</span> <span class="i">fib</span>(<span class="i">n</span> - <span class="n">2</span>) + <span class="i">fib</span>(<span class="i">n</span> - <span class="n">1</span>);
 }

--- a/site/chunks-of-bytecode.html
+++ b/site/chunks-of-bytecode.html
@@ -120,7 +120,7 @@ this book is going to fit on your bookshelf.</p>
 slow. A tree-walk interpreter is fine for some kinds of high-level, declarative
 languages. But for a general-purpose, imperative language<span class="em">&mdash;</span>even a &ldquo;scripting&rdquo;
 language like Lox<span class="em">&mdash;</span>it won&rsquo;t fly. Take this little script:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">fib</span>(<span class="i">n</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">fib</span>(<span class="i">n</span>) {
   <span class="k">if</span> (<span class="i">n</span> &lt; <span class="n">2</span>) <span class="k">return</span> <span class="i">n</span>;
   <span class="k">return</span> <span class="i">fib</span>(<span class="i">n</span> - <span class="n">1</span>) + <span class="i">fib</span>(<span class="i">n</span> - <span class="n">2</span>);<span name="fib"> </span>
 }
@@ -302,7 +302,7 @@ trusty text editor and start typing.</p>
 <p>Now is a good time to stretch, maybe crack your knuckles. A little montage music
 wouldn&rsquo;t hurt either.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>main.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>main.c</em><br>
 create new file</div>
 <pre><span class="a">#include &quot;common.h&quot;</span>
 
@@ -315,7 +315,7 @@ create new file</div>
 <p>From this tiny seed, we will grow our entire VM. Since C provides us with so
 little, we first need to spend some time amending the soil. Some of that goes
 into this header:</p>
-<div class="codehilite"><div class="source-file"><em>common.h</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>common.h</em><br>
 create new file</div>
 <pre><span class="a">#ifndef clox_common_h</span>
 <span class="a">#define clox_common_h</span>
@@ -335,7 +335,7 @@ and this is a convenient place to put them. For now, it&rsquo;s the venerable <c
 <p>Next, we need a module to define our code representation. I&rsquo;ve been using
 &ldquo;chunk&rdquo; to refer to sequences of bytecode, so let&rsquo;s make that the official name
 for that module.</p>
-<div class="codehilite"><div class="source-file"><em>chunk.h</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>chunk.h</em><br>
 create new file</div>
 <pre><span class="a">#ifndef clox_chunk_h</span>
 <span class="a">#define clox_chunk_h</span>
@@ -350,7 +350,7 @@ create new file</div>
 (universally shortened to <strong>opcode</strong>). That number controls what kind of
 instruction we&rsquo;re dealing with<span class="em">&mdash;</span>add, subtract, look up variable, etc. We
 define those here:</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;common.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;common.h&quot;
 </pre><div class="source-file"><em>chunk.h</em></div>
 <pre class="insert">
 
@@ -371,7 +371,7 @@ is a particularly simple instruction, for reasons we&rsquo;ll get to later.</p>
 <p>Bytecode is a series of instructions. Eventually, we&rsquo;ll store some other data
 along with the instructions, so let&rsquo;s go ahead and create a struct to hold it
 all.</p>
-<div class="codehilite"><pre class="insert-before">} OpCode;
+<div class="codehilite" translate="no"><pre class="insert-before">} OpCode;
 </pre><div class="source-file"><em>chunk.h</em><br>
 add after enum <em>OpCode</em></div>
 <pre class="insert">
@@ -410,7 +410,7 @@ own. If you&rsquo;re rusty on dynamic arrays, the idea is pretty simple. In addi
 to the array itself, we keep two numbers: the number of elements in the array we
 have allocated (&ldquo;capacity&rdquo;) and how many of those allocated entries are actually
 in use (&ldquo;count&rdquo;).</p>
-<div class="codehilite"><pre class="insert-before">typedef struct {
+<div class="codehilite" translate="no"><pre class="insert-before">typedef struct {
 </pre><div class="source-file"><em>chunk.h</em><br>
 in struct <em>Chunk</em></div>
 <pre class="insert">  <span class="t">int</span> <span class="i">count</span>;
@@ -449,7 +449,7 @@ average out the cost of a <em>sequence</em> of appends, each append is <em>O(1)<
 </aside>
 <p>We have our struct ready, so let&rsquo;s implement the functions to work with it. C
 doesn&rsquo;t have constructors, so we declare a function to initialize a new chunk.</p>
-<div class="codehilite"><pre class="insert-before">} Chunk;
+<div class="codehilite" translate="no"><pre class="insert-before">} Chunk;
 </pre><div class="source-file"><em>chunk.h</em><br>
 add after struct <em>Chunk</em></div>
 <pre class="insert">
@@ -462,7 +462,7 @@ add after struct <em>Chunk</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, add after struct <em>Chunk</em></div>
 
 <p>And implement it thusly:</p>
-<div class="codehilite"><div class="source-file"><em>chunk.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>chunk.c</em><br>
 create new file</div>
 <pre><span class="a">#include &lt;stdlib.h&gt;</span>
 
@@ -478,7 +478,7 @@ create new file</div>
 
 <p>The dynamic array starts off completely empty. We don&rsquo;t even allocate a raw
 array yet. To append a byte to the end of the chunk, we use a new function.</p>
-<div class="codehilite"><pre class="insert-before">void initChunk(Chunk* chunk);
+<div class="codehilite" translate="no"><pre class="insert-before">void initChunk(Chunk* chunk);
 </pre><div class="source-file"><em>chunk.h</em><br>
 add after <em>initChunk</em>()</div>
 <pre class="insert"><span class="t">void</span> <span class="i">writeChunk</span>(<span class="t">Chunk</span>* <span class="i">chunk</span>, <span class="t">uint8_t</span> <span class="i">byte</span>);
@@ -489,7 +489,7 @@ add after <em>initChunk</em>()</div>
 <div class="source-file-narrow"><em>chunk.h</em>, add after <em>initChunk</em>()</div>
 
 <p>This is where the interesting work happens.</p>
-<div class="codehilite"><div class="source-file"><em>chunk.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>chunk.c</em><br>
 add after <em>initChunk</em>()</div>
 <pre><span class="t">void</span> <span class="i">writeChunk</span>(<span class="t">Chunk</span>* <span class="i">chunk</span>, <span class="t">uint8_t</span> <span class="i">byte</span>) {
   <span class="k">if</span> (<span class="i">chunk</span>-&gt;<span class="i">capacity</span> &lt; <span class="i">chunk</span>-&gt;<span class="i">count</span> + <span class="n">1</span>) {
@@ -512,7 +512,7 @@ and <code>capacity</code> is 0.)</p>
 <p>To grow the array, first we figure out the new capacity and grow the array to
 that size. Both of those lower-level memory operations are defined in a new
 module.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;chunk.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;chunk.h&quot;
 </pre><div class="source-file"><em>chunk.c</em></div>
 <pre class="insert"><span class="a">#include &quot;memory.h&quot;</span>
 </pre><pre class="insert-after">
@@ -522,7 +522,7 @@ void initChunk(Chunk* chunk) {
 <div class="source-file-narrow"><em>chunk.c</em></div>
 
 <p>This is enough to get us started.</p>
-<div class="codehilite"><div class="source-file"><em>memory.h</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>memory.h</em><br>
 create new file</div>
 <pre><span class="a">#ifndef clox_memory_h</span>
 <span class="a">#define clox_memory_h</span>
@@ -552,7 +552,7 @@ makes the best performance trade-off between extra grows versus wasted space.</p
 </aside>
 <p>Once we know the desired capacity, we create or grow the array to that size
 using <code>GROW_ARRAY()</code>.</p>
-<div class="codehilite"><pre class="insert-before">#define GROW_CAPACITY(capacity) \
+<div class="codehilite" translate="no"><pre class="insert-before">#define GROW_CAPACITY(capacity) \
     ((capacity) &lt; 8 ? 8 : (capacity) * 2)
 </pre><div class="source-file"><em>memory.h</em></div>
 <pre class="insert">
@@ -609,7 +609,7 @@ perform:</p><table>
   </tbody>
 </table>
 <p>That sounds like a lot of cases to handle, but here&rsquo;s the implementation:</p>
-<div class="codehilite"><div class="source-file"><em>memory.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>memory.c</em><br>
 create new file</div>
 <pre><span class="a">#include &lt;stdlib.h&gt;</span>
 
@@ -646,7 +646,7 @@ behavior we want for our dynamic array.</p>
 abstractions computer science theory would have us believe, allocation can fail
 if there isn&rsquo;t enough memory and <code>realloc()</code> will return <code>NULL</code>. We should
 handle that.</p>
-<div class="codehilite"><pre class="insert-before">  void* result = realloc(pointer, newSize);
+<div class="codehilite" translate="no"><pre class="insert-before">  void* result = realloc(pointer, newSize);
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>reallocate</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">result</span> == <span class="a">NULL</span>) <span class="i">exit</span>(<span class="n">1</span>);
@@ -671,7 +671,7 @@ this size metadata that <code>realloc()</code> updates.</p>
 <p>OK, we can create new chunks and write instructions to them. Are we done? Nope!
 We&rsquo;re in C now, remember, we have to manage memory ourselves, like in Ye Olden
 Times, and that means <em>freeing</em> it too.</p>
-<div class="codehilite"><pre class="insert-before">void initChunk(Chunk* chunk);
+<div class="codehilite" translate="no"><pre class="insert-before">void initChunk(Chunk* chunk);
 </pre><div class="source-file"><em>chunk.h</em><br>
 add after <em>initChunk</em>()</div>
 <pre class="insert"><span class="t">void</span> <span class="i">freeChunk</span>(<span class="t">Chunk</span>* <span class="i">chunk</span>);
@@ -680,7 +680,7 @@ add after <em>initChunk</em>()</div>
 <div class="source-file-narrow"><em>chunk.h</em>, add after <em>initChunk</em>()</div>
 
 <p>The implementation is:</p>
-<div class="codehilite"><div class="source-file"><em>chunk.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>chunk.c</em><br>
 add after <em>initChunk</em>()</div>
 <pre><span class="t">void</span> <span class="i">freeChunk</span>(<span class="t">Chunk</span>* <span class="i">chunk</span>) {
   <span class="a">FREE_ARRAY</span>(<span class="t">uint8_t</span>, <span class="i">chunk</span>-&gt;<span class="i">code</span>, <span class="i">chunk</span>-&gt;<span class="i">capacity</span>);
@@ -692,7 +692,7 @@ add after <em>initChunk</em>()</div>
 <p>We deallocate all of the memory and then call <code>initChunk()</code> to zero out the
 fields leaving the chunk in a well-defined empty state. To free the memory, we
 add one more macro.</p>
-<div class="codehilite"><pre class="insert-before">#define GROW_ARRAY(type, pointer, oldCount, newCount) \
+<div class="codehilite" translate="no"><pre class="insert-before">#define GROW_ARRAY(type, pointer, oldCount, newCount) \
     (type*)reallocate(pointer, sizeof(type) * (oldCount), \
         sizeof(type) * (newCount))
 </pre><div class="source-file"><em>memory.h</em></div>
@@ -714,7 +714,7 @@ though, we gotta lay our own foundation.</p>
 <h2><a href="#disassembling-chunks" id="disassembling-chunks"><small>14&#8202;.&#8202;4</small>Disassembling Chunks</a></h2>
 <p>Now we have a little module for creating chunks of bytecode. Let&rsquo;s try it out by
 hand-building a sample chunk.</p>
-<div class="codehilite"><pre class="insert-before">int main(int argc, const char* argv[]) {
+<div class="codehilite" translate="no"><pre class="insert-before">int main(int argc, const char* argv[]) {
 </pre><div class="source-file"><em>main.c</em><br>
 in <em>main</em>()</div>
 <pre class="insert">  <span class="t">Chunk</span> <span class="i">chunk</span>;
@@ -726,7 +726,7 @@ in <em>main</em>()</div>
 <div class="source-file-narrow"><em>main.c</em>, in <em>main</em>()</div>
 
 <p>Don&rsquo;t forget the include.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;common.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;common.h&quot;
 </pre><div class="source-file"><em>main.c</em></div>
 <pre class="insert"><span class="a">#include &quot;chunk.h&quot;</span>
 </pre><pre class="insert-after">
@@ -751,7 +751,7 @@ interpreter&rsquo;s internal representation of code.</p>
 <p>In jlox, our analogous tool was the <a href="representing-code.html#a-not-very-pretty-printer">AstPrinter class</a>.</p>
 </aside>
 <p>In <code>main()</code>, after we create the chunk, we pass it to the disassembler.</p>
-<div class="codehilite"><pre class="insert-before">  initChunk(&amp;chunk);
+<div class="codehilite" translate="no"><pre class="insert-before">  initChunk(&amp;chunk);
   writeChunk(&amp;chunk, OP_RETURN);
 </pre><div class="source-file"><em>main.c</em><br>
 in <em>main</em>()</div>
@@ -766,7 +766,7 @@ in <em>main</em>()</div>
 <aside name="module">
 <p>I promise you we won&rsquo;t be creating this many new files in later chapters.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">#include &quot;chunk.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;chunk.h&quot;
 </pre><div class="source-file"><em>main.c</em></div>
 <pre class="insert"><span class="a">#include &quot;debug.h&quot;</span>
 </pre><pre class="insert-after">
@@ -776,7 +776,7 @@ int main(int argc, const char* argv[]) {
 <div class="source-file-narrow"><em>main.c</em></div>
 
 <p>Here&rsquo;s that header:</p>
-<div class="codehilite"><div class="source-file"><em>debug.h</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>debug.h</em><br>
 create new file</div>
 <pre><span class="a">#ifndef clox_debug_h</span>
 <span class="a">#define clox_debug_h</span>
@@ -795,7 +795,7 @@ in the entire chunk. That&rsquo;s implemented in terms of the other function, wh
 just disassembles a single instruction. It shows up here in the header because
 we&rsquo;ll call it from the VM in later chapters.</p>
 <p>Here&rsquo;s a start at the implementation file:</p>
-<div class="codehilite"><div class="source-file"><em>debug.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>debug.c</em><br>
 create new file</div>
 <pre><span class="a">#include &lt;stdio.h&gt;</span>
 
@@ -819,7 +819,7 @@ us. When we call that function, after disassembling the instruction at the given
 offset, it returns the offset of the <em>next</em> instruction. This is because, as
 we&rsquo;ll see later, instructions can have different sizes.</p>
 <p>The core of the &ldquo;debug&rdquo; module is this function:</p>
-<div class="codehilite"><div class="source-file"><em>debug.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>debug.c</em><br>
 add after <em>disassembleChunk</em>()</div>
 <pre><span class="t">int</span> <span class="i">disassembleInstruction</span>(<span class="t">Chunk</span>* <span class="i">chunk</span>, <span class="t">int</span> <span class="i">offset</span>) {
   <span class="i">printf</span>(<span class="s">&quot;%04d &quot;</span>, <span class="i">offset</span>);
@@ -849,7 +849,7 @@ in our compiler<span class="em">&mdash;</span>we print that too. For the one ins
 <p>We have only one instruction right now, but this switch will grow throughout the
 rest of the book.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>debug.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>debug.c</em><br>
 add after <em>disassembleChunk</em>()</div>
 <pre><span class="k">static</span> <span class="t">int</span> <span class="i">simpleInstruction</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">name</span>, <span class="t">int</span> <span class="i">offset</span>) {
   <span class="i">printf</span>(<span class="s">&quot;%s</span><span class="e">\n</span><span class="s">&quot;</span>, <span class="i">name</span>);
@@ -862,7 +862,7 @@ add after <em>disassembleChunk</em>()</div>
 the opcode, then return the next byte offset past this instruction. Other
 instructions will have more going on.</p>
 <p>If we run our nascent interpreter now, it actually prints something:</p>
-<div class="codehilite"><pre>== test chunk ==
+<div class="codehilite" translate="no"><pre>== test chunk ==
 0000 OP_RETURN
 </pre></div>
 <p>It worked! This is sort of the &ldquo;Hello, world!&rdquo; of our code representation. We
@@ -873,7 +873,7 @@ working.</p>
 <p>Now that we have a rudimentary chunk structure working, let&rsquo;s start making it
 more useful. We can store <em>code</em> in chunks, but what about <em>data</em>? Many values
 the interpreter works with are created at runtime as the result of operations.</p>
-<div class="codehilite"><pre><span class="n">1</span> + <span class="n">2</span>;
+<div class="codehilite" translate="no"><pre><span class="n">1</span> + <span class="n">2</span>;
 </pre></div>
 <p>The value 3 appears nowhere in the code here. However, the literals <code>1</code> and <code>2</code>
 do. To compile that statement to bytecode, we need some sort of instruction that
@@ -887,7 +887,7 @@ thinking at least a little bit about how our VM should represent values.</p>
 <p>For now, we&rsquo;re going to start as simple as possible<span class="em">&mdash;</span>we&rsquo;ll support only
 double-precision, floating-point numbers. This will obviously expand over time,
 so we&rsquo;ll set up a new module to give ourselves room to grow.</p>
-<div class="codehilite"><div class="source-file"><em>value.h</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>value.h</em><br>
 create new file</div>
 <pre><span class="a">#ifndef clox_value_h</span>
 <span class="a">#define clox_value_h</span>
@@ -937,7 +937,7 @@ array of a different type is a chore. We could cobble together some preprocessor
 macros to fake generics, but that&rsquo;s overkill for clox. We won&rsquo;t need many more
 of these.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">typedef double Value;
+<div class="codehilite" translate="no"><pre class="insert-before">typedef double Value;
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert">
 
@@ -955,7 +955,7 @@ of these.</p>
 <p>As with the bytecode array in Chunk, this struct wraps a pointer to an array
 along with its allocated capacity and the number of elements in use. We also
 need the same three functions to work with value arrays.</p>
-<div class="codehilite"><pre class="insert-before">} ValueArray;
+<div class="codehilite" translate="no"><pre class="insert-before">} ValueArray;
 </pre><div class="source-file"><em>value.h</em><br>
 add after struct <em>ValueArray</em></div>
 <pre class="insert">
@@ -970,7 +970,7 @@ add after struct <em>ValueArray</em></div>
 <div class="source-file-narrow"><em>value.h</em>, add after struct <em>ValueArray</em></div>
 
 <p>The implementations will probably give you déjà vu. First, to create a new one:</p>
-<div class="codehilite"><div class="source-file"><em>value.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>value.c</em><br>
 create new file</div>
 <pre><span class="a">#include &lt;stdio.h&gt;</span>
 
@@ -990,7 +990,7 @@ values to it.</p>
 <aside name="add">
 <p>Fortunately, we don&rsquo;t need other operations like insertion and removal.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>value.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>value.c</em><br>
 add after <em>initValueArray</em>()</div>
 <pre><span class="t">void</span> <span class="i">writeValueArray</span>(<span class="t">ValueArray</span>* <span class="i">array</span>, <span class="t">Value</span> <span class="i">value</span>) {
   <span class="k">if</span> (<span class="i">array</span>-&gt;<span class="i">capacity</span> &lt; <span class="i">array</span>-&gt;<span class="i">count</span> + <span class="n">1</span>) {
@@ -1009,7 +1009,7 @@ add after <em>initValueArray</em>()</div>
 <p>The memory-management macros we wrote earlier do let us reuse some of the logic
 from the code array, so this isn&rsquo;t too bad. Finally, to release all memory used
 by the array:</p>
-<div class="codehilite"><div class="source-file"><em>value.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>value.c</em><br>
 add after <em>writeValueArray</em>()</div>
 <pre><span class="t">void</span> <span class="i">freeValueArray</span>(<span class="t">ValueArray</span>* <span class="i">array</span>) {
   <span class="a">FREE_ARRAY</span>(<span class="t">Value</span>, <span class="i">array</span>-&gt;<span class="i">values</span>, <span class="i">array</span>-&gt;<span class="i">capacity</span>);
@@ -1020,7 +1020,7 @@ add after <em>writeValueArray</em>()</div>
 
 <p>Now that we have growable arrays of values, we can add one to Chunk to store the
 chunk&rsquo;s constants.</p>
-<div class="codehilite"><pre class="insert-before">  uint8_t* code;
+<div class="codehilite" translate="no"><pre class="insert-before">  uint8_t* code;
 </pre><div class="source-file"><em>chunk.h</em><br>
 in struct <em>Chunk</em></div>
 <pre class="insert">  <span class="t">ValueArray</span> <span class="i">constants</span>;
@@ -1029,7 +1029,7 @@ in struct <em>Chunk</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in struct <em>Chunk</em></div>
 
 <p>Don&rsquo;t forget the include.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;common.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;common.h&quot;
 </pre><div class="source-file"><em>chunk.h</em></div>
 <pre class="insert"><span class="a">#include &quot;value.h&quot;</span>
 </pre><pre class="insert-after">
@@ -1040,7 +1040,7 @@ typedef enum {
 
 <p>Ah, C, and its Stone Age modularity story. Where were we? Right. When we
 initialize a new chunk, we initialize its constant list too.</p>
-<div class="codehilite"><pre class="insert-before">  chunk-&gt;code = NULL;
+<div class="codehilite" translate="no"><pre class="insert-before">  chunk-&gt;code = NULL;
 </pre><div class="source-file"><em>chunk.c</em><br>
 in <em>initChunk</em>()</div>
 <pre class="insert">  <span class="i">initValueArray</span>(&amp;<span class="i">chunk</span>-&gt;<span class="i">constants</span>);
@@ -1049,7 +1049,7 @@ in <em>initChunk</em>()</div>
 <div class="source-file-narrow"><em>chunk.c</em>, in <em>initChunk</em>()</div>
 
 <p>Likewise, we free the constants when we free the chunk.</p>
-<div class="codehilite"><pre class="insert-before">  FREE_ARRAY(uint8_t, chunk-&gt;code, chunk-&gt;capacity);
+<div class="codehilite" translate="no"><pre class="insert-before">  FREE_ARRAY(uint8_t, chunk-&gt;code, chunk-&gt;capacity);
 </pre><div class="source-file"><em>chunk.c</em><br>
 in <em>freeChunk</em>()</div>
 <pre class="insert">  <span class="i">freeValueArray</span>(&amp;<span class="i">chunk</span>-&gt;<span class="i">constants</span>);
@@ -1061,7 +1061,7 @@ in <em>freeChunk</em>()</div>
 yet-to-be-written compiler could write to the constant array inside Chunk
 directly<span class="em">&mdash;</span>it&rsquo;s not like C has private fields or anything<span class="em">&mdash;</span>but it&rsquo;s a little
 nicer to add an explicit function.</p>
-<div class="codehilite"><pre class="insert-before">void writeChunk(Chunk* chunk, uint8_t byte);
+<div class="codehilite" translate="no"><pre class="insert-before">void writeChunk(Chunk* chunk, uint8_t byte);
 </pre><div class="source-file"><em>chunk.h</em><br>
 add after <em>writeChunk</em>()</div>
 <pre class="insert"><span class="t">int</span> <span class="i">addConstant</span>(<span class="t">Chunk</span>* <span class="i">chunk</span>, <span class="t">Value</span> <span class="i">value</span>);
@@ -1072,7 +1072,7 @@ add after <em>writeChunk</em>()</div>
 <div class="source-file-narrow"><em>chunk.h</em>, add after <em>writeChunk</em>()</div>
 
 <p>Then we implement it.</p>
-<div class="codehilite"><div class="source-file"><em>chunk.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>chunk.c</em><br>
 add after <em>writeChunk</em>()</div>
 <pre><span class="t">int</span> <span class="i">addConstant</span>(<span class="t">Chunk</span>* <span class="i">chunk</span>, <span class="t">Value</span> <span class="i">value</span>) {
   <span class="i">writeValueArray</span>(&amp;<span class="i">chunk</span>-&gt;<span class="i">constants</span>, <span class="i">value</span>);
@@ -1086,13 +1086,13 @@ so that we can locate that same constant later.</p>
 <h3><a href="#constant-instructions" id="constant-instructions"><small>14&#8202;.&#8202;5&#8202;.&#8202;3</small>Constant instructions</a></h3>
 <p>We can <em>store</em> constants in chunks, but we also need to <em>execute</em> them. In a
 piece of code like:</p>
-<div class="codehilite"><pre><span class="k">print</span> <span class="n">1</span>;
+<div class="codehilite" translate="no"><pre><span class="k">print</span> <span class="n">1</span>;
 <span class="k">print</span> <span class="n">2</span>;
 </pre></div>
 <p>The compiled chunk needs to not only contain the values 1 and 2, but know <em>when</em>
 to produce them so that they are printed in the right order. Thus, we need an
 instruction that produces a particular constant.</p>
-<div class="codehilite"><pre class="insert-before">typedef enum {
+<div class="codehilite" translate="no"><pre class="insert-before">typedef enum {
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_CONSTANT</span>,
@@ -1130,7 +1130,7 @@ notion that modify how the bytecode instruction itself behaves.</p>
 <p>In this case, <code>OP_CONSTANT</code> takes a single byte operand that specifies which
 constant to load from the chunk&rsquo;s constant array. Since we don&rsquo;t have a compiler
 yet, we &ldquo;hand-compile&rdquo; an instruction in our test chunk.</p>
-<div class="codehilite"><pre class="insert-before">  initChunk(&amp;chunk);
+<div class="codehilite" translate="no"><pre class="insert-before">  initChunk(&amp;chunk);
 </pre><div class="source-file"><em>main.c</em><br>
 in <em>main</em>()</div>
 <pre class="insert">
@@ -1150,7 +1150,7 @@ operand. Note that <code>writeChunk()</code> can write opcodes or operands. It&r
 bytes as far as that function is concerned.</p>
 <p>If we try to run this now, the disassembler is going to yell at us because it
 doesn&rsquo;t know how to decode the new instruction. Let&rsquo;s fix that.</p>
-<div class="codehilite"><pre class="insert-before">  switch (instruction) {
+<div class="codehilite" translate="no"><pre class="insert-before">  switch (instruction) {
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OP_CONSTANT</span>:
@@ -1161,7 +1161,7 @@ in <em>disassembleInstruction</em>()</div>
 
 <p>This instruction has a different instruction format, so we write a new helper
 function to disassemble it.</p>
-<div class="codehilite"><div class="source-file"><em>debug.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>debug.c</em><br>
 add after <em>disassembleChunk</em>()</div>
 <pre><span class="k">static</span> <span class="t">int</span> <span class="i">constantInstruction</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">name</span>, <span class="t">Chunk</span>* <span class="i">chunk</span>,
                                <span class="t">int</span> <span class="i">offset</span>) {
@@ -1180,7 +1180,7 @@ we also look up the actual constant value<span class="em">&mdash;</span>since co
 compile time after all<span class="em">&mdash;</span>and display the value itself too.</p>
 <p>This requires some way to print a clox Value. That function will live in the
 &ldquo;value&rdquo; module, so we include that.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;debug.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;debug.h&quot;
 </pre><div class="source-file"><em>debug.c</em></div>
 <pre class="insert"><span class="a">#include &quot;value.h&quot;</span>
 </pre><pre class="insert-after">
@@ -1190,7 +1190,7 @@ void disassembleChunk(Chunk* chunk, const char* name) {
 <div class="source-file-narrow"><em>debug.c</em></div>
 
 <p>Over in that header, we declare:</p>
-<div class="codehilite"><pre class="insert-before">void freeValueArray(ValueArray* array);
+<div class="codehilite" translate="no"><pre class="insert-before">void freeValueArray(ValueArray* array);
 </pre><div class="source-file"><em>value.h</em><br>
 add after <em>freeValueArray</em>()</div>
 <pre class="insert"><span class="t">void</span> <span class="i">printValue</span>(<span class="t">Value</span> <span class="i">value</span>);
@@ -1201,7 +1201,7 @@ add after <em>freeValueArray</em>()</div>
 <div class="source-file-narrow"><em>value.h</em>, add after <em>freeValueArray</em>()</div>
 
 <p>And here&rsquo;s an implementation:</p>
-<div class="codehilite"><div class="source-file"><em>value.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>value.c</em><br>
 add after <em>freeValueArray</em>()</div>
 <pre><span class="t">void</span> <span class="i">printValue</span>(<span class="t">Value</span> <span class="i">value</span>) {
   <span class="i">printf</span>(<span class="s">&quot;%g&quot;</span>, <span class="i">value</span>);
@@ -1212,7 +1212,7 @@ add after <em>freeValueArray</em>()</div>
 <p>Magnificent, right? As you can imagine, this is going to get more complex once
 we add dynamic typing to Lox and have values of different types.</p>
 <p>Back in <code>constantInstruction()</code>, the only remaining piece is the return value.</p>
-<div class="codehilite"><pre class="insert-before">  printf(&quot;'\n&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">  printf(&quot;'\n&quot;);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>constantInstruction</em>()</div>
 <pre class="insert">  <span class="k">return</span> <span class="i">offset</span> + <span class="n">2</span>;
@@ -1252,7 +1252,7 @@ more cache misses as the interpreter skips past it to get to the opcodes and
 operands it cares about.</p>
 </aside>
 <p>To implement this, we add another array to Chunk.</p>
-<div class="codehilite"><pre class="insert-before">  uint8_t* code;
+<div class="codehilite" translate="no"><pre class="insert-before">  uint8_t* code;
 </pre><div class="source-file"><em>chunk.h</em><br>
 in struct <em>Chunk</em></div>
 <pre class="insert">  <span class="t">int</span>* <span class="i">lines</span>;
@@ -1263,7 +1263,7 @@ in struct <em>Chunk</em></div>
 <p>Since it exactly parallels the bytecode array, we don&rsquo;t need a separate count or
 capacity. Every time we touch the code array, we make a corresponding change to
 the line number array, starting with initialization.</p>
-<div class="codehilite"><pre class="insert-before">  chunk-&gt;code = NULL;
+<div class="codehilite" translate="no"><pre class="insert-before">  chunk-&gt;code = NULL;
 </pre><div class="source-file"><em>chunk.c</em><br>
 in <em>initChunk</em>()</div>
 <pre class="insert">  <span class="i">chunk</span>-&gt;<span class="i">lines</span> = <span class="a">NULL</span>;
@@ -1272,7 +1272,7 @@ in <em>initChunk</em>()</div>
 <div class="source-file-narrow"><em>chunk.c</em>, in <em>initChunk</em>()</div>
 
 <p>And likewise deallocation:</p>
-<div class="codehilite"><pre class="insert-before">  FREE_ARRAY(uint8_t, chunk-&gt;code, chunk-&gt;capacity);
+<div class="codehilite" translate="no"><pre class="insert-before">  FREE_ARRAY(uint8_t, chunk-&gt;code, chunk-&gt;capacity);
 </pre><div class="source-file"><em>chunk.c</em><br>
 in <em>freeChunk</em>()</div>
 <pre class="insert">  <span class="a">FREE_ARRAY</span>(<span class="t">int</span>, <span class="i">chunk</span>-&gt;<span class="i">lines</span>, <span class="i">chunk</span>-&gt;<span class="i">capacity</span>);
@@ -1282,7 +1282,7 @@ in <em>freeChunk</em>()</div>
 
 <p>When we write a byte of code to the chunk, we need to know what source line it
 came from, so we add an extra parameter in the declaration of <code>writeChunk()</code>.</p>
-<div class="codehilite"><pre class="insert-before">void freeChunk(Chunk* chunk);
+<div class="codehilite" translate="no"><pre class="insert-before">void freeChunk(Chunk* chunk);
 </pre><div class="source-file"><em>chunk.h</em><br>
 function <em>writeChunk</em>()<br>
 replace 1 line</div>
@@ -1292,7 +1292,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>chunk.h</em>, function <em>writeChunk</em>(), replace 1 line</div>
 
 <p>And in the implementation:</p>
-<div class="codehilite"><div class="source-file"><em>chunk.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>chunk.c</em><br>
 function <em>writeChunk</em>()<br>
 replace 1 line</div>
 <pre class="insert"><span class="t">void</span> <span class="i">writeChunk</span>(<span class="t">Chunk</span>* <span class="i">chunk</span>, <span class="t">uint8_t</span> <span class="i">byte</span>, <span class="t">int</span> <span class="i">line</span>) {
@@ -1301,7 +1301,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>chunk.c</em>, function <em>writeChunk</em>(), replace 1 line</div>
 
 <p>When we allocate or grow the code array, we do the same for the line info too.</p>
-<div class="codehilite"><pre class="insert-before">    chunk-&gt;code = GROW_ARRAY(uint8_t, chunk-&gt;code,
+<div class="codehilite" translate="no"><pre class="insert-before">    chunk-&gt;code = GROW_ARRAY(uint8_t, chunk-&gt;code,
         oldCapacity, chunk-&gt;capacity);
 </pre><div class="source-file"><em>chunk.c</em><br>
 in <em>writeChunk</em>()</div>
@@ -1312,7 +1312,7 @@ in <em>writeChunk</em>()</div>
 <div class="source-file-narrow"><em>chunk.c</em>, in <em>writeChunk</em>()</div>
 
 <p>Finally, we store the line number in the array.</p>
-<div class="codehilite"><pre class="insert-before">  chunk-&gt;code[chunk-&gt;count] = byte;
+<div class="codehilite" translate="no"><pre class="insert-before">  chunk-&gt;code[chunk-&gt;count] = byte;
 </pre><div class="source-file"><em>chunk.c</em><br>
 in <em>writeChunk</em>()</div>
 <pre class="insert">  <span class="i">chunk</span>-&gt;<span class="i">lines</span>[<span class="i">chunk</span>-&gt;<span class="i">count</span>] = <span class="i">line</span>;
@@ -1324,7 +1324,7 @@ in <em>writeChunk</em>()</div>
 <p>Alright, let&rsquo;s try this out with our little, uh, artisanal chunk. First, since
 we added a new parameter to <code>writeChunk()</code>, we need to fix those calls to pass
 in some<span class="em">&mdash;</span>arbitrary at this point<span class="em">&mdash;</span>line number.</p>
-<div class="codehilite"><pre class="insert-before">  int constant = addConstant(&amp;chunk, 1.2);
+<div class="codehilite" translate="no"><pre class="insert-before">  int constant = addConstant(&amp;chunk, 1.2);
 </pre><div class="source-file"><em>main.c</em><br>
 in <em>main</em>()<br>
 replace 4 lines</div>
@@ -1346,7 +1346,7 @@ instruction was compiled from. That gives us a way to map back to the original
 code when we&rsquo;re trying to figure out what some blob of bytecode is supposed to
 do. After printing the offset of the instruction<span class="em">&mdash;</span>the number of bytes from the
 beginning of the chunk<span class="em">&mdash;</span>we show its source line.</p>
-<div class="codehilite"><pre class="insert-before">int disassembleInstruction(Chunk* chunk, int offset) {
+<div class="codehilite" translate="no"><pre class="insert-before">int disassembleInstruction(Chunk* chunk, int offset) {
   printf(&quot;%04d &quot;, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
@@ -1367,7 +1367,7 @@ code often compiles to a whole sequence of instructions. To make that more
 visually clear, we show a <code>|</code> for any instruction that comes from the same
 source line as the preceding one. The resulting output for our handwritten
 chunk looks like:</p>
-<div class="codehilite"><pre>== test chunk ==
+<div class="codehilite" translate="no"><pre>== test chunk ==
 0000  123 OP_CONSTANT         0 '1.2'
 0002    | OP_RETURN
 </pre></div>
@@ -1416,7 +1416,7 @@ sizes. Leave our existing one-byte <code>OP_CONSTANT</code> instruction alone, a
 define a second <code>OP_CONSTANT_LONG</code> instruction. It stores the operand as a
 24-bit number, which should be plenty.</p>
 <p>Implement this function:</p>
-<div class="codehilite"><pre><span class="t">void</span> <span class="i">writeConstant</span>(<span class="t">Chunk</span>* <span class="i">chunk</span>, <span class="t">Value</span> <span class="i">value</span>, <span class="t">int</span> <span class="i">line</span>) {
+<div class="codehilite" translate="no"><pre><span class="t">void</span> <span class="i">writeConstant</span>(<span class="t">Chunk</span>* <span class="i">chunk</span>, <span class="t">Value</span> <span class="i">value</span>, <span class="t">int</span> <span class="i">line</span>) {
   <span class="c">// Implement me...</span>
 }
 </pre></div>

--- a/site/classes-and-instances.html
+++ b/site/classes-and-instances.html
@@ -125,7 +125,7 @@ produce new instances. Going bottom-up, we&rsquo;ll start with their runtime
 representation and then hook that into the language.</p>
 <p>By this point, we&rsquo;re well-acquainted with the process of adding a new object
 type to the VM. We start with a struct.</p>
-<div class="codehilite"><pre class="insert-before">} ObjClosure;
+<div class="codehilite" translate="no"><pre class="insert-before">} ObjClosure;
 </pre><div class="source-file"><em>object.h</em><br>
 add after struct <em>ObjClosure</em></div>
 <pre class="insert">
@@ -144,7 +144,7 @@ ObjClosure* newClosure(ObjFunction* function);
 the user&rsquo;s program, but it lets us show the name at runtime for things like
 stack traces.</p>
 <p>The new type needs a corresponding case in the ObjType enum.</p>
-<div class="codehilite"><pre class="insert-before">typedef enum {
+<div class="codehilite" translate="no"><pre class="insert-before">typedef enum {
 </pre><div class="source-file"><em>object.h</em><br>
 in enum <em>ObjType</em></div>
 <pre class="insert">  <span class="a">OBJ_CLASS</span>,
@@ -154,7 +154,7 @@ in enum <em>ObjType</em></div>
 
 <p>And that type gets a corresponding pair of macros. First, for testing an
 object&rsquo;s type:</p>
-<div class="codehilite"><pre class="insert-before">#define OBJ_TYPE(value)        (AS_OBJ(value)-&gt;type)
+<div class="codehilite" translate="no"><pre class="insert-before">#define OBJ_TYPE(value)        (AS_OBJ(value)-&gt;type)
 
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert"><span class="a">#define IS_CLASS(value)        isObjType(value, OBJ_CLASS)</span>
@@ -163,7 +163,7 @@ object&rsquo;s type:</p>
 <div class="source-file-narrow"><em>object.h</em></div>
 
 <p>And then for casting a Value to an ObjClass pointer:</p>
-<div class="codehilite"><pre class="insert-before">#define IS_STRING(value)       isObjType(value, OBJ_STRING)
+<div class="codehilite" translate="no"><pre class="insert-before">#define IS_STRING(value)       isObjType(value, OBJ_STRING)
 
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert"><span class="a">#define AS_CLASS(value)        ((ObjClass*)AS_OBJ(value))</span>
@@ -172,7 +172,7 @@ object&rsquo;s type:</p>
 <div class="source-file-narrow"><em>object.h</em></div>
 
 <p>The VM creates new class objects using this function:</p>
-<div class="codehilite"><pre class="insert-before">} ObjClass;
+<div class="codehilite" translate="no"><pre class="insert-before">} ObjClass;
 
 </pre><div class="source-file"><em>object.h</em><br>
 add after struct <em>ObjClass</em></div>
@@ -182,7 +182,7 @@ add after struct <em>ObjClass</em></div>
 <div class="source-file-narrow"><em>object.h</em>, add after struct <em>ObjClass</em></div>
 
 <p>The implementation lives over here:</p>
-<div class="codehilite"><div class="source-file"><em>object.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.c</em><br>
 add after <em>allocateObject</em>()</div>
 <pre><span class="t">ObjClass</span>* <span class="i">newClass</span>(<span class="t">ObjString</span>* <span class="i">name</span>) {
   <span class="t">ObjClass</span>* <span class="i">klass</span> = <span class="a">ALLOCATE_OBJ</span>(<span class="t">ObjClass</span>, <span class="a">OBJ_CLASS</span>);
@@ -201,7 +201,7 @@ Korner&rdquo; feel. It makes it easier to get clox compiling as C++ where &ldquo
 a reserved word.</p>
 </aside>
 <p>When the VM no longer needs a class, it frees it like so:</p>
-<div class="codehilite"><pre class="insert-before">  switch (object-&gt;type) {
+<div class="codehilite" translate="no"><pre class="insert-before">  switch (object-&gt;type) {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>freeObject</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OBJ_CLASS</span>: {
@@ -218,7 +218,7 @@ we add some more code to the switch case.</p>
 </aside>
 <p>We have a memory manager now, so we also need to support tracing through class
 objects.</p>
-<div class="codehilite"><pre class="insert-before">  switch (object-&gt;type) {
+<div class="codehilite" translate="no"><pre class="insert-before">  switch (object-&gt;type) {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>blackenObject</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OBJ_CLASS</span>: {
@@ -233,7 +233,7 @@ in <em>blackenObject</em>()</div>
 <p>When the GC reaches a class object, it marks the class&rsquo;s name to keep that
 string alive too.</p>
 <p>The last operation the VM can perform on a class is printing it.</p>
-<div class="codehilite"><pre class="insert-before">  switch (OBJ_TYPE(value)) {
+<div class="codehilite" translate="no"><pre class="insert-before">  switch (OBJ_TYPE(value)) {
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>printObject</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OBJ_CLASS</span>:
@@ -247,7 +247,7 @@ in <em>printObject</em>()</div>
 <h2><a href="#class-declarations" id="class-declarations"><small>27&#8202;.&#8202;2</small>Class Declarations</a></h2>
 <p>Runtime representation in hand, we are ready to add support for classes to the
 language. Next, we move into the parser.</p>
-<div class="codehilite"><pre class="insert-before">static void declaration() {
+<div class="codehilite" translate="no"><pre class="insert-before">static void declaration() {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>declaration</em>()<br>
 replace 1 line</div>
@@ -260,7 +260,7 @@ replace 1 line</div>
 
 <p>Class declarations are statements, and the parser recognizes one by the leading
 <code>class</code> keyword. The rest of the compilation happens over here:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>function</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">classDeclaration</span>() {
   <span class="i">consume</span>(<span class="a">TOKEN_IDENTIFIER</span>, <span class="s">&quot;Expect class name.&quot;</span>);
@@ -287,7 +287,7 @@ identifier right after consuming its token.</p>
 <aside name="variable">
 <p>We could have made class declarations be <em>expressions</em> instead of statements<span class="em">&mdash;</span>they are essentially a literal that produces a value after all. Then users would
 have to explicitly bind the class to a variable themselves like:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="t">Pie</span> = <span class="k">class</span> {}
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="t">Pie</span> = <span class="k">class</span> {}
 </pre></div>
 <p>Sort of like lambda functions but for classes. But since we generally want
 classes to be named anyway, it makes sense to treat them as declarations.</p>
@@ -305,7 +305,7 @@ useful for things like factory methods that produce new instances of the class.<
 simply an empty pair of braces. Lox doesn&rsquo;t require fields to be declared in the
 class, so we&rsquo;re done with the body<span class="em">&mdash;</span>and the parser<span class="em">&mdash;</span>for now.</p>
 <p>The compiler is emitting a new instruction, so let&rsquo;s define that.</p>
-<div class="codehilite"><pre class="insert-before">  OP_RETURN,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_RETURN,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_CLASS</span>,
@@ -314,7 +314,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>And add it to the disassembler:</p>
-<div class="codehilite"><pre class="insert-before">    case OP_RETURN:
+<div class="codehilite" translate="no"><pre class="insert-before">    case OP_RETURN:
       return simpleInstruction(&quot;OP_RETURN&quot;, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
@@ -325,7 +325,7 @@ in <em>disassembleInstruction</em>()</div>
 <div class="source-file-narrow"><em>debug.c</em>, in <em>disassembleInstruction</em>()</div>
 
 <p>For such a large-seeming feature, the interpreter support is minimal.</p>
-<div class="codehilite"><pre class="insert-before">        break;
+<div class="codehilite" translate="no"><pre class="insert-before">        break;
       }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
@@ -351,7 +351,7 @@ declaration, and since you can declare variables and functions inside blocks,
 you can declare classes in there too.</p>
 </aside>
 <p>There you have it, our VM supports classes now. You can run this:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Brioche</span> {}
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Brioche</span> {}
 <span class="k">print</span> <span class="t">Brioche</span>;
 </pre></div>
 <p>Unfortunately, printing is about <em>all</em> you can do with classes, so next is
@@ -372,7 +372,7 @@ behave.</p>
 <p>We won&rsquo;t get to methods until the next chapter, so for now we will only worry
 about the first part. Before classes can create instances, we need a
 representation for them.</p>
-<div class="codehilite"><pre class="insert-before">} ObjClass;
+<div class="codehilite" translate="no"><pre class="insert-before">} ObjClass;
 </pre><div class="source-file"><em>object.h</em><br>
 add after struct <em>ObjClass</em></div>
 <pre class="insert">
@@ -409,7 +409,7 @@ lookup. Constant time, but still pretty heavyweight. In a language like C++,
 accessing a field is as fast as offsetting a pointer by an integer constant.</p>
 </aside>
 <p>We only need to add an include, and we&rsquo;ve got it.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;chunk.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;chunk.h&quot;
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert"><span class="a">#include &quot;table.h&quot;</span>
 </pre><pre class="insert-after">#include &quot;value.h&quot;
@@ -417,7 +417,7 @@ accessing a field is as fast as offsetting a pointer by an integer constant.</p>
 <div class="source-file-narrow"><em>object.h</em></div>
 
 <p>This new struct gets a new object type.</p>
-<div class="codehilite"><pre class="insert-before">  OBJ_FUNCTION,
+<div class="codehilite" translate="no"><pre class="insert-before">  OBJ_FUNCTION,
 </pre><div class="source-file"><em>object.h</em><br>
 in enum <em>ObjType</em></div>
 <pre class="insert">  <span class="a">OBJ_INSTANCE</span>,
@@ -437,7 +437,7 @@ of type ObjClass. Likewise, each instance in the user&rsquo;s program, no matter
 class it is an instance of, is an ObjInstance. That one VM object type covers
 instances of all classes. The two worlds map to each other something like this:</p><img src="image/classes-and-instances/lox-clox.png" alt="A set of class declarations and instances, and the runtime representations each maps to."/>
 <p>Got it? OK, back to the implementation. We also get our usual macros.</p>
-<div class="codehilite"><pre class="insert-before">#define IS_FUNCTION(value)     isObjType(value, OBJ_FUNCTION)
+<div class="codehilite" translate="no"><pre class="insert-before">#define IS_FUNCTION(value)     isObjType(value, OBJ_FUNCTION)
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert"><span class="a">#define IS_INSTANCE(value)     isObjType(value, OBJ_INSTANCE)</span>
 </pre><pre class="insert-after">#define IS_NATIVE(value)       isObjType(value, OBJ_NATIVE)
@@ -445,7 +445,7 @@ instances of all classes. The two worlds map to each other something like this:<
 <div class="source-file-narrow"><em>object.h</em></div>
 
 <p>And:</p>
-<div class="codehilite"><pre class="insert-before">#define AS_FUNCTION(value)     ((ObjFunction*)AS_OBJ(value))
+<div class="codehilite" translate="no"><pre class="insert-before">#define AS_FUNCTION(value)     ((ObjFunction*)AS_OBJ(value))
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert"><span class="a">#define AS_INSTANCE(value)     ((ObjInstance*)AS_OBJ(value))</span>
 </pre><pre class="insert-after">#define AS_NATIVE(value) \
@@ -454,7 +454,7 @@ instances of all classes. The two worlds map to each other something like this:<
 
 <p>Since fields are added after the instance is created, the &ldquo;constructor&rdquo; function
 only needs to know the class.</p>
-<div class="codehilite"><pre class="insert-before">ObjFunction* newFunction();
+<div class="codehilite" translate="no"><pre class="insert-before">ObjFunction* newFunction();
 </pre><div class="source-file"><em>object.h</em><br>
 add after <em>newFunction</em>()</div>
 <pre class="insert"><span class="t">ObjInstance</span>* <span class="i">newInstance</span>(<span class="t">ObjClass</span>* <span class="i">klass</span>);
@@ -463,7 +463,7 @@ add after <em>newFunction</em>()</div>
 <div class="source-file-narrow"><em>object.h</em>, add after <em>newFunction</em>()</div>
 
 <p>We implement that function here:</p>
-<div class="codehilite"><div class="source-file"><em>object.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.c</em><br>
 add after <em>newFunction</em>()</div>
 <pre><span class="t">ObjInstance</span>* <span class="i">newInstance</span>(<span class="t">ObjClass</span>* <span class="i">klass</span>) {
   <span class="t">ObjInstance</span>* <span class="i">instance</span> = <span class="a">ALLOCATE_OBJ</span>(<span class="t">ObjInstance</span>, <span class="a">OBJ_INSTANCE</span>);
@@ -477,7 +477,7 @@ add after <em>newFunction</em>()</div>
 <p>We store a reference to the instance&rsquo;s class. Then we initialize the field
 table to an empty hash table. A new baby object is born!</p>
 <p>At the sadder end of the instance&rsquo;s lifespan, it gets freed.</p>
-<div class="codehilite"><pre class="insert-before">      FREE(ObjFunction, object);
+<div class="codehilite" translate="no"><pre class="insert-before">      FREE(ObjFunction, object);
       break;
     }
 </pre><div class="source-file"><em>memory.c</em><br>
@@ -498,7 +498,7 @@ be other references to those objects. The garbage collector will take care of
 those for us. Here we free only the entry array of the table itself.</p>
 <p>Speaking of the garbage collector, it needs support for tracing through
 instances.</p>
-<div class="codehilite"><pre class="insert-before">      markArray(&amp;function-&gt;chunk.constants);
+<div class="codehilite" translate="no"><pre class="insert-before">      markArray(&amp;function-&gt;chunk.constants);
       break;
     }
 </pre><div class="source-file"><em>memory.c</em><br>
@@ -519,7 +519,7 @@ are not roots are reachable because some instance refers to the object in a
 field. Fortunately, we already have a nice <code>markTable()</code> function to make
 tracing them easy.</p>
 <p>Less critical but still important is printing.</p>
-<div class="codehilite"><pre class="insert-before">      break;
+<div class="codehilite" translate="no"><pre class="insert-before">      break;
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>printObject</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OBJ_INSTANCE</span>:
@@ -545,7 +545,7 @@ were a function. The runtime already supports function calls, and it checks the
 type of object being called to make sure the user doesn&rsquo;t try to invoke a number
 or other invalid type.</p>
 <p>We extend that runtime checking with a new case.</p>
-<div class="codehilite"><pre class="insert-before">    switch (OBJ_TYPE(callee)) {
+<div class="codehilite" translate="no"><pre class="insert-before">    switch (OBJ_TYPE(callee)) {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>callValue</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OBJ_CLASS</span>: {
@@ -566,7 +566,7 @@ the called class and store the result on the stack.</p>
 the <a href="methods-and-initializers.html">next chapter</a> when we add support for initializers.</p>
 </aside>
 <p>We&rsquo;re one step farther. Now we can define classes and create instances of them.</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Brioche</span> {}
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Brioche</span> {}
 <span class="k">print</span> <span class="t">Brioche</span>();
 </pre></div>
 <p>Note the parentheses after <code>Brioche</code> on the second line now. This prints
@@ -576,7 +576,7 @@ the <a href="methods-and-initializers.html">next chapter</a> when we add support
 remains is exposing that functionality to the user. Fields are accessed and
 modified using get and set expressions. Not one to break with tradition, Lox
 uses the classic &ldquo;dot&rdquo; syntax:</p>
-<div class="codehilite"><pre><span class="i">eclair</span>.<span class="i">filling</span> = <span class="s">&quot;pastry creme&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="i">eclair</span>.<span class="i">filling</span> = <span class="s">&quot;pastry creme&quot;</span>;
 <span class="k">print</span> <span class="i">eclair</span>.<span class="i">filling</span>;
 </pre></div>
 <p>The period<span class="em">&mdash;</span>full stop for my English friends<span class="em">&mdash;</span>works <span
@@ -589,7 +589,7 @@ the parse table as an infix expression.</p>
 but a single identifier whose semantics are handled by the get or set expression
 itself. It&rsquo;s really closer to a postfix expression.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">  [TOKEN_COMMA]         = {NULL,     NULL,   PREC_NONE},
+<div class="codehilite" translate="no"><pre class="insert-before">  [TOKEN_COMMA]         = {NULL,     NULL,   PREC_NONE},
 </pre><div class="source-file"><em>compiler.c</em><br>
 replace 1 line</div>
 <pre class="insert">  [<span class="a">TOKEN_DOT</span>]           = {<span class="a">NULL</span>,     <span class="i">dot</span>,    <span class="a">PREC_CALL</span>},
@@ -600,7 +600,7 @@ replace 1 line</div>
 <p>As in other languages, the <code>.</code> operator binds tightly, with precedence as high
 as the parentheses in a function call. After the parser consumes the dot token,
 it dispatches to a new parse function.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>call</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">dot</span>(<span class="t">bool</span> <span class="i">canAssign</span>) {
   <span class="i">consume</span>(<span class="a">TOKEN_IDENTIFIER</span>, <span class="s">&quot;Expect property name after &#39;.&#39;.&quot;</span>);
@@ -629,13 +629,13 @@ Fields are the subset of properties that are backed by the instance&rsquo;s stat
 function handles. If we see an equals sign after the field name, it must be a
 set expression that is assigning to a field. But we don&rsquo;t <em>always</em> allow an
 equals sign after the field to be compiled. Consider:</p>
-<div class="codehilite"><pre><span class="i">a</span> + <span class="i">b</span>.<span class="i">c</span> = <span class="n">3</span>
+<div class="codehilite" translate="no"><pre><span class="i">a</span> + <span class="i">b</span>.<span class="i">c</span> = <span class="n">3</span>
 </pre></div>
 <p>This is syntactically invalid according to Lox&rsquo;s grammar, which means our Lox
 implementation is obligated to detect and report the error. If <code>dot()</code> silently
 parsed the <code>= 3</code> part, we would incorrectly interpret the code as if the user
 had written:</p>
-<div class="codehilite"><pre><span class="i">a</span> + (<span class="i">b</span>.<span class="i">c</span> = <span class="n">3</span>)
+<div class="codehilite" translate="no"><pre><span class="i">a</span> + (<span class="i">b</span>.<span class="i">c</span> = <span class="n">3</span>)
 </pre></div>
 <p>The problem is that the <code>=</code> side of a set expression has much lower precedence
 than the <code>.</code> part. The parser may call <code>dot()</code> in a context that is too high
@@ -657,7 +657,7 @@ been <code>OP_SET_FIELD</code>, but I thought it looked nicer to be consistent w
 instruction.</p>
 </aside>
 <p>Now is a good time to define these two new instructions.</p>
-<div class="codehilite"><pre class="insert-before">  OP_SET_UPVALUE,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_SET_UPVALUE,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_GET_PROPERTY</span>,
@@ -667,7 +667,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>And add support for disassembling them:</p>
-<div class="codehilite"><pre class="insert-before">      return byteInstruction(&quot;OP_SET_UPVALUE&quot;, chunk, offset);
+<div class="codehilite" translate="no"><pre class="insert-before">      return byteInstruction(&quot;OP_SET_UPVALUE&quot;, chunk, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OP_GET_PROPERTY</span>:
@@ -681,7 +681,7 @@ in <em>disassembleInstruction</em>()</div>
 <h3><a href="#interpreting-getter-and-setter-expressions" id="interpreting-getter-and-setter-expressions"><small>27&#8202;.&#8202;4&#8202;.&#8202;1</small>Interpreting getter and setter expressions</a></h3>
 <p>Sliding over to the runtime, we&rsquo;ll start with get expressions since those are a
 little simpler.</p>
-<div class="codehilite"><pre class="insert-before">      }
+<div class="codehilite" translate="no"><pre class="insert-before">      }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_GET_PROPERTY</span>: {
@@ -706,7 +706,7 @@ field table. If the hash table contains an entry with that name, we pop the
 instance and push the entry&rsquo;s value as the result.</p>
 <p>Of course, the field might not exist. In Lox, we&rsquo;ve defined that to be a runtime
 error. So we add a check for that and abort if it happens.</p>
-<div class="codehilite"><pre class="insert-before">          push(value);
+<div class="codehilite" translate="no"><pre class="insert-before">          push(value);
           break;
         }
 </pre><div class="source-file"><em>vm.c</em><br>
@@ -724,7 +724,7 @@ in <em>run</em>()</div>
 probably noticed. The above code assumes the expression to the left of the dot
 did evaluate to an ObjInstance. But there&rsquo;s nothing preventing a user from
 writing this:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">obj</span> = <span class="s">&quot;not an instance&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">obj</span> = <span class="s">&quot;not an instance&quot;</span>;
 <span class="k">print</span> <span class="i">obj</span>.<span class="i">field</span>;
 </pre></div>
 <p>The user&rsquo;s program is wrong, but the VM still has to handle it with some grace.
@@ -743,7 +743,7 @@ values. If I attach a field to the number <code>3</code>, does the result of <co
 that field as well? If so, how does the implementation track that? If not, are
 those two resulting &ldquo;threes&rdquo; still considered equal?</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">      case OP_GET_PROPERTY: {
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_GET_PROPERTY: {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">        <span class="k">if</span> (!<span class="a">IS_INSTANCE</span>(<span class="i">peek</span>(<span class="n">0</span>))) {
@@ -759,7 +759,7 @@ in <em>run</em>()</div>
 safely exit.</p>
 <p>Of course, get expressions are not very useful when no instances have any
 fields. For that we need setters.</p>
-<div class="codehilite"><pre class="insert-before">        return INTERPRET_RUNTIME_ERROR;
+<div class="codehilite" translate="no"><pre class="insert-before">        return INTERPRET_RUNTIME_ERROR;
       }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
@@ -788,7 +788,7 @@ we need to leave that value on the stack. Here&rsquo;s what I mean:</p>
 <aside name="stack">
 <p>The stack operations go like this:</p><img src="image/classes-and-instances/stack.png" alt="Popping two values and then pushing the first value back on the stack."/>
 </aside>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Toast</span> {}
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Toast</span> {}
 <span class="k">var</span> <span class="i">toast</span> = <span class="t">Toast</span>();
 <span class="k">print</span> <span class="i">toast</span>.<span class="i">jam</span> = <span class="s">&quot;grape&quot;</span>; <span class="c">// Prints &quot;grape&quot;.</span>
 </pre></div>
@@ -796,7 +796,7 @@ we need to leave that value on the stack. Here&rsquo;s what I mean:</p>
 containing the field. A setter implicitly creates the field if needed. We do
 need to handle the user incorrectly trying to store a field on a value that
 isn&rsquo;t an instance.</p>
-<div class="codehilite"><pre class="insert-before">      case OP_SET_PROPERTY: {
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_SET_PROPERTY: {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">        <span class="k">if</span> (!<span class="a">IS_INSTANCE</span>(<span class="i">peek</span>(<span class="n">1</span>))) {
@@ -811,7 +811,7 @@ in <em>run</em>()</div>
 <p>Exactly like with get expressions, we check the value&rsquo;s type and report a
 runtime error if it&rsquo;s invalid. And, with that, the stateful side of Lox&rsquo;s
 support for object-oriented programming is in place. Give it a try:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Pair</span> {}
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Pair</span> {}
 
 <span class="k">var</span> <span class="i">pair</span> = <span class="t">Pair</span>();
 <span class="i">pair</span>.<span class="i">first</span> = <span class="n">1</span>;

--- a/site/classes.html
+++ b/site/classes.html
@@ -165,7 +165,7 @@ together until we have all of the above pieces, so gather your stamina.</p>
 <h2><a href="#class-declarations" id="class-declarations"><small>12&#8202;.&#8202;2</small>Class Declarations</a></h2>
 <p>Like we do, we&rsquo;re gonna start with syntax. A <code>class</code> statement introduces a new
 name, so it lives in the <code>declaration</code> grammar rule.</p>
-<div class="codehilite"><pre><span class="i">declaration</span>    → <span class="i">classDecl</span>
+<div class="codehilite" translate="no"><pre><span class="i">declaration</span>    → <span class="i">classDecl</span>
                | <span class="i">funDecl</span>
                | <span class="i">varDecl</span>
                | <span class="i">statement</span> ;
@@ -174,7 +174,7 @@ name, so it lives in the <code>declaration</code> grammar rule.</p>
 </pre></div>
 <p>The new <code>classDecl</code> rule relies on the <code>function</code> rule we defined
 <a href="functions.html#function-declarations">earlier</a>. To refresh your memory:</p>
-<div class="codehilite"><pre><span class="i">function</span>       → <span class="t">IDENTIFIER</span> <span class="s">&quot;(&quot;</span> <span class="i">parameters</span>? <span class="s">&quot;)&quot;</span> <span class="i">block</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">function</span>       → <span class="t">IDENTIFIER</span> <span class="s">&quot;(&quot;</span> <span class="i">parameters</span>? <span class="s">&quot;)&quot;</span> <span class="i">block</span> ;
 <span class="i">parameters</span>     → <span class="t">IDENTIFIER</span> ( <span class="s">&quot;,&quot;</span> <span class="t">IDENTIFIER</span> )* ;
 </pre></div>
 <p>In plain English, a class declaration is the <code>class</code> keyword, followed by the
@@ -185,7 +185,7 @@ body. Here&rsquo;s an example:</p>
 <aside name="fun">
 <p>Not that I&rsquo;m trying to say methods aren&rsquo;t fun or anything.</p>
 </aside>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Breakfast</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Breakfast</span> {
   <span class="i">cook</span>() {
     <span class="k">print</span> <span class="s">&quot;Eggs a-fryin&#39;!&quot;</span>;
   }
@@ -200,7 +200,7 @@ class declaration. Instances are loose bags of data and you can freely add
 fields to them as you see fit using normal imperative code.</p>
 <p>Over in our AST generator, the <code>classDecl</code> grammar rule gets its own statement
 <span name="class-ast">node</span>.</p>
-<div class="codehilite"><pre class="insert-before">      &quot;Block      : List&lt;Stmt&gt; statements&quot;,
+<div class="codehilite" translate="no"><pre class="insert-before">      &quot;Block      : List&lt;Stmt&gt; statements&quot;,
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Class      : Token name, List&lt;Stmt.Function&gt; methods&quot;</span>,
@@ -217,7 +217,7 @@ declaration AST nodes. That gives us all the bits of state that we need for a
 method: name, parameter list, and body.</p>
 <p>A class can appear anywhere a named declaration is allowed, triggered by the
 leading <code>class</code> keyword.</p>
-<div class="codehilite"><pre class="insert-before">    try {
+<div class="codehilite" translate="no"><pre class="insert-before">    try {
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>declaration</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">match</span>(<span class="i">CLASS</span>)) <span class="k">return</span> <span class="i">classDeclaration</span>();
@@ -226,7 +226,7 @@ in <em>declaration</em>()</div>
 <div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>declaration</em>()</div>
 
 <p>That calls out to:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>declaration</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">classDeclaration</span>() {
     <span class="t">Token</span> <span class="i">name</span> = <span class="i">consume</span>(<span class="i">IDENTIFIER</span>, <span class="s">&quot;Expect class name.&quot;</span>);
@@ -258,7 +258,7 @@ class body.</p>
 <p>We wrap the name and list of methods into a Stmt.Class node and we&rsquo;re done.
 Previously, we would jump straight into the interpreter, but now we need to
 plumb the node through the resolver first.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitClassStmt</span>(<span class="t">Stmt</span>.<span class="t">Class</span> <span class="i">stmt</span>) {
@@ -274,7 +274,7 @@ all we need to do is declare the class using its name. It&rsquo;s not common to
 declare a class as a local variable, but Lox permits it, so we need to handle it
 correctly.</p>
 <p>Now we interpret the class declaration.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitClassStmt</span>(<span class="t">Stmt</span>.<span class="t">Class</span> <span class="i">stmt</span>) {
@@ -293,7 +293,7 @@ store the class object in the variable we previously declared. That two-stage
 variable binding process allows references to the class inside its own methods.</p>
 <p>We will refine it throughout the chapter, but the first draft of LoxClass looks
 like this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxClass.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/LoxClass.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -318,7 +318,7 @@ create new file</div>
 <p>Literally a wrapper around a name. We don&rsquo;t even store the methods yet. Not
 super useful, but it does have a <code>toString()</code> method so we can write a trivial
 script and test that class objects are actually being parsed and executed.</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">DevonshireCream</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">DevonshireCream</span> {
   <span class="i">serveOn</span>() {
     <span class="k">return</span> <span class="s">&quot;Scones&quot;</span>;
   }
@@ -349,13 +349,13 @@ instances of itself. This feels elegant to me, and also spares us the need to
 introduce syntax like <code>new</code>. Therefore, we can skip past the front end straight
 into the runtime.</p>
 <p>Right now, if you try this:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Bagel</span> {}
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Bagel</span> {}
 <span class="t">Bagel</span>();
 </pre></div>
 <p>You get a runtime error. <code>visitCallExpr()</code> checks to see if the called object
 implements <code>LoxCallable</code> and reports an error since LoxClass doesn&rsquo;t. Not <em>yet</em>,
 that is.</p>
-<div class="codehilite"><pre class="insert-before">import java.util.Map;
+<div class="codehilite" translate="no"><pre class="insert-before">import java.util.Map;
 
 </pre><div class="source-file"><em>lox/LoxClass.java</em><br>
 replace 1 line</div>
@@ -365,7 +365,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>lox/LoxClass.java</em>, replace 1 line</div>
 
 <p>Implementing that interface requires two methods.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxClass.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/LoxClass.java</em><br>
 add after <em>toString</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">call</span>(<span class="t">Interpreter</span> <span class="i">interpreter</span>,
@@ -388,7 +388,7 @@ callable. For now, we&rsquo;ll say you can&rsquo;t pass any. When we get to user
 constructors, we&rsquo;ll revisit this.</p>
 <p>That leads us to LoxInstance, the runtime representation of an instance of a Lox
 class. Again, our first implementation starts small.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxInstance.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/LoxInstance.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -412,7 +412,7 @@ create new file</div>
 
 <p>Like LoxClass, it&rsquo;s pretty bare bones, but we&rsquo;re only getting started. If you
 want to give it a try, here&rsquo;s a script to run:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Bagel</span> {}
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Bagel</span> {}
 <span class="k">var</span> <span class="i">bagel</span> = <span class="t">Bagel</span>();
 <span class="k">print</span> <span class="i">bagel</span>; <span class="c">// Prints &quot;Bagel instance&quot;.</span>
 </pre></div>
@@ -436,20 +436,20 @@ object. That syntax is only meaningful inside a method and always accesses state
 on the current object.</p>
 <p>Lox, for better or worse, isn&rsquo;t quite so pious about its OOP faith.</p>
 </aside>
-<div class="codehilite"><pre><span class="i">someObject</span>.<span class="i">someProperty</span>
+<div class="codehilite" translate="no"><pre><span class="i">someObject</span>.<span class="i">someProperty</span>
 </pre></div>
 <p>An expression followed by <code>.</code> and an identifier reads the property with that
 name from the object the expression evaluates to. That dot has the same
 precedence as the parentheses in a function call expression, so we slot it into
 the grammar by replacing the existing <code>call</code> rule with:</p>
-<div class="codehilite"><pre><span class="i">call</span>           → <span class="i">primary</span> ( <span class="s">&quot;(&quot;</span> <span class="i">arguments</span>? <span class="s">&quot;)&quot;</span> | <span class="s">&quot;.&quot;</span> <span class="t">IDENTIFIER</span> )* ;
+<div class="codehilite" translate="no"><pre><span class="i">call</span>           → <span class="i">primary</span> ( <span class="s">&quot;(&quot;</span> <span class="i">arguments</span>? <span class="s">&quot;)&quot;</span> | <span class="s">&quot;.&quot;</span> <span class="t">IDENTIFIER</span> )* ;
 </pre></div>
 <p>After a primary expression, we allow a series of any mixture of parenthesized
 calls and dotted property accesses. &ldquo;Property access&rdquo; is a mouthful, so from
 here on out, we&rsquo;ll call these &ldquo;get expressions&rdquo;.</p>
 <h3><a href="#get-expressions" id="get-expressions"><small>12&#8202;.&#8202;4&#8202;.&#8202;1</small>Get expressions</a></h3>
 <p>The <span name="get-ast">syntax tree node</span> is:</p>
-<div class="codehilite"><pre class="insert-before">      &quot;Call     : Expr callee, Token paren, List&lt;Expr&gt; arguments&quot;,
+<div class="codehilite" translate="no"><pre class="insert-before">      &quot;Call     : Expr callee, Token paren, List&lt;Expr&gt; arguments&quot;,
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Get      : Expr object, Token name&quot;</span>,
@@ -462,7 +462,7 @@ in <em>main</em>()</div>
 </aside>
 <p>Following the grammar, the new parsing code goes in our existing <code>call()</code>
 method.</p>
-<div class="codehilite"><pre class="insert-before">    while (true) {<span name="while-true"> </span>
+<div class="codehilite" translate="no"><pre class="insert-before">    while (true) {<span name="while-true"> </span>
       if (match(LEFT_PAREN)) {
         expr = finishCall(expr);
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
@@ -482,7 +482,7 @@ in <em>call</em>()</div>
 along the tokens building up a chain of calls and gets as we find parentheses
 and dots, like so:</p><img src="image/classes/zip.png" alt="Parsing a series of '.' and '()' expressions to an AST." />
 <p>Instances of the new Expr.Get node feed into the resolver.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitCallExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitGetExpr</span>(<span class="t">Expr</span>.<span class="t">Get</span> <span class="i">expr</span>) {
@@ -500,7 +500,7 @@ access happens in the interpreter.</p>
 <p>You can literally see that property dispatch in Lox is dynamic since we don&rsquo;t
 process the property name during the static resolution pass.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitCallExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitGetExpr</span>(<span class="t">Expr</span>.<span class="t">Get</span> <span class="i">expr</span>) {
@@ -520,7 +520,7 @@ instances of classes have properties. If the object is some other type like a
 number, invoking a getter on it is a runtime error.</p>
 <p>If the object is a LoxInstance, then we ask it to look up the property. It must
 be time to give LoxInstance some actual state. A map will do fine.</p>
-<div class="codehilite"><pre class="insert-before">  private LoxClass klass;
+<div class="codehilite" translate="no"><pre class="insert-before">  private LoxClass klass;
 </pre><div class="source-file"><em>lox/LoxInstance.java</em><br>
 in class <em>LoxInstance</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">Map</span>&lt;<span class="t">String</span>, <span class="t">Object</span>&gt; <span class="i">fields</span> = <span class="k">new</span> <span class="t">HashMap</span>&lt;&gt;();
@@ -532,7 +532,7 @@ in class <em>LoxInstance</em></div>
 
 <p>Each key in the map is a property name and the corresponding value is the
 property&rsquo;s value. To look up a property on an instance:</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxInstance.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/LoxInstance.java</em><br>
 add after <em>LoxInstance</em>()</div>
 <pre>  <span class="t">Object</span> <span class="i">get</span>(<span class="t">Token</span> <span class="i">name</span>) {
     <span class="k">if</span> (<span class="i">fields</span>.<span class="i">containsKey</span>(<span class="i">name</span>.<span class="i">lexeme</span>)) {
@@ -575,11 +575,11 @@ we can test out reading, we must support writing.</p>
 <h3><a href="#set-expressions" id="set-expressions"><small>12&#8202;.&#8202;4&#8202;.&#8202;2</small>Set expressions</a></h3>
 <p>Setters use the same syntax as getters, except they appear on the left side of
 an assignment.</p>
-<div class="codehilite"><pre><span class="i">someObject</span>.<span class="i">someProperty</span> = <span class="i">value</span>;
+<div class="codehilite" translate="no"><pre><span class="i">someObject</span>.<span class="i">someProperty</span> = <span class="i">value</span>;
 </pre></div>
 <p>In grammar land, we extend the rule for assignment to allow dotted identifiers
 on the left-hand side.</p>
-<div class="codehilite"><pre><span class="i">assignment</span>     → ( <span class="i">call</span> <span class="s">&quot;.&quot;</span> )? <span class="t">IDENTIFIER</span> <span class="s">&quot;=&quot;</span> <span class="i">assignment</span>
+<div class="codehilite" translate="no"><pre><span class="i">assignment</span>     → ( <span class="i">call</span> <span class="s">&quot;.&quot;</span> )? <span class="t">IDENTIFIER</span> <span class="s">&quot;=&quot;</span> <span class="i">assignment</span>
                | <span class="i">logic_or</span> ;
 </pre></div>
 <p>Unlike getters, setters don&rsquo;t chain. However, the reference to <code>call</code> allows any
@@ -590,7 +590,7 @@ high-precedence expression before the last dot, including any number of
 <p>Just as we have two separate AST nodes for variable access and variable
 assignment, we need a <span name="set-ast">second setter node</span> to
 complement our getter node.</p>
-<div class="codehilite"><pre class="insert-before">      &quot;Logical  : Expr left, Token operator, Expr right&quot;,
+<div class="codehilite" translate="no"><pre class="insert-before">      &quot;Logical  : Expr left, Token operator, Expr right&quot;,
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Set      : Expr object, Token name, Expr value&quot;</span>,
@@ -613,7 +613,7 @@ already parsed and transform it into the correct syntax tree node for the
 assignment.</p>
 <p>We add another clause to that transformation to handle turning an Expr.Get
 expression on the left into the corresponding Expr.Set.</p>
-<div class="codehilite"><pre class="insert-before">        return new Expr.Assign(name, value);
+<div class="codehilite" translate="no"><pre class="insert-before">        return new Expr.Assign(name, value);
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>assignment</em>()</div>
 <pre class="insert">      } <span class="k">else</span> <span class="k">if</span> (<span class="i">expr</span> <span class="k">instanceof</span> <span class="t">Expr</span>.<span class="t">Get</span>) {
@@ -624,7 +624,7 @@ in <em>assignment</em>()</div>
 <div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>assignment</em>()</div>
 
 <p>That&rsquo;s parsing our syntax. We push that node through into the resolver.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitLogicalExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitSetExpr</span>(<span class="t">Expr</span>.<span class="t">Set</span> <span class="i">expr</span>) {
@@ -640,7 +640,7 @@ nothing to resolve there. All we need to do is recurse into the two
 subexpressions of Expr.Set, the object whose property is being set, and the
 value it&rsquo;s being set to.</p>
 <p>That leads us to the interpreter.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitLogicalExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitSetExpr</span>(<span class="t">Expr</span>.<span class="t">Set</span> <span class="i">expr</span>) {
@@ -679,7 +679,7 @@ LoxInstance.</p>
 to carefully specify it and ensure our implementations do these in the same
 order.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/LoxInstance.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/LoxInstance.java</em><br>
 add after <em>get</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">set</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">Object</span> <span class="i">value</span>) {
     <span class="i">fields</span>.<span class="i">put</span>(<span class="i">name</span>.<span class="i">lexeme</span>, <span class="i">value</span>);
@@ -703,13 +703,13 @@ those together.</p><img src="image/classes/method.png" alt="The syntax tree for 
 pulled apart? Assuming that <code>method</code> in this example is a method on the class of
 <code>object</code> and not a field on the instance, what should the following piece of
 code do?</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">m</span> = <span class="i">object</span>.<span class="i">method</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">m</span> = <span class="i">object</span>.<span class="i">method</span>;
 <span class="i">m</span>(<span class="i">argument</span>);
 </pre></div>
 <p>This program &ldquo;looks up&rdquo; the method and stores the result<span class="em">&mdash;</span>whatever that is<span class="em">&mdash;</span>in a variable and then calls that object later. Is this allowed? Can you treat a
 method like it&rsquo;s a function on the instance?</p>
 <p>What about the other direction?</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Box</span> {}
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Box</span> {}
 
 <span class="k">fun</span> <span class="i">notMethod</span>(<span class="i">argument</span>) {
   <span class="k">print</span> <span class="s">&quot;called function with &quot;</span> + <span class="i">argument</span>;
@@ -730,10 +730,10 @@ normal thing to do.</p>
 <p>The first example is more obscure. One motivation is that users generally expect
 to be able to hoist a subexpression out into a local variable without changing
 the meaning of the program. You can take this:</p>
-<div class="codehilite"><pre><span class="i">breakfast</span>(<span class="i">omelette</span>.<span class="i">filledWith</span>(<span class="i">cheese</span>), <span class="i">sausage</span>);
+<div class="codehilite" translate="no"><pre><span class="i">breakfast</span>(<span class="i">omelette</span>.<span class="i">filledWith</span>(<span class="i">cheese</span>), <span class="i">sausage</span>);
 </pre></div>
 <p>And turn it into this:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">eggs</span> = <span class="i">omelette</span>.<span class="i">filledWith</span>(<span class="i">cheese</span>);
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">eggs</span> = <span class="i">omelette</span>.<span class="i">filledWith</span>(<span class="i">cheese</span>);
 <span class="i">breakfast</span>(<span class="i">eggs</span>, <span class="i">sausage</span>);
 </pre></div>
 <p>And it does the same thing. Likewise, since the <code>.</code> and the <code>()</code> in a method
@@ -747,17 +747,17 @@ like:</p>
 body simply invokes a method on some object. Being able to look up the method and
 pass it directly saves you the chore of manually declaring a function to wrap
 it. Compare this:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">callback</span>(<span class="i">a</span>, <span class="i">b</span>, <span class="i">c</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">callback</span>(<span class="i">a</span>, <span class="i">b</span>, <span class="i">c</span>) {
   <span class="i">object</span>.<span class="i">method</span>(<span class="i">a</span>, <span class="i">b</span>, <span class="i">c</span>);
 }
 
 <span class="i">takeCallback</span>(<span class="i">callback</span>);
 </pre></div>
 <p>With this:</p>
-<div class="codehilite"><pre><span class="i">takeCallback</span>(<span class="i">object</span>.<span class="i">method</span>);
+<div class="codehilite" translate="no"><pre><span class="i">takeCallback</span>(<span class="i">object</span>.<span class="i">method</span>);
 </pre></div>
 </aside>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Person</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Person</span> {
   <span class="i">sayName</span>() {
     <span class="k">print</span> <span class="k">this</span>.<span class="i">name</span>;
   }
@@ -773,7 +773,7 @@ it. Compare this:</p>
 &ldquo;remember&rdquo; the instance it was pulled off from? Does <code>this</code> inside the method
 still refer to that original object?</p>
 <p>Here&rsquo;s a more pathological example to bend your brain:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Person</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Person</span> {
   <span class="i">sayName</span>() {
     <span class="k">print</span> <span class="k">this</span>.<span class="i">name</span>;
   }
@@ -809,7 +809,7 @@ on some other object.</p>
 cases for a bit. We&rsquo;ll get back to those. For now, let&rsquo;s get basic method calls
 working. We&rsquo;re already parsing the method declarations inside the class body, so
 the next step is to resolve them.</p>
-<div class="codehilite"><pre class="insert-before">    define(stmt.name);
+<div class="codehilite" translate="no"><pre class="insert-before">    define(stmt.name);
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">
@@ -830,7 +830,7 @@ expand this code before too long and it will make more sense.</p>
 <p>We iterate through the methods in the class body and call the
 <code>resolveFunction()</code> method we wrote for handling function declarations already.
 The only difference is that we pass in a new FunctionType enum value.</p>
-<div class="codehilite"><pre class="insert-before">    NONE,
+<div class="codehilite" translate="no"><pre class="insert-before">    NONE,
 </pre><pre class="insert-before">    <span class="i">FUNCTION</span><span class="insert-comma">,</span>
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in enum <em>FunctionType</em><br>
@@ -842,7 +842,7 @@ add <em>&ldquo;,&rdquo;</em> to previous line</div>
 
 <p>That&rsquo;s going to be important when we resolve <code>this</code> expressions. For now, don&rsquo;t
 worry about it. The interesting stuff is in the interpreter.</p>
-<div class="codehilite"><pre class="insert-before">    environment.define(stmt.name.lexeme, null);
+<div class="codehilite" translate="no"><pre class="insert-before">    environment.define(stmt.name.lexeme, null);
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitClassStmt</em>()<br>
 replace 1 line</div>
@@ -865,7 +865,7 @@ Now, we need to do that for the methods contained in the class as well. Each
 method declaration blossoms into a LoxFunction object.</p>
 <p>We take all of those and wrap them up into a map, keyed by the method names.
 That gets stored in LoxClass.</p>
-<div class="codehilite"><pre class="insert-before">  final String name;
+<div class="codehilite" translate="no"><pre class="insert-before">  final String name;
 </pre><div class="source-file"><em>lox/LoxClass.java</em><br>
 in class <em>LoxClass</em><br>
 replace 4 lines</div>
@@ -885,7 +885,7 @@ replace 4 lines</div>
 <p>Where an instance stores state, the class stores behavior. LoxInstance has its
 map of fields, and LoxClass gets a map of methods. Even though methods are
 owned by the class, they are still accessed through instances of that class.</p>
-<div class="codehilite"><pre class="insert-before">  Object get(Token name) {
+<div class="codehilite" translate="no"><pre class="insert-before">  Object get(Token name) {
     if (fields.containsKey(name.lexeme)) {
       return fields.get(name.lexeme);
     }
@@ -911,7 +911,7 @@ hit a method defined on the instance&rsquo;s class.</p>
 <p>Looking for a field first implies that fields shadow methods, a subtle but
 important semantic point.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/LoxClass.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/LoxClass.java</em><br>
 add after <em>LoxClass</em>()</div>
 <pre>  <span class="t">LoxFunction</span> <span class="i">findMethod</span>(<span class="t">String</span> <span class="i">name</span>) {
     <span class="k">if</span> (<span class="i">methods</span>.<span class="i">containsKey</span>(<span class="i">name</span>)) {
@@ -927,7 +927,7 @@ add after <em>LoxClass</em>()</div>
 now, a simple map lookup on the class&rsquo;s method table is enough to get us
 started. Give it a try:</p>
 <p><span name="crunch"></span></p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Bacon</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Bacon</span> {
   <span class="i">eat</span>() {
     <span class="k">print</span> <span class="s">&quot;Crunch crunch crunch!&quot;</span>;
   }
@@ -957,7 +957,7 @@ a method body, a <code>this</code> expression evaluates to the instance that the
 called on. Or, more specifically, since methods are accessed and then invoked as
 two steps, it will refer to the object that the method was <em>accessed</em> from.</p>
 <p>That makes our job harder. Peep at:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Egotist</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Egotist</span> {
   <span class="i">speak</span>() {
     <span class="k">print</span> <span class="k">this</span>;
   }
@@ -979,7 +979,7 @@ surrounds the function returned when looking up a method, then uses of <code>thi
 the body would be able to find it later. LoxFunction already has the ability to
 hold on to a surrounding environment, so we have the machinery we need.</p>
 <p>Let&rsquo;s walk through an example to see how it works:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Cake</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Cake</span> {
   <span class="i">taste</span>() {
     <span class="k">var</span> <span class="i">adjective</span> = <span class="s">&quot;delicious&quot;</span>;
     <span class="k">print</span> <span class="s">&quot;The &quot;</span> + <span class="k">this</span>.<span class="i">flavor</span> + <span class="s">&quot; cake is &quot;</span> + <span class="i">adjective</span> + <span class="s">&quot;!&quot;</span>;
@@ -1006,7 +1006,7 @@ we create an environment for the method body as usual.</p><img src="image/classe
 successfully resolves to that instance.</p>
 <p>Reusing our environment code for implementing <code>this</code> also takes care of
 interesting cases where methods and functions interact, like:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Thing</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Thing</span> {
   <span class="i">getCallback</span>() {
     <span class="k">fun</span> <span class="i">localFunction</span>() {
       <span class="k">print</span> <span class="k">this</span>;
@@ -1025,7 +1025,7 @@ callback may want to hang on to and retain access to the original object<span cl
 closures and environment chains should do all this correctly.</p>
 <p>Let&rsquo;s code it up. The first step is adding <span name="this-ast">new
 syntax</span> for <code>this</code>.</p>
-<div class="codehilite"><pre class="insert-before">      &quot;Set      : Expr object, Token name, Expr value&quot;,
+<div class="codehilite" translate="no"><pre class="insert-before">      &quot;Set      : Expr object, Token name, Expr value&quot;,
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;This     : Token keyword&quot;</span>,
@@ -1038,7 +1038,7 @@ in <em>main</em>()</div>
 </aside>
 <p>Parsing is simple since it&rsquo;s a single token which our lexer already
 recognizes as a reserved word.</p>
-<div class="codehilite"><pre class="insert-before">      return new Expr.Literal(previous().literal);
+<div class="codehilite" translate="no"><pre class="insert-before">      return new Expr.Literal(previous().literal);
     }
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>primary</em>()</div>
@@ -1053,7 +1053,7 @@ in <em>primary</em>()</div>
 
 <p>You can start to see how <code>this</code> works like a variable when we get to the
 resolver.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitSetExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitThisExpr</span>(<span class="t">Expr</span>.<span class="t">This</span> <span class="i">expr</span>) {
@@ -1067,7 +1067,7 @@ add after <em>visitSetExpr</em>()</div>
 <p>We resolve it exactly like any other local variable using &ldquo;this&rdquo; as the name for
 the &ldquo;variable&rdquo;. Of course, that&rsquo;s not going to work right now, because &ldquo;this&rdquo;
 <em>isn&rsquo;t</em> declared in any scope. Let&rsquo;s fix that over in <code>visitClassStmt()</code>.</p>
-<div class="codehilite"><pre class="insert-before">    define(stmt.name);
+<div class="codehilite" translate="no"><pre class="insert-before">    define(stmt.name);
 
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
@@ -1081,7 +1081,7 @@ in <em>visitClassStmt</em>()</div>
 <p>Before we step in and start resolving the method bodies, we push a new scope and
 define &ldquo;this&rdquo; in it as if it were a variable. Then, when we&rsquo;re done, we discard
 that surrounding scope.</p>
-<div class="codehilite"><pre class="insert-before">    }
+<div class="codehilite" translate="no"><pre class="insert-before">    }
 
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
@@ -1100,7 +1100,7 @@ resolver&rsquo;s scope chains and the interpreter&rsquo;s linked environments in
 each other. At runtime, we create the environment after we find the method on
 the instance. We replace the previous line of code that simply returned the
 method&rsquo;s LoxFunction with this:</p>
-<div class="codehilite"><pre class="insert-before">    LoxFunction method = klass.findMethod(name.lexeme);
+<div class="codehilite" translate="no"><pre class="insert-before">    LoxFunction method = klass.findMethod(name.lexeme);
 </pre><div class="source-file"><em>lox/LoxInstance.java</em><br>
 in <em>get</em>()<br>
 replace 1 line</div>
@@ -1113,7 +1113,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>lox/LoxInstance.java</em>, in <em>get</em>(), replace 1 line</div>
 
 <p>Note the new call to <code>bind()</code>. That looks like so:</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/LoxFunction.java</em><br>
 add after <em>LoxFunction</em>()</div>
 <pre>  <span class="t">LoxFunction</span> <span class="i">bind</span>(<span class="t">LoxInstance</span> <span class="i">instance</span>) {
     <span class="t">Environment</span> <span class="i">environment</span> = <span class="k">new</span> <span class="t">Environment</span>(<span class="i">closure</span>);
@@ -1132,7 +1132,7 @@ returned LoxFunction now carries around its own little persistent world where
 &ldquo;this&rdquo; is bound to the object.</p>
 <p>The remaining task is interpreting those <code>this</code> expressions. Similar to the
 resolver, it is the same as interpreting a variable expression.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitSetExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitThisExpr</span>(<span class="t">Expr</span>.<span class="t">This</span> <span class="i">expr</span>) {
@@ -1148,10 +1148,10 @@ handles to methods, etc.</p>
 <h3><a href="#invalid-uses-of-this" id="invalid-uses-of-this"><small>12&#8202;.&#8202;6&#8202;.&#8202;1</small>Invalid uses of this</a></h3>
 <p>Wait a minute. What happens if you try to use <code>this</code> <em>outside</em> of a method? What
 about:</p>
-<div class="codehilite"><pre><span class="k">print</span> <span class="k">this</span>;
+<div class="codehilite" translate="no"><pre><span class="k">print</span> <span class="k">this</span>;
 </pre></div>
 <p>Or:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">notAMethod</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">notAMethod</span>() {
   <span class="k">print</span> <span class="k">this</span>;
 }
 </pre></div>
@@ -1163,7 +1163,7 @@ happier they&rsquo;ll be.</p>
 detects <code>return</code> statements outside of functions. We&rsquo;ll do something similar for
 <code>this</code>. In the vein of our existing FunctionType enum, we define a new ClassType
 one.</p>
-<div class="codehilite"><pre class="insert-before">  }
+<div class="codehilite" translate="no"><pre class="insert-before">  }
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 add after enum <em>FunctionType</em></div>
 <pre class="insert">
@@ -1185,7 +1185,7 @@ value, hence the enum right now. We also add a corresponding field,
 declaration while traversing the syntax tree. It starts out <code>NONE</code> which means
 we aren&rsquo;t in one.</p>
 <p>When we begin to resolve a class declaration, we change that.</p>
-<div class="codehilite"><pre class="insert-before">  public Void visitClassStmt(Stmt.Class stmt) {
+<div class="codehilite" translate="no"><pre class="insert-before">  public Void visitClassStmt(Stmt.Class stmt) {
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="t">ClassType</span> <span class="i">enclosingClass</span> = <span class="i">currentClass</span>;
@@ -1201,7 +1201,7 @@ values. That way we don&rsquo;t lose track of the previous value if one class ne
 inside another.</p>
 <p>Once the methods have been resolved, we &ldquo;pop&rdquo; that stack by restoring the old
 value.</p>
-<div class="codehilite"><pre class="insert-before">    endScope();
+<div class="codehilite" translate="no"><pre class="insert-before">    endScope();
 
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
@@ -1213,7 +1213,7 @@ in <em>visitClassStmt</em>()</div>
 <p>When we resolve a <code>this</code> expression, the <code>currentClass</code> field gives us the bit
 of data we need to report an error if the expression doesn&rsquo;t occur nestled
 inside a method body.</p>
-<div class="codehilite"><pre class="insert-before">  public Void visitThisExpr(Expr.This expr) {
+<div class="codehilite" translate="no"><pre class="insert-before">  public Void visitThisExpr(Expr.This expr) {
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitThisExpr</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">currentClass</span> == <span class="t">ClassType</span>.<span class="i">NONE</span>) {
@@ -1268,7 +1268,7 @@ have a variety of notations for the chunk of code that sets up a new object for
 a class. C++, Java, and C# use a method whose name matches the class name. Ruby
 and Python call it <code>init()</code>. The latter is nice and short, so we&rsquo;ll do that.</p>
 <p>In LoxClass&rsquo;s implementation of LoxCallable, we add a few more lines.</p>
-<div class="codehilite"><pre class="insert-before">                     List&lt;Object&gt; arguments) {
+<div class="codehilite" translate="no"><pre class="insert-before">                     List&lt;Object&gt; arguments) {
     LoxInstance instance = new LoxInstance(this);
 </pre><div class="source-file"><em>lox/LoxClass.java</em><br>
 in <em>call</em>()</div>
@@ -1285,7 +1285,7 @@ in <em>call</em>()</div>
 method. If we find one, we immediately bind and invoke it just like a normal
 method call. The argument list is forwarded along.</p>
 <p>That argument list means we also need to tweak how a class declares its arity.</p>
-<div class="codehilite"><pre class="insert-before">  public int arity() {
+<div class="codehilite" translate="no"><pre class="insert-before">  public int arity() {
 </pre><div class="source-file"><em>lox/LoxClass.java</em><br>
 in <em>arity</em>()<br>
 replace 1 line</div>
@@ -1307,7 +1307,7 @@ desire.</p>
 <h3><a href="#invoking-init-directly" id="invoking-init-directly"><small>12&#8202;.&#8202;7&#8202;.&#8202;1</small>Invoking init() directly</a></h3>
 <p>As usual, exploring this new semantic territory rustles up a few weird
 creatures. Consider:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Foo</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Foo</span> {
   <span class="i">init</span>() {
     <span class="k">print</span> <span class="k">this</span>;
   }
@@ -1332,7 +1332,7 @@ more features to users in less time, it may very well be a net win for their
 happiness and productivity. The trick is figuring out <em>which</em> corners to cut
 that won&rsquo;t cause your users and future self to curse your shortsightedness.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">      return returnValue.value;
+<div class="codehilite" translate="no"><pre class="insert-before">      return returnValue.value;
     }
 </pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
 in <em>call</em>()</div>
@@ -1345,7 +1345,7 @@ in <em>call</em>()</div>
 
 <p>If the function is an initializer, we override the actual return value and
 forcibly return <code>this</code>. That relies on a new <code>isInitializer</code> field.</p>
-<div class="codehilite"><pre class="insert-before">  private final Environment closure;
+<div class="codehilite" translate="no"><pre class="insert-before">  private final Environment closure;
 
 </pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
 in class <em>LoxFunction</em><br>
@@ -1365,7 +1365,7 @@ could have defined a <em>function</em> with that name. In that case, there <em>i
 <code>this</code> to return. To avoid <em>that</em> weird edge case, we&rsquo;ll directly store whether
 the LoxFunction represents an initializer method. That means we need to go back
 and fix the few places where we create LoxFunctions.</p>
-<div class="codehilite"><pre class="insert-before">  public Void visitFunctionStmt(Stmt.Function stmt) {
+<div class="codehilite" translate="no"><pre class="insert-before">  public Void visitFunctionStmt(Stmt.Function stmt) {
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitFunctionStmt</em>()<br>
 replace 1 line</div>
@@ -1377,7 +1377,7 @@ replace 1 line</div>
 
 <p>For actual function declarations, <code>isInitializer</code> is always false. For methods,
 we check the name.</p>
-<div class="codehilite"><pre class="insert-before">    for (Stmt.Function method : stmt.methods) {
+<div class="codehilite" translate="no"><pre class="insert-before">    for (Stmt.Function method : stmt.methods) {
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitClassStmt</em>()<br>
 replace 1 line</div>
@@ -1389,7 +1389,7 @@ replace 1 line</div>
 
 <p>And then in <code>bind()</code> where we create the closure that binds <code>this</code> to a method,
 we pass along the original method&rsquo;s value.</p>
-<div class="codehilite"><pre class="insert-before">    environment.define(&quot;this&quot;, instance);
+<div class="codehilite" translate="no"><pre class="insert-before">    environment.define(&quot;this&quot;, instance);
 </pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
 in <em>bind</em>()<br>
 replace 1 line</div>
@@ -1403,7 +1403,7 @@ replace 1 line</div>
 <p>We aren&rsquo;t out of the woods yet. We&rsquo;ve been assuming that a user-written
 initializer doesn&rsquo;t explicitly return a value because most constructors don&rsquo;t.
 What should happen if a user tries:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Foo</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Foo</span> {
   <span class="i">init</span>() {
     <span class="k">return</span> <span class="s">&quot;something else&quot;</span>;
   }
@@ -1411,7 +1411,7 @@ What should happen if a user tries:</p>
 </pre></div>
 <p>It&rsquo;s definitely not going to do what they want, so we may as well make it a
 static error. Back in the resolver, we add another case to FunctionType.</p>
-<div class="codehilite"><pre class="insert-before">    FUNCTION,
+<div class="codehilite" translate="no"><pre class="insert-before">    FUNCTION,
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in enum <em>FunctionType</em></div>
 <pre class="insert">    <span class="i">INITIALIZER</span>,
@@ -1421,7 +1421,7 @@ in enum <em>FunctionType</em></div>
 
 <p>We use the visited method&rsquo;s name to determine if we&rsquo;re resolving an initializer
 or not.</p>
-<div class="codehilite"><pre class="insert-before">      FunctionType declaration = FunctionType.METHOD;
+<div class="codehilite" translate="no"><pre class="insert-before">      FunctionType declaration = FunctionType.METHOD;
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">method</span>.<span class="i">name</span>.<span class="i">lexeme</span>.<span class="i">equals</span>(<span class="s">&quot;init&quot;</span>)) {
@@ -1434,7 +1434,7 @@ in <em>visitClassStmt</em>()</div>
 
 <p>When we later traverse into a <code>return</code> statement, we check that field and make
 it an error to return a value from inside an <code>init()</code> method.</p>
-<div class="codehilite"><pre class="insert-before">    if (stmt.value != null) {
+<div class="codehilite" translate="no"><pre class="insert-before">    if (stmt.value != null) {
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitReturnStmt</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">currentFunction</span> == <span class="t">FunctionType</span>.<span class="i">INITIALIZER</span>) {
@@ -1448,7 +1448,7 @@ in <em>visitReturnStmt</em>()</div>
 
 <p>We&rsquo;re <em>still</em> not done. We statically disallow returning a <em>value</em> from an
 initializer, but you can still use an empty early <code>return</code>.</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Foo</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Foo</span> {
   <span class="i">init</span>() {
     <span class="k">return</span>;
   }
@@ -1457,7 +1457,7 @@ initializer, but you can still use an empty early <code>return</code>.</p>
 <p>That is actually kind of useful sometimes, so we don&rsquo;t want to disallow it
 entirely. Instead, it should return <code>this</code> instead of <code>nil</code>. That&rsquo;s an easy fix
 over in LoxFunction.</p>
-<div class="codehilite"><pre class="insert-before">    } catch (Return returnValue) {
+<div class="codehilite" translate="no"><pre class="insert-before">    } catch (Return returnValue) {
 </pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
 in <em>call</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">isInitializer</span>) <span class="k">return</span> <span class="i">closure</span>.<span class="i">getAt</span>(<span class="n">0</span>, <span class="s">&quot;this&quot;</span>);
@@ -1479,7 +1479,7 @@ interpreter has grown an entire programming paradigm. Classes, methods, fields,
 that can be called directly on the class object itself. Add support for
 them. Use a <code>class</code> keyword preceding the method to indicate a static method
 that hangs off the class object.</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Math</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Math</span> {
   <span class="k">class</span> <span class="i">square</span>(<span class="i">n</span>) {
     <span class="k">return</span> <span class="i">n</span> * <span class="i">n</span>;
   }
@@ -1497,7 +1497,7 @@ that look like field reads and writes but that actually execute user-defined
 code. Extend Lox to support getter methods. These are declared without a
 parameter list. The body of the getter is executed when a property with that
 name is accessed.</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Circle</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Circle</span> {
   <span class="i">init</span>(<span class="i">radius</span>) {
     <span class="k">this</span>.<span class="i">radius</span> = <span class="i">radius</span>;
   }
@@ -1560,7 +1560,7 @@ write, and fewer concepts for the user to learn and understand. Does that make
 them better? We language nerds have a tendency to fetishize minimalism.
 Personally, I think simplicity is only part of the equation. What we really want
 to give the user is <em>power</em>, which I define as:</p>
-<div class="codehilite"><pre>power = breadth × ease ÷ complexity
+<div class="codehilite" translate="no"><pre>power = breadth × ease ÷ complexity
 </pre></div>
 <p>None of these are precise numeric measures. I&rsquo;m using math as analogy here, not
 actual quantification.</p>

--- a/site/closures.html
+++ b/site/closures.html
@@ -101,7 +101,7 @@ wrong.</p>
 machine with working functions. What it lacks is closures. Aside from global
 variables, which are their own breed of animal, a function has no way to
 reference a variable declared outside of its own body.</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">x</span> = <span class="s">&quot;global&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">x</span> = <span class="s">&quot;global&quot;</span>;
 <span class="k">fun</span> <span class="i">outer</span>() {
   <span class="k">var</span> <span class="i">x</span> = <span class="s">&quot;outer&quot;</span>;
   <span class="k">fun</span> <span class="i">inner</span>() {
@@ -118,7 +118,7 @@ functions when resolving a variable.</p>
 stores locals on a stack. We used a stack because I claimed locals have stack
 semantics<span class="em">&mdash;</span>variables are discarded in the reverse order that they are created.
 But with closures, that&rsquo;s only <em>mostly</em> true.</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">makeClosure</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">makeClosure</span>() {
   <span class="k">var</span> <span class="i">local</span> = <span class="s">&quot;local&quot;</span>;
   <span class="k">fun</span> <span class="i">closure</span>() {
     <span class="k">print</span> <span class="i">local</span>;
@@ -182,7 +182,7 @@ of syntax that defines a constant value of a built-in type.</p>
 compile time: the chunk of bytecode compiled from the function&rsquo;s body, and the
 constants used in the body. Once we introduce closures, though, that
 representation is no longer sufficient. Take a gander at:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">makeClosure</span>(<span class="i">value</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">makeClosure</span>(<span class="i">value</span>) {
   <span class="k">fun</span> <span class="i">closure</span>() {
     <span class="k">print</span> <span class="i">value</span>;
   }
@@ -217,7 +217,7 @@ gets overloaded to refer to <a href="https://en.wikipedia.org/wiki/Prototype-bas
 actually close over and capture any surrounding local variables. This is a
 little wasteful, but it simplifies the VM because we can always assume that the
 function we&rsquo;re calling is an ObjClosure. That new struct starts out like this:</p>
-<div class="codehilite"><div class="source-file"><em>object.h</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.h</em><br>
 add after struct <em>ObjString</em></div>
 <pre><span class="k">typedef</span> <span class="k">struct</span> {
   <span class="t">Obj</span> <span class="i">obj</span>;
@@ -229,7 +229,7 @@ add after struct <em>ObjString</em></div>
 <p>Right now, it simply points to an ObjFunction and adds the necessary object
 header stuff. Grinding through the usual ceremony for adding a new object type
 to clox, we declare a C function to create a new closure.</p>
-<div class="codehilite"><pre class="insert-before">} ObjClosure;
+<div class="codehilite" translate="no"><pre class="insert-before">} ObjClosure;
 
 </pre><div class="source-file"><em>object.h</em><br>
 add after struct <em>ObjClosure</em></div>
@@ -239,7 +239,7 @@ add after struct <em>ObjClosure</em></div>
 <div class="source-file-narrow"><em>object.h</em>, add after struct <em>ObjClosure</em></div>
 
 <p>Then we implement it here:</p>
-<div class="codehilite"><div class="source-file"><em>object.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.c</em><br>
 add after <em>allocateObject</em>()</div>
 <pre><span class="t">ObjClosure</span>* <span class="i">newClosure</span>(<span class="t">ObjFunction</span>* <span class="i">function</span>) {
   <span class="t">ObjClosure</span>* <span class="i">closure</span> = <span class="a">ALLOCATE_OBJ</span>(<span class="t">ObjClosure</span>, <span class="a">OBJ_CLOSURE</span>);
@@ -251,7 +251,7 @@ add after <em>allocateObject</em>()</div>
 
 <p>It takes a pointer to the ObjFunction it wraps. It also initializes the type
 field to a new type.</p>
-<div class="codehilite"><pre class="insert-before">typedef enum {
+<div class="codehilite" translate="no"><pre class="insert-before">typedef enum {
 </pre><div class="source-file"><em>object.h</em><br>
 in enum <em>ObjType</em></div>
 <pre class="insert">  <span class="a">OBJ_CLOSURE</span>,
@@ -260,7 +260,7 @@ in enum <em>ObjType</em></div>
 <div class="source-file-narrow"><em>object.h</em>, in enum <em>ObjType</em></div>
 
 <p>And when we&rsquo;re done with a closure, we release its memory.</p>
-<div class="codehilite"><pre class="insert-before">  switch (object-&gt;type) {
+<div class="codehilite" translate="no"><pre class="insert-before">  switch (object-&gt;type) {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>freeObject</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OBJ_CLOSURE</span>: {
@@ -283,7 +283,7 @@ type.</p>
 <p>Perhaps I should have defined a macro to make it easier to generate these
 macros. Maybe that would be a little too meta.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">#define OBJ_TYPE(value)        (AS_OBJ(value)-&gt;type)
+<div class="codehilite" translate="no"><pre class="insert-before">#define OBJ_TYPE(value)        (AS_OBJ(value)-&gt;type)
 
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert"><span class="a">#define IS_CLOSURE(value)      isObjType(value, OBJ_CLOSURE)</span>
@@ -292,7 +292,7 @@ macros. Maybe that would be a little too meta.</p>
 <div class="source-file-narrow"><em>object.h</em></div>
 
 <p>And to cast a value:</p>
-<div class="codehilite"><pre class="insert-before">#define IS_STRING(value)       isObjType(value, OBJ_STRING)
+<div class="codehilite" translate="no"><pre class="insert-before">#define IS_STRING(value)       isObjType(value, OBJ_STRING)
 
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert"><span class="a">#define AS_CLOSURE(value)      ((ObjClosure*)AS_OBJ(value))</span>
@@ -301,7 +301,7 @@ macros. Maybe that would be a little too meta.</p>
 <div class="source-file-narrow"><em>object.h</em></div>
 
 <p>Closures are first-class objects, so you can print them.</p>
-<div class="codehilite"><pre class="insert-before">  switch (OBJ_TYPE(value)) {
+<div class="codehilite" translate="no"><pre class="insert-before">  switch (OBJ_TYPE(value)) {
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>printObject</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OBJ_CLOSURE</span>:
@@ -320,7 +320,7 @@ closures.</p>
 the compiler to emit instructions to tell the runtime when to create a new
 ObjClosure to wrap a given ObjFunction. This happens right at the end of a
 function declaration.</p>
-<div class="codehilite"><pre class="insert-before">  ObjFunction* function = endCompiler();
+<div class="codehilite" translate="no"><pre class="insert-before">  ObjFunction* function = endCompiler();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>function</em>()<br>
 replace 1 line</div>
@@ -332,7 +332,7 @@ replace 1 line</div>
 <p>Before, the final bytecode for a function declaration was a single <code>OP_CONSTANT</code>
 instruction to load the compiled function from the surrounding function&rsquo;s
 constant table and push it onto the stack. Now we have a new instruction.</p>
-<div class="codehilite"><pre class="insert-before">  OP_CALL,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_CALL,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_CLOSURE</span>,
@@ -345,7 +345,7 @@ index for the function. But when we get over to the runtime implementation, we
 do something more interesting.</p>
 <p>First, let&rsquo;s be diligent VM hackers and slot in disassembler support for the
 instruction.</p>
-<div class="codehilite"><pre class="insert-before">    case OP_CALL:
+<div class="codehilite" translate="no"><pre class="insert-before">    case OP_CALL:
       return byteInstruction(&quot;OP_CALL&quot;, chunk, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
@@ -370,7 +370,7 @@ we&rsquo;ll be adding to it. This code here anticipates that future.</p>
 instruction, naturally. But we also need to touch every piece of code in the VM
 that works with ObjFunction and change it to use ObjClosure instead<span class="em">&mdash;</span>function
 calls, call frames, etc. We&rsquo;ll start with the instruction, though.</p>
-<div class="codehilite"><pre class="insert-before">      }
+<div class="codehilite" translate="no"><pre class="insert-before">      }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_CLOSURE</span>: {
@@ -387,7 +387,7 @@ in <em>run</em>()</div>
 function from the constant table. The difference now is that we wrap that
 function in a new ObjClosure and push the result onto the stack.</p>
 <p>Once you have a closure, you&rsquo;ll eventually want to call it.</p>
-<div class="codehilite"><pre class="insert-before">    switch (OBJ_TYPE(callee)) {
+<div class="codehilite" translate="no"><pre class="insert-before">    switch (OBJ_TYPE(callee)) {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>callValue</em>()<br>
 replace 2 lines</div>
@@ -409,7 +409,7 @@ neighbors say?</p>
 <p>We replace the old code with very similar code for calling a closure instead.
 The only difference is the type of object we pass to <code>call()</code>. The real changes
 are over in that function. First, we update its signature.</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 function <em>call</em>()<br>
 replace 1 line</div>
 <pre class="insert"><span class="k">static</span> <span class="t">bool</span> <span class="i">call</span>(<span class="t">ObjClosure</span>* <span class="i">closure</span>, <span class="t">int</span> <span class="i">argCount</span>) {
@@ -420,7 +420,7 @@ replace 1 line</div>
 <p>Then, in the body, we need to fix everything that referenced the function to
 handle the fact that we&rsquo;ve introduced a layer of indirection. We start with the
 arity checking:</p>
-<div class="codehilite"><pre class="insert-before">static bool call(ObjClosure* closure, int argCount) {
+<div class="codehilite" translate="no"><pre class="insert-before">static bool call(ObjClosure* closure, int argCount) {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>call</em>()<br>
 replace 3 lines</div>
@@ -435,7 +435,7 @@ replace 3 lines</div>
 The next thing <code>call()</code> does is create a new CallFrame. We change that code to
 store the closure in the CallFrame and get the bytecode pointer from the
 closure&rsquo;s function.</p>
-<div class="codehilite"><pre class="insert-before">  CallFrame* frame = &amp;vm.frames[vm.frameCount++];
+<div class="codehilite" translate="no"><pre class="insert-before">  CallFrame* frame = &amp;vm.frames[vm.frameCount++];
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>call</em>()<br>
 replace 2 lines</div>
@@ -446,7 +446,7 @@ replace 2 lines</div>
 <div class="source-file-narrow"><em>vm.c</em>, in <em>call</em>(), replace 2 lines</div>
 
 <p>This necessitates changing the declaration of CallFrame too.</p>
-<div class="codehilite"><pre class="insert-before">typedef struct {
+<div class="codehilite" translate="no"><pre class="insert-before">typedef struct {
 </pre><div class="source-file"><em>vm.h</em><br>
 in struct <em>CallFrame</em><br>
 replace 1 line</div>
@@ -458,7 +458,7 @@ replace 1 line</div>
 <p>That change triggers a few other cascading changes. Every place in the VM that
 accessed CallFrame&rsquo;s function needs to use a closure instead. First, the macro
 for reading a constant from the current function&rsquo;s constant table:</p>
-<div class="codehilite"><pre class="insert-before">    (uint16_t)((frame-&gt;ip[-2] &lt;&lt; 8) | frame-&gt;ip[-1]))
+<div class="codehilite" translate="no"><pre class="insert-before">    (uint16_t)((frame-&gt;ip[-2] &lt;&lt; 8) | frame-&gt;ip[-1]))
 
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
@@ -473,7 +473,7 @@ replace 2 lines</div>
 
 <p>When <code>DEBUG_TRACE_EXECUTION</code> is enabled, it needs to get to the chunk from the
 closure.</p>
-<div class="codehilite"><pre class="insert-before">    printf(&quot;\n&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">    printf(&quot;\n&quot;);
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
 replace 2 lines</div>
@@ -484,7 +484,7 @@ replace 2 lines</div>
 <div class="source-file-narrow"><em>vm.c</em>, in <em>run</em>(), replace 2 lines</div>
 
 <p>Likewise when reporting a runtime error:</p>
-<div class="codehilite"><pre class="insert-before">    CallFrame* frame = &amp;vm.frames[i];
+<div class="codehilite" translate="no"><pre class="insert-before">    CallFrame* frame = &amp;vm.frames[i];
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>runtimeError</em>()<br>
 replace 1 line</div>
@@ -495,7 +495,7 @@ replace 1 line</div>
 
 <p>Almost there. The last piece is the blob of code that sets up the very first
 CallFrame to begin executing the top-level code for a Lox script.</p>
-<div class="codehilite"><pre class="insert-before">  push(OBJ_VAL(function));
+<div class="codehilite" translate="no"><pre class="insert-before">  push(OBJ_VAL(function));
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>interpret</em>()<br>
 replace 1 line</div>
@@ -541,7 +541,7 @@ memory for it dynamically. That way it could live as long as needed.</p>
 <p>This would be a fine approach if clox didn&rsquo;t have a single-pass compiler. But
 that restriction we chose in our implementation makes things harder. Take a look
 at this example:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">outer</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">outer</span>() {
   <span class="k">var</span> <span class="i">x</span> = <span class="n">1</span>;    <span class="c">// (1)</span>
   <span class="i">x</span> = <span class="n">2</span>;        <span class="c">// (2)</span>
   <span class="k">fun</span> <span class="i">inner</span>() { <span class="c">// (3)</span>
@@ -567,7 +567,7 @@ corresponding upvalue to reach it. When a function declaration is first executed
 and we create a closure for it, the VM creates the array of upvalues and wires
 them up to &ldquo;capture&rdquo; the surrounding local variables that the closure needs.</p>
 <p>For example, if we throw this program at clox,</p>
-<div class="codehilite"><pre>{
+<div class="codehilite" translate="no"><pre>{
   <span class="k">var</span> <span class="i">a</span> = <span class="n">3</span>;
   <span class="k">fun</span> <span class="i">f</span>() {
     <span class="k">print</span> <span class="i">a</span>;
@@ -594,7 +594,7 @@ variable in that function, we assume the variable must be a global. We don&rsquo
 consider the local scopes of enclosing functions<span class="em">&mdash;</span>they get skipped right over.
 The first change, then, is inserting a resolution step for those outer local
 scopes.</p>
-<div class="codehilite"><pre class="insert-before">  if (arg != -1) {
+<div class="codehilite" translate="no"><pre class="insert-before">  if (arg != -1) {
     getOp = OP_GET_LOCAL;
     setOp = OP_SET_LOCAL;
 </pre><div class="source-file"><em>compiler.c</em><br>
@@ -611,7 +611,7 @@ of the surrounding functions. If it finds one, it returns an &ldquo;upvalue inde
 that variable. (We&rsquo;ll get into what that means later.) Otherwise, it returns -1
 to indicate the variable wasn&rsquo;t found. If it was found, we use these two new
 instructions for reading or writing to the variable through its upvalue:</p>
-<div class="codehilite"><pre class="insert-before">  OP_SET_GLOBAL,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_SET_GLOBAL,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_GET_UPVALUE</span>,
@@ -623,7 +623,7 @@ in enum <em>OpCode</em></div>
 <p>We&rsquo;re implementing this sort of top-down, so I&rsquo;ll show you how these work at
 runtime soon. The part to focus on now is how the compiler actually resolves the
 identifier.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>resolveLocal</em>()</div>
 <pre><span class="k">static</span> <span class="t">int</span> <span class="i">resolveUpvalue</span>(<span class="t">Compiler</span>* <span class="i">compiler</span>, <span class="t">Token</span>* <span class="i">name</span>) {
   <span class="k">if</span> (<span class="i">compiler</span>-&gt;<span class="i">enclosing</span> == <span class="a">NULL</span>) <span class="k">return</span> -<span class="n">1</span>;
@@ -653,7 +653,7 @@ perspective, it&rsquo;s &ldquo;hopefully global&rdquo;.</p>
 <p>Otherwise, we try to resolve the identifier as a <em>local</em> variable in the
 <em>enclosing</em> compiler. In other words, we look for it right outside the current
 function. For example:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">outer</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">outer</span>() {
   <span class="k">var</span> <span class="i">x</span> = <span class="n">1</span>;
   <span class="k">fun</span> <span class="i">inner</span>() {
     <span class="k">print</span> <span class="i">x</span>; <span class="c">// (1)</span>
@@ -666,7 +666,7 @@ a local variable <code>x</code> declared in <code>outer()</code>. If found<span 
 example<span class="em">&mdash;</span>then we&rsquo;ve successfully resolved the variable. We create an upvalue
 so that the inner function can access the variable through that. The upvalue is
 created here:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>resolveLocal</em>()</div>
 <pre><span class="k">static</span> <span class="t">int</span> <span class="i">addUpvalue</span>(<span class="t">Compiler</span>* <span class="i">compiler</span>, <span class="t">uint8_t</span> <span class="i">index</span>,
                       <span class="t">bool</span> <span class="i">isLocal</span>) {
@@ -704,7 +704,7 @@ multiple times. In that case, we don&rsquo;t want to waste time and memory creat
 separate upvalue for each identifier expression. To fix that, before we add a
 new upvalue, we first check to see if the function already has an upvalue that
 closes over that variable.</p>
-<div class="codehilite"><pre class="insert-before">  int upvalueCount = compiler-&gt;function-&gt;upvalueCount;
+<div class="codehilite" translate="no"><pre class="insert-before">  int upvalueCount = compiler-&gt;function-&gt;upvalueCount;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>addUpvalue</em>()</div>
 <pre class="insert">
@@ -725,7 +725,7 @@ adding, we just return that <em>upvalue</em> index and reuse it. Otherwise, we f
 through and add the new upvalue.</p>
 <p>These two functions access and modify a bunch of new state, so let&rsquo;s define
 that. First, we add the upvalue count to ObjFunction.</p>
-<div class="codehilite"><pre class="insert-before">  int arity;
+<div class="codehilite" translate="no"><pre class="insert-before">  int arity;
 </pre><div class="source-file"><em>object.h</em><br>
 in struct <em>ObjFunction</em></div>
 <pre class="insert">  <span class="t">int</span> <span class="i">upvalueCount</span>;
@@ -735,7 +735,7 @@ in struct <em>ObjFunction</em></div>
 
 <p>We&rsquo;re conscientious C programmers, so we zero-initialize that when an
 ObjFunction is first allocated.</p>
-<div class="codehilite"><pre class="insert-before">  function-&gt;arity = 0;
+<div class="codehilite" translate="no"><pre class="insert-before">  function-&gt;arity = 0;
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>newFunction</em>()</div>
 <pre class="insert">  <span class="i">function</span>-&gt;<span class="i">upvalueCount</span> = <span class="n">0</span>;
@@ -744,7 +744,7 @@ in <em>newFunction</em>()</div>
 <div class="source-file-narrow"><em>object.c</em>, in <em>newFunction</em>()</div>
 
 <p>In the compiler, we add a field for the upvalue array.</p>
-<div class="codehilite"><pre class="insert-before">  int localCount;
+<div class="codehilite" translate="no"><pre class="insert-before">  int localCount;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in struct <em>Compiler</em></div>
 <pre class="insert">  <span class="t">Upvalue</span> <span class="i">upvalues</span>[<span class="a">UINT8_COUNT</span>];
@@ -757,7 +757,7 @@ in struct <em>Compiler</em></div>
 operand, so there&rsquo;s a restriction on how many upvalues a function can have<span class="em">&mdash;</span>how many unique variables it can close over. Given that, we can afford a static
 array that large. We also need to make sure the compiler doesn&rsquo;t overflow that
 limit.</p>
-<div class="codehilite"><pre class="insert-before">    if (upvalue-&gt;index == index &amp;&amp; upvalue-&gt;isLocal == isLocal) {
+<div class="codehilite" translate="no"><pre class="insert-before">    if (upvalue-&gt;index == index &amp;&amp; upvalue-&gt;isLocal == isLocal) {
       return i;
     }
   }
@@ -774,7 +774,7 @@ in <em>addUpvalue</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>addUpvalue</em>()</div>
 
 <p>Finally, the Upvalue struct type itself.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after struct <em>Local</em></div>
 <pre><span class="k">typedef</span> <span class="k">struct</span> {
   <span class="t">uint8_t</span> <span class="i">index</span>;
@@ -789,7 +789,7 @@ add after struct <em>Local</em></div>
 <p>In the example I showed before, the closure is accessing a variable declared in
 the immediately enclosing function. Lox also supports accessing local variables
 declared in <em>any</em> enclosing scope, as in:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">outer</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">outer</span>() {
   <span class="k">var</span> <span class="i">x</span> = <span class="n">1</span>;
   <span class="k">fun</span> <span class="i">middle</span>() {
     <span class="k">fun</span> <span class="i">inner</span>() {
@@ -809,7 +809,7 @@ finely honed skill at creating bizarre programs like this that are technically
 valid but likely to trip up an implementation written by someone with a less
 perverse imagination than you.</p>
 </aside>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">outer</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">outer</span>() {
   <span class="k">var</span> <span class="i">x</span> = <span class="s">&quot;value&quot;</span>;
   <span class="k">fun</span> <span class="i">middle</span>() {
     <span class="k">fun</span> <span class="i">inner</span>() {
@@ -829,7 +829,7 @@ perverse imagination than you.</p>
 <span class="i">in</span>();
 </pre></div>
 <p>When you run this, it should print:</p>
-<div class="codehilite"><pre>return from outer
+<div class="codehilite" translate="no"><pre>return from outer
 create inner closure
 value
 </pre></div>
@@ -867,7 +867,7 @@ local or upvalue<span class="em">&mdash;</span><em>only</em> from the immediatel
 guaranteed to still be around at the point that the inner function declaration
 executes.</p>
 <p>In order to implement this, <code>resolveUpvalue()</code> becomes recursive.</p>
-<div class="codehilite"><pre class="insert-before">  if (local != -1) {
+<div class="codehilite" translate="no"><pre class="insert-before">  if (local != -1) {
     return addUpvalue(compiler, (uint8_t)local, true);
   }
 
@@ -927,7 +927,7 @@ Each upvalue may in turn capture a local variable from the surrounding function,
 or an upvalue in the case of transitive closures. We finally have enough data to
 emit bytecode which creates a closure at runtime that captures all of the
 correct variables.</p>
-<div class="codehilite"><pre class="insert-before">  emitBytes(OP_CLOSURE, makeConstant(OBJ_VAL(function)));
+<div class="codehilite" translate="no"><pre class="insert-before">  emitBytes(OP_CLOSURE, makeConstant(OBJ_VAL(function)));
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>function</em>()</div>
 <pre class="insert">
@@ -948,7 +948,7 @@ of the function&rsquo;s upvalues. The next byte is the local slot or upvalue ind
 capture.</p>
 <p>This odd encoding means we need some bespoke support in the disassembly code
 for <code>OP_CLOSURE</code>.</p>
-<div class="codehilite"><pre class="insert-before">      printf(&quot;\n&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">      printf(&quot;\n&quot;);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
 <pre class="insert">
@@ -967,7 +967,7 @@ in <em>disassembleInstruction</em>()</div>
 <div class="source-file-narrow"><em>debug.c</em>, in <em>disassembleInstruction</em>()</div>
 
 <p>For example, take this script:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">outer</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">outer</span>() {
   <span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>;
   <span class="k">var</span> <span class="i">b</span> = <span class="n">2</span>;
   <span class="k">fun</span> <span class="i">middle</span>() {
@@ -981,14 +981,14 @@ in <em>disassembleInstruction</em>()</div>
 </pre></div>
 <p>If we disassemble the instruction that creates the closure for <code>inner()</code>, it
 prints this:</p>
-<div class="codehilite"><pre>0004    9 OP_CLOSURE          2 &lt;fn inner&gt;
+<div class="codehilite" translate="no"><pre>0004    9 OP_CLOSURE          2 &lt;fn inner&gt;
 0006      |                     upvalue 0
 0008      |                     local 1
 0010      |                     upvalue 1
 0012      |                     local 2
 </pre></div>
 <p>We have two other, simpler instructions to add disassembler support for.</p>
-<div class="codehilite"><pre class="insert-before">    case OP_SET_GLOBAL:
+<div class="codehilite" translate="no"><pre class="insert-before">    case OP_SET_GLOBAL:
       return constantInstruction(&quot;OP_SET_GLOBAL&quot;, chunk, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
@@ -1002,7 +1002,7 @@ in <em>disassembleInstruction</em>()</div>
 
 <p>These both have a single-byte operand, so there&rsquo;s nothing exciting going on. We
 do need to add an include so the debug module can get to <code>AS_FUNCTION()</code>.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;debug.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;debug.h&quot;
 </pre><div class="source-file"><em>debug.c</em></div>
 <pre class="insert"><span class="a">#include &quot;object.h&quot;</span>
 </pre><pre class="insert-after">#include &quot;value.h&quot;
@@ -1017,7 +1017,7 @@ side of the VM and get things running.</p>
 <p>Each <code>OP_CLOSURE</code> instruction is now followed by the series of bytes that
 specify the upvalues the ObjClosure should own. Before we process those
 operands, we need a runtime representation for upvalues.</p>
-<div class="codehilite"><div class="source-file"><em>object.h</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.h</em><br>
 add after struct <em>ObjString</em></div>
 <pre><span class="k">typedef</span> <span class="k">struct</span> <span class="t">ObjUpvalue</span> {
   <span class="t">Obj</span> <span class="i">obj</span>;
@@ -1037,7 +1037,7 @@ variable. Note that this is a <em>pointer</em> to a Value, not a Value itself. I
 reference to a <em>variable</em>, not a <em>value</em>. This is important because it means
 that when we assign to the variable the upvalue captures, we&rsquo;re assigning to the
 actual variable, not a copy. For example:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">outer</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">outer</span>() {
   <span class="k">var</span> <span class="i">x</span> = <span class="s">&quot;before&quot;</span>;
   <span class="k">fun</span> <span class="i">inner</span>() {
     <span class="i">x</span> = <span class="s">&quot;assigned&quot;</span>;
@@ -1051,7 +1051,7 @@ actual variable, not a copy. For example:</p>
 the surrounding function accesses it.</p>
 <p>Because upvalues are objects, we&rsquo;ve got all the usual object machinery, starting
 with a constructor-like function:</p>
-<div class="codehilite"><pre class="insert-before">ObjString* copyString(const char* chars, int length);
+<div class="codehilite" translate="no"><pre class="insert-before">ObjString* copyString(const char* chars, int length);
 </pre><div class="source-file"><em>object.h</em><br>
 add after <em>copyString</em>()</div>
 <pre class="insert"><span class="t">ObjUpvalue</span>* <span class="i">newUpvalue</span>(<span class="t">Value</span>* <span class="i">slot</span>);
@@ -1061,7 +1061,7 @@ add after <em>copyString</em>()</div>
 
 <p>It takes the address of the slot where the closed-over variable lives. Here is
 the implementation:</p>
-<div class="codehilite"><div class="source-file"><em>object.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.c</em><br>
 add after <em>copyString</em>()</div>
 <pre><span class="t">ObjUpvalue</span>* <span class="i">newUpvalue</span>(<span class="t">Value</span>* <span class="i">slot</span>) {
   <span class="t">ObjUpvalue</span>* <span class="i">upvalue</span> = <span class="a">ALLOCATE_OBJ</span>(<span class="t">ObjUpvalue</span>, <span class="a">OBJ_UPVALUE</span>);
@@ -1073,7 +1073,7 @@ add after <em>copyString</em>()</div>
 
 <p>We simply initialize the object and store the pointer. That requires a new
 object type.</p>
-<div class="codehilite"><pre class="insert-before">  OBJ_STRING,
+<div class="codehilite" translate="no"><pre class="insert-before">  OBJ_STRING,
 </pre><div class="source-file"><em>object.h</em><br>
 in enum <em>ObjType</em></div>
 <pre class="insert">  <span class="a">OBJ_UPVALUE</span>
@@ -1082,7 +1082,7 @@ in enum <em>ObjType</em></div>
 <div class="source-file-narrow"><em>object.h</em>, in enum <em>ObjType</em></div>
 
 <p>And on the back side, a destructor-like function:</p>
-<div class="codehilite"><pre class="insert-before">      FREE(ObjString, object);
+<div class="codehilite" translate="no"><pre class="insert-before">      FREE(ObjString, object);
       break;
     }
 </pre><div class="source-file"><em>memory.c</em><br>
@@ -1098,7 +1098,7 @@ in <em>freeObject</em>()</div>
 the variable it references. Thus, the only thing to free is the ObjUpvalue
 itself.</p>
 <p>And, finally, to print:</p>
-<div class="codehilite"><pre class="insert-before">    case OBJ_STRING:
+<div class="codehilite" translate="no"><pre class="insert-before">    case OBJ_STRING:
       printf(&quot;%s&quot;, AS_CSTRING(value));
       break;
 </pre><div class="source-file"><em>object.c</em><br>
@@ -1118,7 +1118,7 @@ unhandled switch case, so here we are.</p>
 <h3><a href="#upvalues-in-closures" id="upvalues-in-closures"><small>25&#8202;.&#8202;3&#8202;.&#8202;1</small>Upvalues in closures</a></h3>
 <p>When I first introduced upvalues, I said each closure has an array of them.
 We&rsquo;ve finally worked our way back to implementing that.</p>
-<div class="codehilite"><pre class="insert-before">  ObjFunction* function;
+<div class="codehilite" translate="no"><pre class="insert-before">  ObjFunction* function;
 </pre><div class="source-file"><em>object.h</em><br>
 in struct <em>ObjClosure</em></div>
 <pre class="insert">  <span class="t">ObjUpvalue</span>** <span class="i">upvalues</span>;
@@ -1140,7 +1140,7 @@ array size after the closure&rsquo;s corresponding ObjFunction has already been 
 </aside>
 <p>When we create an ObjClosure, we allocate an upvalue array of the proper size,
 which we determined at compile time and stored in the ObjFunction.</p>
-<div class="codehilite"><pre class="insert-before">ObjClosure* newClosure(ObjFunction* function) {
+<div class="codehilite" translate="no"><pre class="insert-before">ObjClosure* newClosure(ObjFunction* function) {
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>newClosure</em>()</div>
 <pre class="insert">  <span class="t">ObjUpvalue</span>** <span class="i">upvalues</span> = <span class="a">ALLOCATE</span>(<span class="t">ObjUpvalue</span>*,
@@ -1159,7 +1159,7 @@ dance to please the (forthcoming) garbage collection deities. It ensures the
 memory manager never sees uninitialized memory.</p>
 <p>Then we store the array in the new closure, as well as copy the count over from
 the ObjFunction.</p>
-<div class="codehilite"><pre class="insert-before">  closure-&gt;function = function;
+<div class="codehilite" translate="no"><pre class="insert-before">  closure-&gt;function = function;
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>newClosure</em>()</div>
 <pre class="insert">  <span class="i">closure</span>-&gt;<span class="i">upvalues</span> = <span class="i">upvalues</span>;
@@ -1169,7 +1169,7 @@ in <em>newClosure</em>()</div>
 <div class="source-file-narrow"><em>object.c</em>, in <em>newClosure</em>()</div>
 
 <p>When we free an ObjClosure, we also free the upvalue array.</p>
-<div class="codehilite"><pre class="insert-before">    case OBJ_CLOSURE: {
+<div class="codehilite" translate="no"><pre class="insert-before">    case OBJ_CLOSURE: {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>freeObject</em>()</div>
 <pre class="insert">      <span class="t">ObjClosure</span>* <span class="i">closure</span> = (<span class="t">ObjClosure</span>*)<span class="i">object</span>;
@@ -1184,7 +1184,7 @@ array</em> containing pointers to those upvalues.</p>
 <p>We fill the upvalue array over in the interpreter when it creates a closure.
 This is where we walk through all of the operands after <code>OP_CLOSURE</code> to see what
 kind of upvalue each slot captures.</p>
-<div class="codehilite"><pre class="insert-before">        push(OBJ_VAL(closure));
+<div class="codehilite" translate="no"><pre class="insert-before">        push(OBJ_VAL(closure));
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">        <span class="k">for</span> (<span class="t">int</span> <span class="i">i</span> = <span class="n">0</span>; <span class="i">i</span> &lt; <span class="i">closure</span>-&gt;<span class="i">upvalueCount</span>; <span class="i">i</span>++) {
@@ -1218,7 +1218,7 @@ grab a pointer to the captured local&rsquo;s slot in the surrounding function&rs
 window. That window begins at <code>frame-&gt;slots</code>, which points to slot zero. Adding
 <code>index</code> offsets that to the local slot we want to capture. We pass that pointer
 here:</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>callValue</em>()</div>
 <pre><span class="k">static</span> <span class="t">ObjUpvalue</span>* <span class="i">captureUpvalue</span>(<span class="t">Value</span>* <span class="i">local</span>) {
   <span class="t">ObjUpvalue</span>* <span class="i">createdUpvalue</span> = <span class="i">newUpvalue</span>(<span class="i">local</span>);
@@ -1237,7 +1237,7 @@ array and initialize each one. When that completes, we have a new closure with
 an array full of upvalues pointing to variables.</p>
 <p>With that in hand, we can implement the instructions that work with those
 upvalues.</p>
-<div class="codehilite"><pre class="insert-before">      }
+<div class="codehilite" translate="no"><pre class="insert-before">      }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_GET_UPVALUE</span>: {
@@ -1252,7 +1252,7 @@ in <em>run</em>()</div>
 <p>The operand is the index into the current function&rsquo;s upvalue array. So we simply
 look up the corresponding upvalue and dereference its location pointer to read
 the value in that slot. Setting a variable is similar.</p>
-<div class="codehilite"><pre class="insert-before">      }
+<div class="codehilite" translate="no"><pre class="insert-before">      }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_SET_UPVALUE</span>: {
@@ -1278,7 +1278,7 @@ assigned value<span class="em">&mdash;</span>needs to remain on the stack for th
 </aside>
 <p>This is a milestone. As long as all of the variables remain on the stack, we
 have working closures. Try this:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">outer</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">outer</span>() {
   <span class="k">var</span> <span class="i">x</span> = <span class="s">&quot;outside&quot;</span>;
   <span class="k">fun</span> <span class="i">inner</span>() {
     <span class="k">print</span> <span class="i">x</span>;
@@ -1292,7 +1292,7 @@ have working closures. Try this:</p>
 <p>Of course, a key feature of closures is that they hold on to the variable as
 long as needed, even after the function that declares the variable has returned.
 Here&rsquo;s another example that <em>should</em> work:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">outer</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">outer</span>() {
   <span class="k">var</span> <span class="i">x</span> = <span class="s">&quot;outside&quot;</span>;
   <span class="k">fun</span> <span class="i">inner</span>() {
     <span class="k">print</span> <span class="i">x</span>;
@@ -1318,7 +1318,7 @@ Consider:</p>
 <aside name="academic">
 <p>If Lox didn&rsquo;t allow assignment, it <em>would</em> be an academic question.</p>
 </aside>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">globalSet</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">globalSet</span>;
 <span class="k">var</span> <span class="i">globalGet</span>;
 
 <span class="k">fun</span> <span class="i">main</span>() {
@@ -1412,7 +1412,7 @@ upvalue state.</p>
 capture, but not in the other direction. So we first need to add some extra
 tracking inside the existing Local struct so that we can tell if a given local
 is captured by a closure.</p>
-<div class="codehilite"><pre class="insert-before">  int depth;
+<div class="codehilite" translate="no"><pre class="insert-before">  int depth;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in struct <em>Local</em></div>
 <pre class="insert">  <span class="t">bool</span> <span class="i">isCaptured</span>;
@@ -1422,7 +1422,7 @@ in struct <em>Local</em></div>
 
 <p>This field is <code>true</code> if the local is captured by any later nested function
 declaration. Initially, all locals are not captured.</p>
-<div class="codehilite"><pre class="insert-before">  local-&gt;depth = -1;
+<div class="codehilite" translate="no"><pre class="insert-before">  local-&gt;depth = -1;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>addLocal</em>()</div>
 <pre class="insert">  <span class="i">local</span>-&gt;<span class="i">isCaptured</span> = <span class="k">false</span>;
@@ -1436,7 +1436,7 @@ compiler implicitly declares is not captured.</p>
 <p>Later in the book, it <em>will</em> become possible for a user to capture this
 variable. Just building some anticipation here.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">  local-&gt;depth = 0;
+<div class="codehilite" translate="no"><pre class="insert-before">  local-&gt;depth = 0;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>initCompiler</em>()</div>
 <pre class="insert">  <span class="i">local</span>-&gt;<span class="i">isCaptured</span> = <span class="k">false</span>;
@@ -1446,7 +1446,7 @@ in <em>initCompiler</em>()</div>
 
 <p>When resolving an identifier, if we end up creating an upvalue for a local
 variable, we mark it as captured.</p>
-<div class="codehilite"><pre class="insert-before">  if (local != -1) {
+<div class="codehilite" translate="no"><pre class="insert-before">  if (local != -1) {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>resolveUpvalue</em>()</div>
 <pre class="insert">    <span class="i">compiler</span>-&gt;<span class="i">enclosing</span>-&gt;<span class="i">locals</span>[<span class="i">local</span>].<span class="i">isCaptured</span> = <span class="k">true</span>;
@@ -1457,7 +1457,7 @@ in <em>resolveUpvalue</em>()</div>
 <p>Now, at the end of a block scope when the compiler emits code to free the stack
 slots for the locals, we can tell which ones need to get hoisted onto the heap.
 We&rsquo;ll use a new instruction for that.</p>
-<div class="codehilite"><pre class="insert-before">  while (current-&gt;localCount &gt; 0 &amp;&amp;
+<div class="codehilite" translate="no"><pre class="insert-before">  while (current-&gt;localCount &gt; 0 &amp;&amp;
          current-&gt;locals[current-&gt;localCount - 1].depth &gt;
             current-&gt;scopeDepth) {
 </pre><div class="source-file"><em>compiler.c</em><br>
@@ -1476,7 +1476,7 @@ replace 1 line</div>
 <p>The instruction requires no operand. We know that the variable will always be
 right on top of the stack at the point that this instruction executes. We
 declare the instruction.</p>
-<div class="codehilite"><pre class="insert-before">  OP_CLOSURE,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_CLOSURE,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_CLOSE_UPVALUE</span>,
@@ -1485,7 +1485,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>And add trivial disassembler support for it:</p>
-<div class="codehilite"><pre class="insert-before">    }
+<div class="codehilite" translate="no"><pre class="insert-before">    }
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OP_CLOSE_UPVALUE</span>:
@@ -1544,7 +1544,7 @@ we can exit the loop pretty early.</p>
 That suggests using a linked list instead of a dynamic array. Since we defined
 the ObjUpvalue struct ourselves, the easiest implementation is an intrusive list
 that puts the next pointer right inside the ObjUpvalue struct itself.</p>
-<div class="codehilite"><pre class="insert-before">  Value* location;
+<div class="codehilite" translate="no"><pre class="insert-before">  Value* location;
 </pre><div class="source-file"><em>object.h</em><br>
 in struct <em>ObjUpvalue</em></div>
 <pre class="insert">  <span class="k">struct</span> <span class="t">ObjUpvalue</span>* <span class="i">next</span>;
@@ -1554,7 +1554,7 @@ in struct <em>ObjUpvalue</em></div>
 
 <p>When we allocate an upvalue, it is not attached to any list yet so the link is
 <code>NULL</code>.</p>
-<div class="codehilite"><pre class="insert-before">  upvalue-&gt;location = slot;
+<div class="codehilite" translate="no"><pre class="insert-before">  upvalue-&gt;location = slot;
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>newUpvalue</em>()</div>
 <pre class="insert">  <span class="i">upvalue</span>-&gt;<span class="i">next</span> = <span class="a">NULL</span>;
@@ -1563,7 +1563,7 @@ in <em>newUpvalue</em>()</div>
 <div class="source-file-narrow"><em>object.c</em>, in <em>newUpvalue</em>()</div>
 
 <p>The VM owns the list, so the head pointer goes right inside the main VM struct.</p>
-<div class="codehilite"><pre class="insert-before">  Table strings;
+<div class="codehilite" translate="no"><pre class="insert-before">  Table strings;
 </pre><div class="source-file"><em>vm.h</em><br>
 in struct <em>VM</em></div>
 <pre class="insert">  <span class="t">ObjUpvalue</span>* <span class="i">openUpvalues</span>;
@@ -1572,7 +1572,7 @@ in struct <em>VM</em></div>
 <div class="source-file-narrow"><em>vm.h</em>, in struct <em>VM</em></div>
 
 <p>The list starts out empty.</p>
-<div class="codehilite"><pre class="insert-before">  vm.frameCount = 0;
+<div class="codehilite" translate="no"><pre class="insert-before">  vm.frameCount = 0;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>resetStack</em>()</div>
 <pre class="insert">  <span class="i">vm</span>.<span class="i">openUpvalues</span> = <span class="a">NULL</span>;
@@ -1583,7 +1583,7 @@ in <em>resetStack</em>()</div>
 <p>Starting with the first upvalue pointed to by the VM, each open upvalue points
 to the next open upvalue that references a local variable farther down the
 stack. This script, for example,</p>
-<div class="codehilite"><pre>{
+<div class="codehilite" translate="no"><pre>{
   <span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>;
   <span class="k">fun</span> <span class="i">f</span>() {
     <span class="k">print</span> <span class="i">a</span>;
@@ -1601,7 +1601,7 @@ stack. This script, for example,</p>
 <p>should produce a series of linked upvalues like so:</p><img src="image/closures/linked-list.png" alt="Three upvalues in a linked list."/>
 <p>Whenever we close over a local variable, before creating a new upvalue, we look
 for an existing one in the list.</p>
-<div class="codehilite"><pre class="insert-before">static ObjUpvalue* captureUpvalue(Value* local) {
+<div class="codehilite" translate="no"><pre class="insert-before">static ObjUpvalue* captureUpvalue(Value* local) {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>captureUpvalue</em>()</div>
 <pre class="insert">  <span class="t">ObjUpvalue</span>* <span class="i">prevUpvalue</span> = <span class="a">NULL</span>;
@@ -1649,7 +1649,7 @@ closing over, and thus there must not be an existing upvalue for it.</p>
 </ol>
 <p>In the first case, we&rsquo;re done and we&rsquo;ve returned. Otherwise, we create a new
 upvalue for our local slot and insert it into the list at the right location.</p>
-<div class="codehilite"><pre class="insert-before">  ObjUpvalue* createdUpvalue = newUpvalue(local);
+<div class="codehilite" translate="no"><pre class="insert-before">  ObjUpvalue* createdUpvalue = newUpvalue(local);
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>captureUpvalue</em>()</div>
 <pre class="insert">  <span class="i">createdUpvalue</span>-&gt;<span class="i">next</span> = <span class="i">upvalue</span>;
@@ -1691,7 +1691,7 @@ stack now.</p>
 <p>The compiler helpfully emits an <code>OP_CLOSE_UPVALUE</code> instruction to tell the VM
 exactly when a local variable should be hoisted onto the heap. Executing that
 instruction is the interpreter&rsquo;s responsibility.</p>
-<div class="codehilite"><pre class="insert-before">      }
+<div class="codehilite" translate="no"><pre class="insert-before">      }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_CLOSE_UPVALUE</span>:
@@ -1708,7 +1708,7 @@ That function is responsible for closing the upvalue and moving the local from
 the stack to the heap. After that, the VM is free to discard the stack slot,
 which it does by calling <code>pop()</code>.</p>
 <p>The fun stuff happens here:</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>captureUpvalue</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">closeUpvalues</span>(<span class="t">Value</span>* <span class="i">last</span>) {
   <span class="k">while</span> (<span class="i">vm</span>.<span class="i">openUpvalues</span> != <span class="a">NULL</span> &amp;&amp;
@@ -1746,7 +1746,7 @@ variable moves from the stack to the <code>closed</code> field, we simply update
 <p>We don&rsquo;t need to change how <code>OP_GET_UPVALUE</code> and <code>OP_SET_UPVALUE</code> are
 interpreted at all. That keeps them simple, which in turn keeps them fast. We do
 need to add the new field to ObjUpvalue, though.</p>
-<div class="codehilite"><pre class="insert-before">  Value* location;
+<div class="codehilite" translate="no"><pre class="insert-before">  Value* location;
 </pre><div class="source-file"><em>object.h</em><br>
 in struct <em>ObjUpvalue</em></div>
 <pre class="insert">  <span class="t">Value</span> <span class="i">closed</span>;
@@ -1756,7 +1756,7 @@ in struct <em>ObjUpvalue</em></div>
 
 <p>And we should zero it out when we create an ObjUpvalue so there&rsquo;s no
 uninitialized memory floating around.</p>
-<div class="codehilite"><pre class="insert-before">  ObjUpvalue* upvalue = ALLOCATE_OBJ(ObjUpvalue, OBJ_UPVALUE);
+<div class="codehilite" translate="no"><pre class="insert-before">  ObjUpvalue* upvalue = ALLOCATE_OBJ(ObjUpvalue, OBJ_UPVALUE);
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>newUpvalue</em>()</div>
 <pre class="insert">  <span class="i">upvalue</span>-&gt;<span class="i">closed</span> = <span class="a">NIL_VAL</span>;
@@ -1779,7 +1779,7 @@ function implicitly when it pops the call frame.</p>
 <p>This is the reason <code>closeUpvalues()</code> accepts a pointer to a stack slot. When a
 function returns, we call that same helper and pass in the first stack slot
 owned by the function.</p>
-<div class="codehilite"><pre class="insert-before">        Value result = pop();
+<div class="codehilite" translate="no"><pre class="insert-before">        Value result = pop();
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">        <span class="i">closeUpvalues</span>(<span class="i">frame</span>-&gt;<span class="i">slots</span>);
@@ -1864,7 +1864,7 @@ returned from that constructor.</p>
 share a reference to the same underlying storage location. This fact is visible
 when new values are assigned to the variable. Obviously, if two closures capture
 <em>different</em> variables, there is no sharing.</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">globalOne</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">globalOne</span>;
 <span class="k">var</span> <span class="i">globalTwo</span>;
 
 <span class="k">fun</span> <span class="i">main</span>() {
@@ -1891,7 +1891,7 @@ when new values are assigned to the variable. Obviously, if two closures capture
 </pre></div>
 <p>This prints &ldquo;one&rdquo; then &ldquo;two&rdquo;. In this example, it&rsquo;s pretty clear that the two
 <code>a</code> variables are different. But it&rsquo;s not always so obvious. Consider:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">globalOne</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">globalOne</span>;
 <span class="k">var</span> <span class="i">globalTwo</span>;
 
 <span class="k">fun</span> <span class="i">main</span>() {
@@ -1920,7 +1920,7 @@ variables? Is there only one <code>a</code> for the entire duration of the loop,
 each iteration get its own distinct <code>a</code> variable?</p>
 <p>The script here is strange and contrived, but this does show up in real code
 in languages that aren&rsquo;t as minimal as clox. Here&rsquo;s a JavaScript example:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">closures</span> = [];
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">closures</span> = [];
 <span class="k">for</span> (<span class="k">var</span> <span class="i">i</span> = <span class="n">1</span>; <span class="i">i</span> &lt;= <span class="n">2</span>; <span class="i">i</span>++) {
   <span class="i">closures</span>.<span class="i">push</span>(<span class="k">function</span> () { <span class="i">console</span>.<span class="i">log</span>(<span class="i">i</span>); });
 }
@@ -1941,7 +1941,7 @@ run forever.</p>
 <p>If you&rsquo;re familiar with JavaScript, you probably know that variables declared
 using <code>var</code> are implicitly <em>hoisted</em> to the surrounding function or top-level
 scope. It&rsquo;s as if you really wrote this:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">closures</span> = [];
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">closures</span> = [];
 <span class="k">var</span> <span class="i">i</span>;
 <span class="k">for</span> (<span class="i">i</span> = <span class="n">1</span>; <span class="i">i</span> &lt;= <span class="n">2</span>; <span class="i">i</span>++) {
   <span class="i">closures</span>.<span class="i">push</span>(<span class="k">function</span> () { <span class="i">console</span>.<span class="i">log</span>(<span class="i">i</span>); });
@@ -1952,7 +1952,7 @@ scope. It&rsquo;s as if you really wrote this:</p>
 </pre></div>
 <p>At that point, it&rsquo;s clearer that there is only a single <code>i</code>. Now consider if
 you change the program to use the newer <code>let</code> keyword:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">closures</span> = [];
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">closures</span> = [];
 <span class="k">for</span> (<span class="k">let</span> <span class="i">i</span> = <span class="n">1</span>; <span class="i">i</span> &lt;= <span class="n">2</span>; <span class="i">i</span>++) {
   <span class="i">closures</span>.<span class="i">push</span>(<span class="k">function</span> () { <span class="i">console</span>.<span class="i">log</span>(<span class="i">i</span>); });
 }
@@ -1965,7 +1965,7 @@ you change the program to use the newer <code>let</code> keyword:</p>
 it. The increment clause is <code>i++</code>. That looks very much like it is assigning to
 and mutating an existing variable, not creating a new one.</p>
 <p>Let&rsquo;s try some other languages. Here&rsquo;s Python:</p>
-<div class="codehilite"><pre><span class="i">closures</span> = []
+<div class="codehilite" translate="no"><pre><span class="i">closures</span> = []
 <span class="k">for</span> <span class="i">i</span> <span class="k">in</span> <span class="k">range</span>(<span class="n">1</span>, <span class="n">3</span>):
   <span class="i">closures</span>.<span class="i">append</span>(<span class="k">lambda</span>: <span class="k">print</span>(<span class="i">i</span>))
 
@@ -1979,7 +1979,7 @@ Unlike C, though, we don&rsquo;t exit the loop by incrementing <code>i</code> <e
 value, so this prints &ldquo;2&rdquo; twice.</p>
 <p>What about Ruby? Ruby has two typical ways to iterate numerically. Here&rsquo;s the
 classic imperative style:</p>
-<div class="codehilite"><pre><span class="i">closures</span> = []
+<div class="codehilite" translate="no"><pre><span class="i">closures</span> = []
 <span class="k">for</span> <span class="i">i</span> <span class="k">in</span> <span class="n">1</span>..<span class="n">2</span> <span class="k">do</span>
   <span class="i">closures</span> &lt;&lt; <span class="k">lambda</span> { <span class="i">puts</span> <span class="i">i</span> }
 <span class="k">end</span>
@@ -1989,7 +1989,7 @@ classic imperative style:</p>
 </pre></div>
 <p>This, like Python, prints &ldquo;2&rdquo; twice. But the more idiomatic Ruby style is using
 a higher-order <code>each()</code> method on range objects:</p>
-<div class="codehilite"><pre><span class="i">closures</span> = []
+<div class="codehilite" translate="no"><pre><span class="i">closures</span> = []
 (<span class="n">1</span>..<span class="n">2</span>).<span class="i">each</span> <span class="k">do</span> |<span class="i">i</span>|
   <span class="i">closures</span> &lt;&lt; <span class="k">lambda</span> { <span class="i">puts</span> <span class="i">i</span> }
 <span class="k">end</span>

--- a/site/compiling-expressions.html
+++ b/site/compiling-expressions.html
@@ -133,7 +133,7 @@ this old front end<span class="ellipse">&thinsp;.&thinsp;.&thinsp;.&nbsp;</span>
 through. You have to eat your vegetables before you get dessert. First, let&rsquo;s
 ditch that temporary scaffolding we wrote for testing the scanner and replace it
 with something more useful.</p>
-<div class="codehilite"><pre class="insert-before">InterpretResult interpret(const char* source) {
+<div class="codehilite" translate="no"><pre class="insert-before">InterpretResult interpret(const char* source) {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>interpret</em>()<br>
 replace 2 lines</div>
@@ -164,7 +164,7 @@ chunk.</p>
 <p>Otherwise, we send the completed chunk over to the VM to be executed. When the
 VM finishes, we free the chunk and we&rsquo;re done. As you can see, the signature to
 <code>compile()</code> is different now.</p>
-<div class="codehilite"><pre class="insert-before">#define clox_compiler_h
+<div class="codehilite" translate="no"><pre class="insert-before">#define clox_compiler_h
 
 </pre><div class="source-file"><em>compiler.h</em><br>
 replace 1 line</div>
@@ -180,7 +180,7 @@ replace 1 line</div>
 <p>We pass in the chunk where the compiler will write the code, and then
 <code>compile()</code> returns whether or not compilation succeeded. We make the same
 change to the signature in the implementation.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;scanner.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;scanner.h&quot;
 
 </pre><div class="source-file"><em>compiler.c</em><br>
 function <em>compile</em>()<br>
@@ -193,7 +193,7 @@ replace 1 line</div>
 <p>That call to <code>initScanner()</code> is the only line that survives this chapter. Rip
 out the temporary code we wrote to test the scanner and replace it with these
 three lines:</p>
-<div class="codehilite"><pre class="insert-before">  initScanner(source);
+<div class="codehilite" translate="no"><pre class="insert-before">  initScanner(source);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>compile</em>()<br>
 replace 13 lines</div>
@@ -267,7 +267,7 @@ particular grammar and output the right bytecode.</p>
 <h2><a href="#parsing-tokens" id="parsing-tokens"><small>17&#8202;.&#8202;2</small>Parsing Tokens</a></h2>
 <p>First up, the front half of the compiler. This function&rsquo;s name should sound
 familiar.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;scanner.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;scanner.h&quot;
 </pre><div class="source-file"><em>compiler.c</em></div>
 <pre class="insert">
 
@@ -294,7 +294,7 @@ leaves it up to the parser to report them. We do that here.</p>
 <p>We keep looping, reading tokens and reporting the errors, until we hit a
 non-error one or reach the end. That way, the rest of the parser sees only valid
 tokens. The current and previous token are stored in this struct:</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;scanner.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;scanner.h&quot;
 </pre><div class="source-file"><em>compiler.c</em></div>
 <pre class="insert">
 
@@ -316,7 +316,7 @@ compiler.</p>
 <h3><a href="#handling-syntax-errors" id="handling-syntax-errors"><small>17&#8202;.&#8202;2&#8202;.&#8202;1</small>Handling syntax errors</a></h3>
 <p>If the scanner hands us an error token, we need to actually tell the user. That
 happens using this:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after variable <em>parser</em></div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">errorAtCurrent</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">message</span>) {
   <span class="i">errorAt</span>(&amp;<span class="i">parser</span>.<span class="i">current</span>, <span class="i">message</span>);
@@ -328,7 +328,7 @@ add after variable <em>parser</em></div>
 the error occurred and forward it to <code>errorAt()</code>. More often, we&rsquo;ll report an
 error at the location of the token we just consumed, so we give the shorter name
 to this other function:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after variable <em>parser</em></div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">error</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">message</span>) {
   <span class="i">errorAt</span>(&amp;<span class="i">parser</span>.<span class="i">previous</span>, <span class="i">message</span>);
@@ -337,7 +337,7 @@ add after variable <em>parser</em></div>
 <div class="source-file-narrow"><em>compiler.c</em>, add after variable <em>parser</em></div>
 
 <p>The actual work happens here:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after variable <em>parser</em></div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">errorAt</span>(<span class="t">Token</span>* <span class="i">token</span>, <span class="k">const</span> <span class="t">char</span>* <span class="i">message</span>) {
   <span class="i">fprintf</span>(<span class="i">stderr</span>, <span class="s">&quot;[line %d] Error&quot;</span>, <span class="i">token</span>-&gt;<span class="i">line</span>);
@@ -360,7 +360,7 @@ add after variable <em>parser</em></div>
 human-readable. Then we print the error message itself. After that, we set this
 <code>hadError</code> flag. That records whether any errors occurred during compilation.
 This field also lives in the parser struct.</p>
-<div class="codehilite"><pre class="insert-before">  Token previous;
+<div class="codehilite" translate="no"><pre class="insert-before">  Token previous;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in struct <em>Parser</em></div>
 <pre class="insert">  <span class="t">bool</span> <span class="i">hadError</span>;
@@ -370,7 +370,7 @@ in struct <em>Parser</em></div>
 
 <p>Earlier I said that <code>compile()</code> should return <code>false</code> if an error occurred. Now
 we can make it do that.</p>
-<div class="codehilite"><pre class="insert-before">  consume(TOKEN_EOF, &quot;Expect end of expression.&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">  consume(TOKEN_EOF, &quot;Expect end of expression.&quot;);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>compile</em>()</div>
 <pre class="insert">  <span class="k">return</span> !<span class="i">parser</span>.<span class="i">hadError</span>;
@@ -392,7 +392,7 @@ mirrors. We add a flag to track whether we&rsquo;re currently in panic mode.</p>
 too easy to leak memory, forget to maintain invariants, or otherwise have a Very
 Bad Day.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">  bool hadError;
+<div class="codehilite" translate="no"><pre class="insert-before">  bool hadError;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in struct <em>Parser</em></div>
 <pre class="insert">  <span class="t">bool</span> <span class="i">panicMode</span>;
@@ -401,7 +401,7 @@ in struct <em>Parser</em></div>
 <div class="source-file-narrow"><em>compiler.c</em>, in struct <em>Parser</em></div>
 
 <p>When an error occurs, we set it.</p>
-<div class="codehilite"><pre class="insert-before">static void errorAt(Token* token, const char* message) {
+<div class="codehilite" translate="no"><pre class="insert-before">static void errorAt(Token* token, const char* message) {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>errorAt</em>()</div>
 <pre class="insert">  <span class="i">parser</span>.<span class="i">panicMode</span> = <span class="k">true</span>;
@@ -413,7 +413,7 @@ in <em>errorAt</em>()</div>
 occurred. The bytecode will never get executed, so it&rsquo;s harmless to keep on
 trucking. The trick is that while the panic mode flag is set, we simply suppress
 any other errors that get detected.</p>
-<div class="codehilite"><pre class="insert-before">static void errorAt(Token* token, const char* message) {
+<div class="codehilite" translate="no"><pre class="insert-before">static void errorAt(Token* token, const char* message) {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>errorAt</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">parser</span>.<span class="i">panicMode</span>) <span class="k">return</span>;
@@ -426,7 +426,7 @@ know because the errors all get swallowed. Panic mode ends when the parser
 reaches a synchronization point. For Lox, we chose statement boundaries, so when
 we later add those to our compiler, we&rsquo;ll clear the flag there.</p>
 <p>These new fields need to be initialized.</p>
-<div class="codehilite"><pre class="insert-before">  initScanner(source);
+<div class="codehilite" translate="no"><pre class="insert-before">  initScanner(source);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>compile</em>()</div>
 <pre class="insert">
@@ -439,7 +439,7 @@ in <em>compile</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>compile</em>()</div>
 
 <p>And to display the errors, we need a standard header.</p>
-<div class="codehilite"><pre class="insert-before">#include &lt;stdio.h&gt;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &lt;stdio.h&gt;
 </pre><div class="source-file"><em>compiler.c</em></div>
 <pre class="insert"><span class="a">#include &lt;stdlib.h&gt;</span>
 </pre><pre class="insert-after">
@@ -449,7 +449,7 @@ in <em>compile</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em></div>
 
 <p>There&rsquo;s one last parsing function, another old friend from jlox.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>advance</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">consume</span>(<span class="t">TokenType</span> <span class="i">type</span>, <span class="k">const</span> <span class="t">char</span>* <span class="i">message</span>) {
   <span class="k">if</span> (<span class="i">parser</span>.<span class="i">current</span>.<span class="i">type</span> == <span class="i">type</span>) {
@@ -470,7 +470,7 @@ function is the foundation of most syntax errors in the compiler.</p>
 <p>After we parse and understand a piece of the user&rsquo;s program, the next step is to
 translate that to a series of bytecode instructions. It starts with the easiest
 possible step: appending a single byte to the chunk.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>consume</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">emitByte</span>(<span class="t">uint8_t</span> <span class="i">byte</span>) {
   <span class="i">writeChunk</span>(<span class="i">currentChunk</span>(), <span class="i">byte</span>, <span class="i">parser</span>.<span class="i">previous</span>.<span class="i">line</span>);
@@ -484,7 +484,7 @@ It sends in the previous token&rsquo;s line information so that runtime errors a
 associated with that line.</p>
 <p>The chunk that we&rsquo;re writing gets passed into <code>compile()</code>, but it needs to make
 its way to <code>emitByte()</code>. To do that, we rely on this intermediary function:</p>
-<div class="codehilite"><pre class="insert-before">Parser parser;
+<div class="codehilite" translate="no"><pre class="insert-before">Parser parser;
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after variable <em>parser</em></div>
 <pre class="insert"><span class="t">Chunk</span>* <span class="i">compilingChunk</span>;
@@ -502,7 +502,7 @@ other global state. Later, when we start compiling user-defined functions, the
 notion of &ldquo;current chunk&rdquo; gets more complicated. To avoid having to go back and
 change a lot of code, I encapsulate that logic in the <code>currentChunk()</code> function.</p>
 <p>We initialize this new module variable before we write any bytecode:</p>
-<div class="codehilite"><pre class="insert-before">bool compile(const char* source, Chunk* chunk) {
+<div class="codehilite" translate="no"><pre class="insert-before">bool compile(const char* source, Chunk* chunk) {
   initScanner(source);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>compile</em>()</div>
@@ -514,7 +514,7 @@ in <em>compile</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>compile</em>()</div>
 
 <p>Then, at the very end, when we&rsquo;re done compiling the chunk, we wrap things up.</p>
-<div class="codehilite"><pre class="insert-before">  consume(TOKEN_EOF, &quot;Expect end of expression.&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">  consume(TOKEN_EOF, &quot;Expect end of expression.&quot;);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>compile</em>()</div>
 <pre class="insert">  <span class="i">endCompiler</span>();
@@ -523,7 +523,7 @@ in <em>compile</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>compile</em>()</div>
 
 <p>That calls this:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>emitByte</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">endCompiler</span>() {
   <span class="i">emitReturn</span>();
@@ -535,7 +535,7 @@ add after <em>emitByte</em>()</div>
 parse, compile, and execute a single expression, then print the result. To print
 that value, we are temporarily using the <code>OP_RETURN</code> instruction. So we have the
 compiler add one of those to the end of the chunk.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>emitByte</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">emitReturn</span>() {
   <span class="i">emitByte</span>(<span class="a">OP_RETURN</span>);
@@ -544,7 +544,7 @@ add after <em>emitByte</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, add after <em>emitByte</em>()</div>
 
 <p>While we&rsquo;re here in the back end we may as well make our lives easier.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>emitByte</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">emitBytes</span>(<span class="t">uint8_t</span> <span class="i">byte1</span>, <span class="t">uint8_t</span> <span class="i">byte2</span>) {
   <span class="i">emitByte</span>(<span class="i">byte1</span>);
@@ -559,7 +559,7 @@ a one-byte operand that it&rsquo;s worth defining this convenience function.</p>
 <p>We&rsquo;ve assembled our parsing and code generation utility functions. The missing
 piece is the code in the middle that connects those together.</p><img src="image/compiling-expressions/mystery.png" alt="Parsing functions on the left, bytecode emitting functions on the right. What goes in the middle?" />
 <p>The only step in <code>compile()</code> that we have left to implement is this function:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>endCompiler</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">expression</span>() {
   <span class="c">// What goes here?</span>
@@ -589,7 +589,7 @@ array of function pointers. The indexes in the array correspond to the
 an expression of that token type.</p>
 <p>To compile number literals, we store a pointer to the following function at the
 <code>TOKEN_NUMBER</code> index in the array.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>endCompiler</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">number</span>() {
   <span class="t">double</span> <span class="i">value</span> = <span class="i">strtod</span>(<span class="i">parser</span>.<span class="i">previous</span>.<span class="i">start</span>, <span class="a">NULL</span>);
@@ -602,7 +602,7 @@ add after <em>endCompiler</em>()</div>
 stored in <code>previous</code>. We take that lexeme and use the C standard library to
 convert it to a double value. Then we generate the code to load that value using
 this function:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>emitReturn</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">emitConstant</span>(<span class="t">Value</span> <span class="i">value</span>) {
   <span class="i">emitBytes</span>(<span class="a">OP_CONSTANT</span>, <span class="i">makeConstant</span>(<span class="i">value</span>));
@@ -613,7 +613,7 @@ add after <em>emitReturn</em>()</div>
 <p>First, we add the value to the constant table, then we emit an <code>OP_CONSTANT</code>
 instruction that pushes it onto the stack at runtime. To insert an entry in the
 constant table, we rely on:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>emitReturn</em>()</div>
 <pre><span class="k">static</span> <span class="t">uint8_t</span> <span class="i">makeConstant</span>(<span class="t">Value</span> <span class="i">value</span>) {
   <span class="t">int</span> <span class="i">constant</span> = <span class="i">addConstant</span>(<span class="i">currentChunk</span>(), <span class="i">value</span>);
@@ -653,7 +653,7 @@ know we must be looking at a parenthesized grouping expression.</p>
 <p>It turns out our function pointer array handles those too. The parsing function
 for an expression type can consume any additional tokens that it wants to, just
 like in a regular recursive descent parser. Here&rsquo;s how parentheses work:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>endCompiler</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">grouping</span>() {
   <span class="i">expression</span>();
@@ -677,7 +677,7 @@ inner call to <code>expression()</code> takes care of generating bytecode for th
 expression inside the parentheses.</p>
 <h3><a href="#unary-negation" id="unary-negation"><small>17&#8202;.&#8202;4&#8202;.&#8202;3</small>Unary negation</a></h3>
 <p>Unary minus is also a prefix expression, so it works with our model too.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>number</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">unary</span>() {
   <span class="t">TokenType</span> <span class="i">operatorType</span> = <span class="i">parser</span>.<span class="i">previous</span>.<span class="i">type</span>;
@@ -720,7 +720,7 @@ current token when the bytecode is written is <em>not</em> the <code>-</code> to
 doesn&rsquo;t matter, except that we use that token for the line number to associate
 with that instruction.</p>
 <p>This means if you have a multi-line negation expression, like:</p>
-<div class="codehilite"><pre><span class="k">print</span> -
+<div class="codehilite" translate="no"><pre><span class="k">print</span> -
   <span class="k">true</span>;
 </pre></div>
 <p>Then the runtime error will be reported on the wrong line. Here, it would show
@@ -732,7 +732,7 @@ that into <code>emitByte()</code>, but I wanted to keep things simple for the bo
 calls will parse any expression for the operand, regardless of precedence. Once
 we add binary operators and other syntax, that will do the wrong thing.
 Consider:</p>
-<div class="codehilite"><pre>-<span class="i">a</span>.<span class="i">b</span> + <span class="i">c</span>;
+<div class="codehilite" translate="no"><pre>-<span class="i">a</span>.<span class="i">b</span> + <span class="i">c</span>;
 </pre></div>
 <p>Here, the operand to <code>-</code> should be just the <code>a.b</code> expression, not the entire
 <code>a.b + c</code>. But if <code>unary()</code> calls <code>expression()</code>, the latter will happily chew
@@ -748,7 +748,7 @@ that included the rest of the precedence table.</p>
 Each only parses exactly one type of expression. They don&rsquo;t cascade to include
 higher-precedence expression types too. We need a different solution, and it
 looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>unary</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">parsePrecedence</span>(<span class="t">Precedence</span> <span class="i">precedence</span>) {
   <span class="c">// What goes here?</span>
@@ -762,7 +762,7 @@ to get through before we can write the body of this function, but you can
 probably guess that it will use that table of parsing function pointers I&rsquo;ve
 been talking about. For now, don&rsquo;t worry too much about how it works. In order
 to take the &ldquo;precedence&rdquo; as a parameter, we define it numerically.</p>
-<div class="codehilite"><pre class="insert-before">} Parser;
+<div class="codehilite" translate="no"><pre class="insert-before">} Parser;
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after struct <em>Parser</em></div>
 <pre class="insert">
@@ -790,7 +790,7 @@ Parser parser;
 C implicitly gives successively larger numbers for enums, this means that
 <code>PREC_CALL</code> is numerically larger than <code>PREC_UNARY</code>. For example, say the
 compiler is sitting on a chunk of code like:</p>
-<div class="codehilite"><pre>-<span class="i">a</span>.<span class="i">b</span> + <span class="i">c</span>
+<div class="codehilite" translate="no"><pre>-<span class="i">a</span>.<span class="i">b</span> + <span class="i">c</span>
 </pre></div>
 <p>If we call <code>parsePrecedence(PREC_ASSIGNMENT)</code>, then it will parse the entire
 expression because <code>+</code> has higher precedence than assignment. If instead we
@@ -799,7 +799,7 @@ It doesn&rsquo;t keep going through the <code>+</code> because the addition has 
 than unary operators.</p>
 <p>With this function in hand, it&rsquo;s a snap to fill in the missing body for
 <code>expression()</code>.</p>
-<div class="codehilite"><pre class="insert-before">static void expression() {
+<div class="codehilite" translate="no"><pre class="insert-before">static void expression() {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>expression</em>()<br>
 replace 1 line</div>
@@ -811,7 +811,7 @@ replace 1 line</div>
 <p>We simply parse the lowest precedence level, which subsumes all of the
 higher-precedence expressions too. Now, to compile the operand for a unary
 expression, we call this new function and limit it to the appropriate level:</p>
-<div class="codehilite"><pre class="insert-before">  // Compile the operand.
+<div class="codehilite" translate="no"><pre class="insert-before">  // Compile the operand.
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>unary</em>()<br>
 replace 1 line</div>
@@ -837,7 +837,7 @@ first token. With infix expressions, we don&rsquo;t know we&rsquo;re in the midd
 binary operator until <em>after</em> we&rsquo;ve parsed its left operand and then stumbled
 onto the operator token in the middle.</p>
 <p>Here&rsquo;s an example:</p>
-<div class="codehilite"><pre><span class="n">1</span> + <span class="n">2</span>
+<div class="codehilite" translate="no"><pre><span class="n">1</span> + <span class="n">2</span>
 </pre></div>
 <p>Let&rsquo;s walk through trying to compile it with what we know so far:</p>
 <ol>
@@ -867,7 +867,7 @@ function pointers. One column associates prefix parser functions with token
 types. The second column associates infix parser functions with token types.</p>
 <p>The function we will use as the infix parser for <code>TOKEN_PLUS</code>, <code>TOKEN_MINUS</code>,
 <code>TOKEN_STAR</code>, and <code>TOKEN_SLASH</code> is this:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>endCompiler</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">binary</span>() {
   <span class="t">TokenType</span> <span class="i">operatorType</span> = <span class="i">parser</span>.<span class="i">previous</span>.<span class="i">type</span>;
@@ -903,7 +903,7 @@ result.</p>
 <p>The code that probably caught your eye here is that <code>getRule()</code> line. When we
 parse the right-hand operand, we again need to worry about precedence. Take an
 expression like:</p>
-<div class="codehilite"><pre><span class="n">2</span> * <span class="n">3</span> + <span class="n">4</span>
+<div class="codehilite" translate="no"><pre><span class="n">2</span> * <span class="n">3</span> + <span class="n">4</span>
 </pre></div>
 <p>When we parse the right operand of the <code>*</code> expression, we need to just capture
 <code>3</code>, and not <code>3 + 4</code>, because <code>+</code> is lower precedence than <code>*</code>. We could define
@@ -916,18 +916,18 @@ dynamically with this <code>getRule()</code> thing we&rsquo;ll get to soon. Usin
 <aside name="higher">
 <p>We use one <em>higher</em> level of precedence for the right operand because the binary
 operators are left-associative. Given a series of the <em>same</em> operator, like:</p>
-<div class="codehilite"><pre><span class="n">1</span> + <span class="n">2</span> + <span class="n">3</span> + <span class="n">4</span>
+<div class="codehilite" translate="no"><pre><span class="n">1</span> + <span class="n">2</span> + <span class="n">3</span> + <span class="n">4</span>
 </pre></div>
 <p>We want to parse it like:</p>
-<div class="codehilite"><pre>((<span class="n">1</span> + <span class="n">2</span>) + <span class="n">3</span>) + <span class="n">4</span>
+<div class="codehilite" translate="no"><pre>((<span class="n">1</span> + <span class="n">2</span>) + <span class="n">3</span>) + <span class="n">4</span>
 </pre></div>
 <p>Thus, when parsing the right-hand operand to the first <code>+</code>, we want to consume
 the <code>2</code>, but not the rest, so we use one level above <code>+</code>&rsquo;s precedence. But if
 our operator was <em>right</em>-associative, this would be wrong. Given:</p>
-<div class="codehilite"><pre><span class="i">a</span> = <span class="i">b</span> = <span class="i">c</span> = <span class="i">d</span>
+<div class="codehilite" translate="no"><pre><span class="i">a</span> = <span class="i">b</span> = <span class="i">c</span> = <span class="i">d</span>
 </pre></div>
 <p>Since assignment is right-associative, we want to parse it as:</p>
-<div class="codehilite"><pre><span class="i">a</span> = (<span class="i">b</span> = (<span class="i">c</span> = <span class="i">d</span>))
+<div class="codehilite" translate="no"><pre><span class="i">a</span> = (<span class="i">b</span> = (<span class="i">c</span> = <span class="i">d</span>))
 </pre></div>
 <p>To enable that, we would call <code>parsePrecedence()</code> with the <em>same</em> precedence as
 the current operator.</p>
@@ -959,7 +959,7 @@ given token because all prefix operators in Lox have the same precedence.</p>
 </aside>
 <p>We wrap these three properties in a little struct which represents a single row
 in the parser table.</p>
-<div class="codehilite"><pre class="insert-before">} Precedence;
+<div class="codehilite" translate="no"><pre class="insert-before">} Precedence;
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after enum <em>Precedence</em></div>
 <pre class="insert">
@@ -982,7 +982,7 @@ type that takes no arguments and returns nothing.</p>
 typedef. I understand the intent behind the syntax<span class="em">&mdash;</span>the whole &ldquo;declaration
 reflects use&rdquo; thing<span class="em">&mdash;</span>but I think it was a failed syntactic experiment.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">} Precedence;
+<div class="codehilite" translate="no"><pre class="insert-before">} Precedence;
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after enum <em>Precedence</em></div>
 <pre class="insert">
@@ -996,7 +996,7 @@ typedef struct {
 
 <p>The table that drives our whole parser is an array of ParseRules. We&rsquo;ve been
 talking about it forever, and finally you get to see it.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>unary</em>()</div>
 <pre><span class="t">ParseRule</span> <span class="i">rules</span>[] = {
   [<span class="a">TOKEN_LEFT_PAREN</span>]    = {<span class="i">grouping</span>, <span class="a">NULL</span>,   <span class="a">PREC_NONE</span>},
@@ -1065,7 +1065,7 @@ to see which tokens are in use by the grammar and which are available.</p>
 <p>Now that we have the table, we are finally ready to write the code that uses it.
 This is where our Pratt parser comes to life. The easiest function to define is
 <code>getRule()</code>.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>parsePrecedence</em>()</div>
 <pre><span class="k">static</span> <span class="t">ParseRule</span>* <span class="i">getRule</span>(<span class="t">TokenType</span> <span class="i">type</span>) {
   <span class="k">return</span> &amp;<span class="i">rules</span>[<span class="i">type</span>];
@@ -1087,7 +1087,7 @@ recursive, so let&rsquo;s get them all out of the way.</p>
 <p>This is what happens when you write your VM in a language that was designed to
 be compiled on a PDP-11.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">  emitReturn();
+<div class="codehilite" translate="no"><pre class="insert-before">  emitReturn();
 }
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after <em>endCompiler</em>()</div>
@@ -1108,7 +1108,7 @@ worry, though, if you get it wrong, the C compiler will be happy to tell you.</p
 <p>Now we&rsquo;re getting to the fun stuff. The maestro that orchestrates all of the
 parsing functions we&rsquo;ve defined is <code>parsePrecedence()</code>. Let&rsquo;s start with parsing
 prefix expressions.</p>
-<div class="codehilite"><pre class="insert-before">static void parsePrecedence(Precedence precedence) {
+<div class="codehilite" translate="no"><pre class="insert-before">static void parsePrecedence(Precedence precedence) {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>parsePrecedence</em>()<br>
 replace 1 line</div>
@@ -1132,7 +1132,7 @@ prefix parser compiles the rest of the prefix expression, consuming any other
 tokens it needs, and returns back here. Infix expressions are where it gets
 interesting since precedence comes into play. The implementation is remarkably
 simple.</p>
-<div class="codehilite"><pre class="insert-before">  prefixRule();
+<div class="codehilite" translate="no"><pre class="insert-before">  prefixRule();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>parsePrecedence</em>()</div>
 <pre class="insert">
@@ -1191,7 +1191,7 @@ dumping the chunk once the compiler finishes. We had some temporary logging
 earlier when we hand-authored the chunk. Now we&rsquo;ll put in some real code so that
 we can enable it whenever we want.</p>
 <p>Since this isn&rsquo;t for end users, we hide it behind a flag.</p>
-<div class="codehilite"><pre class="insert-before">#include &lt;stdint.h&gt;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &lt;stdint.h&gt;
 
 </pre><div class="source-file"><em>common.h</em></div>
 <pre class="insert"><span class="a">#define DEBUG_PRINT_CODE</span>
@@ -1201,7 +1201,7 @@ we can enable it whenever we want.</p>
 
 <p>When that flag is defined, we use our existing &ldquo;debug&rdquo; module to print out the
 chunk&rsquo;s bytecode.</p>
-<div class="codehilite"><pre class="insert-before">  emitReturn();
+<div class="codehilite" translate="no"><pre class="insert-before">  emitReturn();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>endCompiler</em>()</div>
 <pre class="insert"><span class="a">#ifdef DEBUG_PRINT_CODE</span>
@@ -1218,7 +1218,7 @@ compiler keeps on going but it&rsquo;s in kind of a weird state and might produc
 broken code. That&rsquo;s harmless because it won&rsquo;t get executed, but we&rsquo;ll just
 confuse ourselves if we try to read it.</p>
 <p>Finally, to access <code>disassembleChunk()</code>, we need to include its header.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;scanner.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;scanner.h&quot;
 </pre><div class="source-file"><em>compiler.c</em></div>
 <pre class="insert">
 
@@ -1245,7 +1245,7 @@ but the foundation is in place.</p>
 <p>To really understand the parser, you need to see how execution threads
 through the interesting parsing functions<span class="em">&mdash;</span><code>parsePrecedence()</code> and the
 parser functions stored in the table. Take this (strange) expression:</p>
-<div class="codehilite"><pre>(-<span class="n">1</span> + <span class="n">2</span>) * <span class="n">3</span> - -<span class="n">4</span>
+<div class="codehilite" translate="no"><pre>(-<span class="n">1</span> + <span class="n">2</span>) * <span class="n">3</span> - -<span class="n">4</span>
 </pre></div>
 <p>Write a trace of how those functions are called. Show the order they are
 called, which calls which, and the arguments passed to them.</p>

--- a/site/control-flow.html
+++ b/site/control-flow.html
@@ -201,7 +201,7 @@ only operator in C that takes three operands.</p>
 <p>For simplicity&rsquo;s sake, Lox doesn&rsquo;t have a conditional operator, so let&rsquo;s get our
 <code>if</code> statement on. Our statement grammar gets a new production.</p>
 <p><span name="semicolon"></span></p>
-<div class="codehilite"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
+<div class="codehilite" translate="no"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
                | <span class="i">ifStmt</span>
                | <span class="i">printStmt</span>
                | <span class="i">block</span> ;
@@ -219,7 +219,7 @@ be one that ends in a semicolon.</p>
 if the condition is truthy. Optionally, it may also have an <code>else</code> keyword and a
 statement to execute if the condition is falsey. The <span name="if-ast">syntax
 tree node</span> has fields for each of those three pieces.</p>
-<div class="codehilite"><pre class="insert-before">      &quot;Expression : Expr expression&quot;,
+<div class="codehilite" translate="no"><pre class="insert-before">      &quot;Expression : Expr expression&quot;,
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;If         : Expr condition, Stmt thenBranch,&quot;</span> +
@@ -233,7 +233,7 @@ in <em>main</em>()</div>
 </aside>
 <p>Like other statements, the parser recognizes an <code>if</code> statement by the leading
 <code>if</code> keyword.</p>
-<div class="codehilite"><pre class="insert-before">  private Stmt statement() {
+<div class="codehilite" translate="no"><pre class="insert-before">  private Stmt statement() {
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">match</span>(<span class="i">IF</span>)) <span class="k">return</span> <span class="i">ifStatement</span>();
@@ -242,7 +242,7 @@ in <em>statement</em>()</div>
 <div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>statement</em>()</div>
 
 <p>When it finds one, it calls this new method to parse the rest:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>statement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">ifStatement</span>() {
     <span class="i">consume</span>(<span class="i">LEFT_PAREN</span>, <span class="s">&quot;Expect &#39;(&#39; after &#39;if&#39;.&quot;</span>);
@@ -277,7 +277,7 @@ clause by looking for the preceding <code>else</code> keyword. If there isn&rsqu
 <code>elseBranch</code> field in the syntax tree is <code>null</code>.</p>
 <p>That seemingly innocuous optional else has, in fact, opened up an ambiguity in
 our grammar. Consider:</p>
-<div class="codehilite"><pre><span class="k">if</span> (<span class="i">first</span>) <span class="k">if</span> (<span class="i">second</span>) <span class="i">whenTrue</span>(); <span class="k">else</span> <span class="i">whenFalse</span>();
+<div class="codehilite" translate="no"><pre><span class="k">if</span> (<span class="i">first</span>) <span class="k">if</span> (<span class="i">second</span>) <span class="i">whenTrue</span>(); <span class="k">else</span> <span class="i">whenFalse</span>();
 </pre></div>
 <p>Here&rsquo;s the riddle: Which <code>if</code> statement does that else clause belong to? This
 isn&rsquo;t just a theoretical question about how we notate our grammar. It actually
@@ -312,7 +312,7 @@ precedes it.</p>
 for an <code>else</code> before returning, the innermost call to a nested series will claim
 the else clause for itself before returning to the outer <code>if</code> statements.</p>
 <p>Syntax in hand, we are ready to interpret.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitExpressionStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitIfStmt</span>(<span class="t">Stmt</span>.<span class="t">If</span> <span class="i">stmt</span>) {
@@ -342,7 +342,7 @@ operators that are technically control flow constructs<span class="em">&mdash;</
 <p>These aren&rsquo;t like other binary operators because they <strong>short-circuit</strong>. If,
 after evaluating the left operand, we know what the result of the logical
 expression must be, we don&rsquo;t evaluate the right operand. For example:</p>
-<div class="codehilite"><pre><span class="k">false</span> <span class="k">and</span> <span class="i">sideEffect</span>();
+<div class="codehilite" translate="no"><pre><span class="k">false</span> <span class="k">and</span> <span class="i">sideEffect</span>();
 </pre></div>
 <p>For an <code>and</code> expression to evaluate to something truthy, both operands must be
 truthy. We can see as soon as we evaluate the left <code>false</code> operand that that
@@ -357,7 +357,7 @@ right between <code>assignment</code> and <code>equality</code>.</p>
 <p>I&rsquo;ve always wondered why they don&rsquo;t have the same precedence, like the various
 comparison or equality operators do.</p>
 </aside>
-<div class="codehilite"><pre><span class="i">expression</span>     → <span class="i">assignment</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">expression</span>     → <span class="i">assignment</span> ;
 <span class="i">assignment</span>     → <span class="t">IDENTIFIER</span> <span class="s">&quot;=&quot;</span> <span class="i">assignment</span>
                | <span class="i">logic_or</span> ;
 <span class="i">logic_or</span>       → <span class="i">logic_and</span> ( <span class="s">&quot;or&quot;</span> <span class="i">logic_and</span> )* ;
@@ -377,7 +377,7 @@ check to see if the operator is one of the logical operators and use a different
 code path to handle the short circuiting. I think it&rsquo;s cleaner to define a <span
 name="logical-ast">new class</span> for these operators so that they get their
 own visit method.</p>
-<div class="codehilite"><pre class="insert-before">      &quot;Literal  : Object value&quot;,
+<div class="codehilite" translate="no"><pre class="insert-before">      &quot;Literal  : Object value&quot;,
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Logical  : Expr left, Token operator, Expr right&quot;</span>,
@@ -390,7 +390,7 @@ in <em>main</em>()</div>
 </aside>
 <p>To weave the new expressions into the parser, we first change the parsing code
 for assignment to call <code>or()</code>.</p>
-<div class="codehilite"><pre class="insert-before">  private Expr assignment() {
+<div class="codehilite" translate="no"><pre class="insert-before">  private Expr assignment() {
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>assignment</em>()<br>
 replace 1 line</div>
@@ -402,7 +402,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>assignment</em>(), replace 1 line</div>
 
 <p>The code to parse a series of <code>or</code> expressions mirrors other binary operators.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>assignment</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">or</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">and</span>();
@@ -419,7 +419,7 @@ add after <em>assignment</em>()</div>
 <div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>assignment</em>()</div>
 
 <p>Its operands are the next higher level of precedence, the new <code>and</code> expression.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>or</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">and</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">equality</span>();
@@ -437,7 +437,7 @@ add after <em>or</em>()</div>
 
 <p>That calls <code>equality()</code> for its operands, and with that, the expression parser
 is all tied back together again. We&rsquo;re ready to interpret.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitLiteralExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitLogicalExpr</span>(<span class="t">Expr</span>.<span class="t">Logical</span> <span class="i">expr</span>) {
@@ -465,7 +465,7 @@ result. Instead of promising to literally return <code>true</code> or <code>fals
 operator merely guarantees it will return a value with appropriate truthiness.</p>
 <p>Fortunately, we have values with proper truthiness right at hand<span class="em">&mdash;</span>the results
 of the operands themselves. So we use those. For example:</p>
-<div class="codehilite"><pre><span class="k">print</span> <span class="s">&quot;hi&quot;</span> <span class="k">or</span> <span class="n">2</span>; <span class="c">// &quot;hi&quot;.</span>
+<div class="codehilite" translate="no"><pre><span class="k">print</span> <span class="s">&quot;hi&quot;</span> <span class="k">or</span> <span class="n">2</span>; <span class="c">// &quot;hi&quot;.</span>
 <span class="k">print</span> <span class="k">nil</span> <span class="k">or</span> <span class="s">&quot;yes&quot;</span>; <span class="c">// &quot;yes&quot;.</span>
 </pre></div>
 <p>On the first line, <code>"hi"</code> is truthy, so the <code>or</code> short-circuits and returns
@@ -477,7 +477,7 @@ reference to<span class="ellipse">&thinsp;.&thinsp;.&thinsp;.&nbsp;</span>oh, fo
 <h2><a href="#while-loops" id="while-loops"><small>9&#8202;.&#8202;4</small>While Loops</a></h2>
 <p>Lox features two looping control flow statements, <code>while</code> and <code>for</code>. The <code>while</code>
 loop is the simpler one, so we&rsquo;ll start there. Its grammar is the same as in C.</p>
-<div class="codehilite"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
+<div class="codehilite" translate="no"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
                | <span class="i">ifStmt</span>
                | <span class="i">printStmt</span>
                | <span class="i">whileStmt</span>
@@ -489,7 +489,7 @@ loop is the simpler one, so we&rsquo;ll start there. Its grammar is the same as 
 while. It takes a <code>while</code> keyword, followed by a parenthesized condition
 expression, then a statement for the body. That new grammar rule gets a <span
 name="while-ast">syntax tree node</span>.</p>
-<div class="codehilite"><pre class="insert-before">      &quot;Print      : Expr expression&quot;,
+<div class="codehilite" translate="no"><pre class="insert-before">      &quot;Print      : Expr expression&quot;,
 </pre><pre class="insert-before">      <span class="s">&quot;Var        : Token name, Expr initializer&quot;</span><span class="insert-comma">,</span>
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()<br>
@@ -508,7 +508,7 @@ make it clear that the condition is an expression and the body is a statement.</
 <p>Over in the parser, we follow the same process we used for <code>if</code> statements.
 First, we add another case in <code>statement()</code> to detect and match the leading
 keyword.</p>
-<div class="codehilite"><pre class="insert-before">    if (match(PRINT)) return printStatement();
+<div class="codehilite" translate="no"><pre class="insert-before">    if (match(PRINT)) return printStatement();
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">match</span>(<span class="i">WHILE</span>)) <span class="k">return</span> <span class="i">whileStatement</span>();
@@ -517,7 +517,7 @@ in <em>statement</em>()</div>
 <div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>statement</em>()</div>
 
 <p>That delegates the real work to this method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>varDeclaration</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">whileStatement</span>() {
     <span class="i">consume</span>(<span class="i">LEFT_PAREN</span>, <span class="s">&quot;Expect &#39;(&#39; after &#39;while&#39;.&quot;</span>);
@@ -532,7 +532,7 @@ add after <em>varDeclaration</em>()</div>
 
 <p>The grammar is dead simple and this is a straight translation of it to Java.
 Speaking of translating straight to Java, here&rsquo;s how we execute the new syntax:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitVarStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitWhileStmt</span>(<span class="t">Stmt</span>.<span class="t">While</span> <span class="i">stmt</span>) {
@@ -551,10 +551,10 @@ the source code.</p>
 <h2><a href="#for-loops" id="for-loops"><small>9&#8202;.&#8202;5</small>For Loops</a></h2>
 <p>We&rsquo;re down to the last control flow construct, <span name="for">Ye Olde</span>
 C-style <code>for</code> loop. I probably don&rsquo;t need to remind you, but it looks like this:</p>
-<div class="codehilite"><pre><span class="k">for</span> (<span class="k">var</span> <span class="i">i</span> = <span class="n">0</span>; <span class="i">i</span> &lt; <span class="n">10</span>; <span class="i">i</span> = <span class="i">i</span> + <span class="n">1</span>) <span class="k">print</span> <span class="i">i</span>;
+<div class="codehilite" translate="no"><pre><span class="k">for</span> (<span class="k">var</span> <span class="i">i</span> = <span class="n">0</span>; <span class="i">i</span> &lt; <span class="n">10</span>; <span class="i">i</span> = <span class="i">i</span> + <span class="n">1</span>) <span class="k">print</span> <span class="i">i</span>;
 </pre></div>
 <p>In grammarese, that&rsquo;s:</p>
-<div class="codehilite"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
+<div class="codehilite" translate="no"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
                | <span class="i">forStmt</span>
                | <span class="i">ifStmt</span>
                | <span class="i">printStmt</span>
@@ -615,7 +615,7 @@ could be rewritten like so:</p>
 how some of the nice expression forms supported by languages like ALGOL were a
 sweetener sprinkled over the more fundamental<span class="em">&mdash;</span>but presumably less palatable<span class="em">&mdash;</span>lambda calculus underneath.</p><img class="above" src="image/control-flow/sugar.png" alt="Slightly more than a spoonful of sugar." />
 </aside>
-<div class="codehilite"><pre>{
+<div class="codehilite" translate="no"><pre>{
   <span class="k">var</span> <span class="i">i</span> = <span class="n">0</span>;
   <span class="k">while</span> (<span class="i">i</span> &lt; <span class="n">10</span>) {
     <span class="k">print</span> <span class="i">i</span>;
@@ -641,7 +641,7 @@ interpreter already handles. In our simple interpreter, desugaring really
 doesn&rsquo;t save us much work, but it does give me an excuse to introduce you to the
 technique. So, unlike the previous statements, we <em>won&rsquo;t</em> add a new syntax tree
 node. Instead, we go straight to parsing. First, add an import we&rsquo;ll need soon.</p>
-<div class="codehilite"><pre class="insert-before">import java.util.ArrayList;
+<div class="codehilite" translate="no"><pre class="insert-before">import java.util.ArrayList;
 </pre><div class="source-file"><em>lox/Parser.java</em></div>
 <pre class="insert"><span class="k">import</span> <span class="i">java.util.Arrays</span>;
 </pre><pre class="insert-after">import java.util.List;
@@ -649,7 +649,7 @@ node. Instead, we go straight to parsing. First, add an import we&rsquo;ll need 
 <div class="source-file-narrow"><em>lox/Parser.java</em></div>
 
 <p>Like every statement, we start parsing a <code>for</code> loop by matching its keyword.</p>
-<div class="codehilite"><pre class="insert-before">  private Stmt statement() {
+<div class="codehilite" translate="no"><pre class="insert-before">  private Stmt statement() {
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">match</span>(<span class="i">FOR</span>)) <span class="k">return</span> <span class="i">forStatement</span>();
@@ -660,7 +660,7 @@ in <em>statement</em>()</div>
 <p>Here is where it gets interesting. The desugaring is going to happen here, so
 we&rsquo;ll build this method a piece at a time, starting with the opening parenthesis
 before the clauses.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>statement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">forStatement</span>() {
     <span class="i">consume</span>(<span class="i">LEFT_PAREN</span>, <span class="s">&quot;Expect &#39;(&#39; after &#39;for&#39;.&quot;</span>);
@@ -671,7 +671,7 @@ add after <em>statement</em>()</div>
 <div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>statement</em>()</div>
 
 <p>The first clause following that is the initializer.</p>
-<div class="codehilite"><pre class="insert-before">    consume(LEFT_PAREN, &quot;Expect '(' after 'for'.&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">    consume(LEFT_PAREN, &quot;Expect '(' after 'for'.&quot;);
 
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>forStatement</em>()<br>
@@ -700,7 +700,7 @@ grammar that allows both an expression and a statement. That wasn&rsquo;t <em>en
 true, I guess.</p>
 </aside>
 <p>Next up is the condition.</p>
-<div class="codehilite"><pre class="insert-before">      initializer = expressionStatement();
+<div class="codehilite" translate="no"><pre class="insert-before">      initializer = expressionStatement();
     }
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>forStatement</em>()</div>
@@ -717,7 +717,7 @@ in <em>forStatement</em>()</div>
 
 <p>Again, we look for a semicolon to see if the clause has been omitted. The last
 clause is the increment.</p>
-<div class="codehilite"><pre class="insert-before">    consume(SEMICOLON, &quot;Expect ';' after loop condition.&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">    consume(SEMICOLON, &quot;Expect ';' after loop condition.&quot;);
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">
@@ -736,7 +736,7 @@ closing parenthesis. All that remains is the <span name="body">body</span>.</p>
 <aside name="body">
 <p>Is it just me or does that sound morbid? &ldquo;All that remained<span class="ellipse">&thinsp;.&thinsp;.&thinsp;.&nbsp;</span>was the <em>body</em>&rdquo;.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">    consume(RIGHT_PAREN, &quot;Expect ')' after for clauses.&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">    consume(RIGHT_PAREN, &quot;Expect ')' after for clauses.&quot;);
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">    <span class="t">Stmt</span> <span class="i">body</span> = <span class="i">statement</span>();
@@ -753,7 +753,7 @@ that express the semantics of the <code>for</code> loop, like the hand-desugared
 showed you earlier.</p>
 <p>The code is a little simpler if we work backward, so we start with the increment
 clause.</p>
-<div class="codehilite"><pre class="insert-before">    Stmt body = statement();
+<div class="codehilite" translate="no"><pre class="insert-before">    Stmt body = statement();
 
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>forStatement</em>()</div>
@@ -771,7 +771,7 @@ in <em>forStatement</em>()</div>
 <p>The increment, if there is one, executes after the body in each iteration of the
 loop. We do that by replacing the body with a little block that contains the
 original body followed by an expression statement that evaluates the increment.</p>
-<div class="codehilite"><pre class="insert-before">    }
+<div class="codehilite" translate="no"><pre class="insert-before">    }
 
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>forStatement</em>()</div>
@@ -785,7 +785,7 @@ in <em>forStatement</em>()</div>
 <p>Next, we take the condition and the body and build the loop using a primitive
 <code>while</code> loop. If the condition is omitted, we jam in <code>true</code> to make an infinite
 loop.</p>
-<div class="codehilite"><pre class="insert-before">    body = new Stmt.While(condition, body);
+<div class="codehilite" translate="no"><pre class="insert-before">    body = new Stmt.While(condition, body);
 
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>forStatement</em>()</div>
@@ -806,7 +806,7 @@ interpreter already knows how to visit, there is no more work to do.</p>
 <p>Finally, Lox is powerful enough to entertain us, at least for a few minutes.
 Here&rsquo;s a tiny program to print the first 21 elements in the Fibonacci
 sequence:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="n">0</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="n">0</span>;
 <span class="k">var</span> <span class="i">temp</span>;
 
 <span class="k">for</span> (<span class="k">var</span> <span class="i">b</span> = <span class="n">1</span>; <span class="i">a</span> &lt; <span class="n">10000</span>; <span class="i">b</span> = <span class="i">temp</span> + <span class="i">b</span>) {

--- a/site/evaluating-expressions.html
+++ b/site/evaluating-expressions.html
@@ -201,7 +201,7 @@ recursively traversed it, building up a string which it ultimately returned.
 That&rsquo;s almost exactly what a real interpreter does, except instead of
 concatenating strings, it computes values.</p>
 <p>We start with a new class.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -230,7 +230,7 @@ expressions, which are also leaf nodes.</p>
 <p>So, much like we converted a literal <em>token</em> into a literal <em>syntax tree node</em>
 in the parser, now we convert the literal tree node into a runtime value. That
 turns out to be trivial.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitLiteralExpr</span>(<span class="t">Expr</span>.<span class="t">Literal</span> <span class="i">expr</span>) {
@@ -245,7 +245,7 @@ so to evaluate a literal, we simply pull it back out.</p>
 <h3><a href="#evaluating-parentheses" id="evaluating-parentheses"><small>7&#8202;.&#8202;2&#8202;.&#8202;2</small>Evaluating parentheses</a></h3>
 <p>The next simplest node to evaluate is grouping<span class="em">&mdash;</span>the node you get as a result
 of using explicit parentheses in an expression.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitGroupingExpr</span>(<span class="t">Expr</span>.<span class="t">Grouping</span> <span class="i">expr</span>) {
@@ -265,7 +265,7 @@ parenthesized expression, they simply return the node for the inner expression.
 We do create a node for parentheses in Lox because we&rsquo;ll need it later to
 correctly handle the left-hand sides of assignment expressions.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre>  <span class="k">private</span> <span class="t">Object</span> <span class="i">evaluate</span>(<span class="t">Expr</span> <span class="i">expr</span>) {
     <span class="k">return</span> <span class="i">expr</span>.<span class="i">accept</span>(<span class="k">this</span>);
@@ -277,7 +277,7 @@ in class <em>Interpreter</em></div>
 <p>Like grouping, unary expressions have a single subexpression that we must
 evaluate first. The difference is that the unary expression itself does a little
 work afterwards.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitLiteralExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitUnaryExpr</span>(<span class="t">Expr</span>.<span class="t">Unary</span> <span class="i">expr</span>) {
@@ -310,7 +310,7 @@ into that soon.</p>
 evaluate the unary operator itself until after we evaluate its operand
 subexpression. That means our interpreter is doing a <strong>post-order traversal</strong><span class="em">&mdash;</span>each node evaluates its children before doing its own work.</p>
 <p>The other unary operator is logical not.</p>
-<div class="codehilite"><pre class="insert-before">    switch (expr.operator.type) {
+<div class="codehilite" translate="no"><pre class="insert-before">    switch (expr.operator.type) {
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitUnaryExpr</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="i">BANG</span>:
@@ -345,7 +345,7 @@ non-empty strings are truthy.</p>
 </aside>
 <p>Lox follows Ruby&rsquo;s simple rule: <code>false</code> and <code>nil</code> are falsey, and everything else
 is truthy. We implement that like so:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitUnaryExpr</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isTruthy</span>(<span class="t">Object</span> <span class="i">object</span>) {
     <span class="k">if</span> (<span class="i">object</span> == <span class="k">null</span>) <span class="k">return</span> <span class="k">false</span>;
@@ -358,7 +358,7 @@ add after <em>visitUnaryExpr</em>()</div>
 <h3><a href="#evaluating-binary-operators" id="evaluating-binary-operators"><small>7&#8202;.&#8202;2&#8202;.&#8202;5</small>Evaluating binary operators</a></h3>
 <p>On to the last expression tree class, binary operators. There&rsquo;s a handful of
 them, and we&rsquo;ll start with the arithmetic ones.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>evaluate</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitBinaryExpr</span>(<span class="t">Expr</span>.<span class="t">Binary</span> <span class="i">expr</span>) {
@@ -391,7 +391,7 @@ make sure clox does the same thing.</p>
 <p>I think you can figure out what&rsquo;s going on here. The main difference from the
 unary negation operator is that we have two operands to evaluate.</p>
 <p>I left out one arithmetic operator because it&rsquo;s a little special.</p>
-<div class="codehilite"><pre class="insert-before">    switch (expr.operator.type) {
+<div class="codehilite" translate="no"><pre class="insert-before">    switch (expr.operator.type) {
       case MINUS:
         return (double)left - (double)right;
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
@@ -424,7 +424,7 @@ languages that don&rsquo;t use <code>+</code> for strings, they still often over
 adding both integers and floating-point numbers.</p>
 </aside>
 <p>Next up are the comparison operators.</p>
-<div class="codehilite"><pre class="insert-before">    switch (expr.operator.type) {
+<div class="codehilite" translate="no"><pre class="insert-before">    switch (expr.operator.type) {
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="i">GREATER</span>:
@@ -443,7 +443,7 @@ in <em>visitBinaryExpr</em>()</div>
 arithmetic operators produce a value whose type is the same as the operands
 (numbers or strings), the comparison operators always produce a Boolean.</p>
 <p>The last pair of operators are equality.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre>      <span class="k">case</span> <span class="i">BANG_EQUAL</span>: <span class="k">return</span> !<span class="i">isEqual</span>(<span class="i">left</span>, <span class="i">right</span>);
       <span class="k">case</span> <span class="i">EQUAL_EQUAL</span>: <span class="k">return</span> <span class="i">isEqual</span>(<span class="i">left</span>, <span class="i">right</span>);
@@ -458,7 +458,7 @@ it.</p>
 <p>Spoiler alert: it&rsquo;s not.</p>
 </aside>
 <p>Like truthiness, the equality logic is hoisted out into a separate method.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>isTruthy</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isEqual</span>(<span class="t">Object</span> <span class="i">a</span>, <span class="t">Object</span> <span class="i">b</span>) {
     <span class="k">if</span> (<span class="i">a</span> == <span class="k">null</span> &amp;&amp; <span class="i">b</span> == <span class="k">null</span>) <span class="k">return</span> <span class="k">true</span>;
@@ -479,7 +479,7 @@ so that we don&rsquo;t throw a NullPointerException if we try to call <code>equa
 on Boolean, Double, and String have the behavior we want for Lox.</p>
 <aside name="nan">
 <p>What do you expect this to evaluate to:</p>
-<div class="codehilite"><pre>(<span class="n">0</span> / <span class="n">0</span>) == (<span class="n">0</span> / <span class="n">0</span>)
+<div class="codehilite" translate="no"><pre>(<span class="n">0</span> / <span class="n">0</span>) == (<span class="n">0</span> / <span class="n">0</span>)
 </pre></div>
 <p>According to <a href="https://en.wikipedia.org/wiki/IEEE_754">IEEE 754</a>, which specifies the behavior of double-precision
 numbers, dividing a zero by zero gives you the special <strong>NaN</strong> (&ldquo;not a number&rdquo;)
@@ -523,7 +523,7 @@ message relevant to our language and their program.</p>
 <p>The Java behavior does have one thing going for it, though. It correctly stops
 executing any code when the error occurs. Let&rsquo;s say the user enters some
 expression like:</p>
-<div class="codehilite"><pre><span class="n">2</span> * (<span class="n">3</span> / -<span class="s">&quot;muffin&quot;</span>)
+<div class="codehilite" translate="no"><pre><span class="n">2</span> * (<span class="n">3</span> / -<span class="s">&quot;muffin&quot;</span>)
 </pre></div>
 <p>You can&rsquo;t negate a <span name="muffin">muffin</span>, so we need to report a
 runtime error at that inner <code>-</code> expression. That in turn means we can&rsquo;t evaluate
@@ -548,7 +548,7 @@ is a fine way to accomplish that. However, instead of using Java&rsquo;s own cas
 failure, we&rsquo;ll define a Lox-specific one so that we can handle it how we want.</p>
 <p>Before we do the cast, we check the object&rsquo;s type ourselves. So, for unary <code>-</code>,
 we add:</p>
-<div class="codehilite"><pre class="insert-before">      case MINUS:
+<div class="codehilite" translate="no"><pre class="insert-before">      case MINUS:
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitUnaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperand</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">right</span>);
@@ -557,7 +557,7 @@ in <em>visitUnaryExpr</em>()</div>
 <div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitUnaryExpr</em>()</div>
 
 <p>The code to check the operand is:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitUnaryExpr</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">checkNumberOperand</span>(<span class="t">Token</span> <span class="i">operator</span>, <span class="t">Object</span> <span class="i">operand</span>) {
     <span class="k">if</span> (<span class="i">operand</span> <span class="k">instanceof</span> <span class="t">Double</span>) <span class="k">return</span>;
@@ -567,7 +567,7 @@ add after <em>visitUnaryExpr</em>()</div>
 <div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitUnaryExpr</em>()</div>
 
 <p>When the check fails, it throws one of these:</p>
-<div class="codehilite"><div class="source-file"><em>lox/RuntimeError.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/RuntimeError.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -595,7 +595,7 @@ wait until we support Lox classes.</p>
 single line of code needed to implement the interpreters, I&rsquo;ll run through them
 all.</p>
 <p>Greater than:</p>
-<div class="codehilite"><pre class="insert-before">      case GREATER:
+<div class="codehilite" translate="no"><pre class="insert-before">      case GREATER:
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
@@ -604,7 +604,7 @@ in <em>visitBinaryExpr</em>()</div>
 <div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Greater than or equal to:</p>
-<div class="codehilite"><pre class="insert-before">      case GREATER_EQUAL:
+<div class="codehilite" translate="no"><pre class="insert-before">      case GREATER_EQUAL:
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
@@ -613,7 +613,7 @@ in <em>visitBinaryExpr</em>()</div>
 <div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Less than:</p>
-<div class="codehilite"><pre class="insert-before">      case LESS:
+<div class="codehilite" translate="no"><pre class="insert-before">      case LESS:
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
@@ -622,7 +622,7 @@ in <em>visitBinaryExpr</em>()</div>
 <div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Less than or equal to:</p>
-<div class="codehilite"><pre class="insert-before">      case LESS_EQUAL:
+<div class="codehilite" translate="no"><pre class="insert-before">      case LESS_EQUAL:
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
@@ -631,7 +631,7 @@ in <em>visitBinaryExpr</em>()</div>
 <div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Subtraction:</p>
-<div class="codehilite"><pre class="insert-before">      case MINUS:
+<div class="codehilite" translate="no"><pre class="insert-before">      case MINUS:
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
@@ -640,7 +640,7 @@ in <em>visitBinaryExpr</em>()</div>
 <div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Division:</p>
-<div class="codehilite"><pre class="insert-before">      case SLASH:
+<div class="codehilite" translate="no"><pre class="insert-before">      case SLASH:
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
@@ -649,7 +649,7 @@ in <em>visitBinaryExpr</em>()</div>
 <div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Multiplication:</p>
-<div class="codehilite"><pre class="insert-before">      case STAR:
+<div class="codehilite" translate="no"><pre class="insert-before">      case STAR:
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
@@ -659,7 +659,7 @@ in <em>visitBinaryExpr</em>()</div>
 
 <p>All of those rely on this validator, which is virtually the same as the unary
 one:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>checkNumberOperand</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">checkNumberOperands</span>(<span class="t">Token</span> <span class="i">operator</span>,
                                    <span class="t">Object</span> <span class="i">left</span>, <span class="t">Object</span> <span class="i">right</span>) {
@@ -674,7 +674,7 @@ add after <em>checkNumberOperand</em>()</div>
 <p>Another subtle semantic choice: We evaluate <em>both</em> operands before checking the
 type of <em>either</em>. Imagine we have a function <code>say()</code> that prints its argument
 then returns it. Using that, we write:</p>
-<div class="codehilite"><pre><span class="i">say</span>(<span class="s">&quot;left&quot;</span>) - <span class="i">say</span>(<span class="s">&quot;right&quot;</span>);
+<div class="codehilite" translate="no"><pre><span class="i">say</span>(<span class="s">&quot;left&quot;</span>) - <span class="i">say</span>(<span class="s">&quot;right&quot;</span>);
 </pre></div>
 <p>Our interpreter prints &ldquo;left&rdquo; and &ldquo;right&rdquo; before reporting the runtime error. We
 could have instead specified that the left operand is checked before even
@@ -683,7 +683,7 @@ evaluating the right.</p>
 <p>The last remaining operator, again the odd one out, is addition. Since <code>+</code> is
 overloaded for numbers and strings, it already has code to check the types. All
 we need to do is fail if neither of the two success cases match.</p>
-<div class="codehilite"><pre class="insert-before">          return (String)left + (String)right;
+<div class="codehilite" translate="no"><pre class="insert-before">          return (String)left + (String)right;
         }
 
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
@@ -703,7 +703,7 @@ drives it.</p>
 <p>The visit methods are sort of the guts of the Interpreter class, where the real
 work happens. We need to wrap a skin around them to interface with the rest of
 the program. The Interpreter&rsquo;s public API is simply one method.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre>  <span class="t">void</span> <span class="i">interpret</span>(<span class="t">Expr</span> <span class="i">expression</span>) {<span name="void"> </span>
     <span class="k">try</span> {
@@ -720,7 +720,7 @@ in class <em>Interpreter</em></div>
 succeeds, <code>evaluate()</code> returns an object for the result value. <code>interpret()</code>
 converts that to a string and shows it to the user. To convert a Lox value to a
 string, we rely on:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>isEqual</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">String</span> <span class="i">stringify</span>(<span class="t">Object</span> <span class="i">object</span>) {
     <span class="k">if</span> (<span class="i">object</span> == <span class="k">null</span>) <span class="k">return</span> <span class="s">&quot;nil&quot;</span>;
@@ -762,7 +762,7 @@ on different interpreters.</p>
 catches it. This lets us report the error to the user and then gracefully
 continue. All of our existing error reporting code lives in the Lox class, so we
 put this method there too:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Lox.java</em><br>
 add after <em>error</em>()</div>
 <pre>  <span class="k">static</span> <span class="t">void</span> <span class="i">runtimeError</span>(<span class="t">RuntimeError</span> <span class="i">error</span>) {
     <span class="t">System</span>.<span class="i">err</span>.<span class="i">println</span>(<span class="i">error</span>.<span class="i">getMessage</span>() +
@@ -777,7 +777,7 @@ code was executing when the error occurred. Even better would be to give the
 user an entire call stack to show how they <em>got</em> to be executing that code. But
 we don&rsquo;t have function calls yet, so I guess we don&rsquo;t have to worry about it.</p>
 <p>After showing the error, <code>runtimeError()</code> sets this field:</p>
-<div class="codehilite"><pre class="insert-before">  static boolean hadError = false;
+<div class="codehilite" translate="no"><pre class="insert-before">  static boolean hadError = false;
 </pre><div class="source-file"><em>lox/Lox.java</em><br>
 in class <em>Lox</em></div>
 <pre class="insert">  <span class="k">static</span> <span class="t">boolean</span> <span class="i">hadRuntimeError</span> = <span class="k">false</span>;
@@ -787,7 +787,7 @@ in class <em>Lox</em></div>
 <div class="source-file-narrow"><em>lox/Lox.java</em>, in class <em>Lox</em></div>
 
 <p>That field plays a small but important role.</p>
-<div class="codehilite"><pre class="insert-before">    run(new String(bytes, Charset.defaultCharset()));
+<div class="codehilite" translate="no"><pre class="insert-before">    run(new String(bytes, Charset.defaultCharset()));
 
     // Indicate an error in the exit code.
     if (hadError) System.exit(65);
@@ -808,7 +808,7 @@ keep going.</p>
 </aside>
 <h3><a href="#running-the-interpreter" id="running-the-interpreter"><small>7&#8202;.&#8202;4&#8202;.&#8202;2</small>Running the interpreter</a></h3>
 <p>Now that we have an interpreter, the Lox class can start using it.</p>
-<div class="codehilite"><pre class="insert-before">public class Lox {
+<div class="codehilite" translate="no"><pre class="insert-before">public class Lox {
 </pre><div class="source-file"><em>lox/Lox.java</em><br>
 in class <em>Lox</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">static</span> <span class="k">final</span> <span class="t">Interpreter</span> <span class="i">interpreter</span> = <span class="k">new</span> <span class="t">Interpreter</span>();
@@ -822,7 +822,7 @@ will later when the interpreter stores global variables. Those variables should
 persist throughout the REPL session.</p>
 <p>Finally, we remove the line of temporary code from the <a href="parsing-expressions.html">last chapter</a> for
 printing the syntax tree and replace it with this:</p>
-<div class="codehilite"><pre class="insert-before">    // Stop if there was a syntax error.
+<div class="codehilite" translate="no"><pre class="insert-before">    // Stop if there was a syntax error.
     if (hadError) return;
 
 </pre><div class="source-file"><em>lox/Lox.java</em><br>
@@ -885,7 +885,7 @@ succeed without violating the language&rsquo;s soundness guarantees, is because 
 cast is checked <em>at runtime</em> and throws an exception on failure.</p>
 <p>A more subtle example is <a href="https://en.wikipedia.org/wiki/Covariance_and_contravariance_(computer_science)#Covariant_arrays_in_Java_and_C.23">covariant arrays</a> in Java and C#. The static
 subtyping rules for arrays allow operations that are not sound. Consider:</p>
-<div class="codehilite"><pre><span class="t">Object</span>[] <span class="i">stuff</span> = <span class="k">new</span> <span class="t">Integer</span>[<span class="n">1</span>];
+<div class="codehilite" translate="no"><pre><span class="t">Object</span>[] <span class="i">stuff</span> = <span class="k">new</span> <span class="t">Integer</span>[<span class="n">1</span>];
 <span class="i">stuff</span>[<span class="n">0</span>] = <span class="s">&quot;not an int!&quot;</span>;
 </pre></div>
 <p>This code compiles without any errors. The first line upcasts the Integer array

--- a/site/functions.html
+++ b/site/functions.html
@@ -112,7 +112,7 @@ calls.</p>
 <h2><a href="#function-calls" id="function-calls"><small>10&#8202;.&#8202;1</small>Function Calls</a></h2>
 <p>You&rsquo;re certainly familiar with C-style function call syntax, but the grammar is
 more subtle than you may realize. Calls are typically to named functions like:</p>
-<div class="codehilite"><pre><span class="i">average</span>(<span class="n">1</span>, <span class="n">2</span>);
+<div class="codehilite" translate="no"><pre><span class="i">average</span>(<span class="n">1</span>, <span class="n">2</span>);
 </pre></div>
 <p>But the <span name="pascal">name</span> of the function being called isn&rsquo;t
 actually part of the call syntax. The thing being called<span class="em">&mdash;</span>the <strong>callee</strong><span class="em">&mdash;</span>can be any expression that evaluates to a function. (Well, it does have to be a
@@ -122,7 +122,7 @@ example:</p>
 <p>The name <em>is</em> part of the call syntax in Pascal. You can call only named
 functions or functions stored directly in variables.</p>
 </aside>
-<div class="codehilite"><pre><span class="i">getCallback</span>()();
+<div class="codehilite" translate="no"><pre><span class="i">getCallback</span>()();
 </pre></div>
 <p>There are two call expressions here. The first pair of parentheses has
 <code>getCallback</code> as its callee. But the second call has the entire <code>getCallback()</code>
@@ -133,7 +133,7 @@ operator that starts with <code>(</code>.</p>
 ones. So we slot it into the grammar by having the <code>unary</code> rule bubble up to a
 new <code>call</code> rule.</p>
 <p><span name="curry"></span></p>
-<div class="codehilite"><pre><span class="i">unary</span>          → ( <span class="s">&quot;!&quot;</span> | <span class="s">&quot;-&quot;</span> ) <span class="i">unary</span> | <span class="i">call</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">unary</span>          → ( <span class="s">&quot;!&quot;</span> | <span class="s">&quot;-&quot;</span> ) <span class="i">unary</span> | <span class="i">call</span> ;
 <span class="i">call</span>           → <span class="i">primary</span> ( <span class="s">&quot;(&quot;</span> <span class="i">arguments</span>? <span class="s">&quot;)&quot;</span> )* ;
 </pre></div>
 <p>This rule matches a primary expression followed by zero or more function calls.
@@ -152,7 +152,7 @@ arguments are consumed, the last function completes the operation.</p>
 name graces that <em>other</em> well-known functional language), is baked directly into
 the language syntax so it&rsquo;s not as weird looking as it would be here.</p>
 </aside>
-<div class="codehilite"><pre><span class="i">arguments</span>      → <span class="i">expression</span> ( <span class="s">&quot;,&quot;</span> <span class="i">expression</span> )* ;
+<div class="codehilite" translate="no"><pre><span class="i">arguments</span>      → <span class="i">expression</span> ( <span class="s">&quot;,&quot;</span> <span class="i">expression</span> )* ;
 </pre></div>
 <p>This rule requires at least one argument expression, followed by zero or more
 other expressions, each preceded by a comma. To handle zero-argument calls, the
@@ -163,7 +163,7 @@ sophisticated metasyntaxes that handle this better, but in our BNF and in many
 language specs I&rsquo;ve seen, it is this cumbersome.</p>
 <p>Over in our syntax tree generator, we add a <span name="call-ast">new
 node</span>.</p>
-<div class="codehilite"><pre class="insert-before">      &quot;Binary   : Expr left, Token operator, Expr right&quot;,
+<div class="codehilite" translate="no"><pre class="insert-before">      &quot;Binary   : Expr left, Token operator, Expr right&quot;,
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Call     : Expr callee, Token paren, List&lt;Expr&gt; arguments&quot;</span>,
@@ -179,7 +179,7 @@ also stores the token for the closing parenthesis. We&rsquo;ll use that token&rs
 location when we report a runtime error caused by a function call.</p>
 <p>Crack open the parser. Where <code>unary()</code> used to jump straight to <code>primary()</code>,
 change it to call, well, <code>call()</code>.</p>
-<div class="codehilite"><pre class="insert-before">      return new Expr.Unary(operator, right);
+<div class="codehilite" translate="no"><pre class="insert-before">      return new Expr.Unary(operator, right);
     }
 
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
@@ -191,7 +191,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>unary</em>(), replace 1 line</div>
 
 <p>Its definition is:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>unary</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">call</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">primary</span>();
@@ -222,7 +222,7 @@ new <code>expr</code> and we loop to see if the result is itself called.</p>
 parser later to handle properties on objects.</p>
 </aside>
 <p>The code to parse the argument list is in this helper:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>unary</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">finishCall</span>(<span class="t">Expr</span> <span class="i">callee</span>) {
     <span class="t">List</span>&lt;<span class="t">Expr</span>&gt; <span class="i">arguments</span> = <span class="k">new</span> <span class="t">ArrayList</span>&lt;&gt;();
@@ -265,7 +265,7 @@ implicitly passed to the method, so it claims one of the slots.</p>
 number of arguments will simplify our bytecode interpreter in <a href="a-bytecode-virtual-machine.html">Part III</a>. We
 want our two interpreters to be compatible with each other, even in weird corner
 cases like this, so we&rsquo;ll add the same limit to jlox.</p>
-<div class="codehilite"><pre class="insert-before">      do {
+<div class="codehilite" translate="no"><pre class="insert-before">      do {
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>finishCall</em>()</div>
 <pre class="insert">        <span class="k">if</span> (<span class="i">arguments</span>.<span class="i">size</span>() &gt;= <span class="n">255</span>) {
@@ -285,7 +285,7 @@ keepin&rsquo; on.</p>
 <p>We don&rsquo;t have any functions we can call, so it seems weird to start implementing
 calls first, but we&rsquo;ll worry about that when we get there. First, our
 interpreter needs a new import.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em></div>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em></div>
 <pre class="insert"><span class="k">import</span> <span class="i">java.util.ArrayList</span>;
 </pre><pre class="insert-after">import java.util.List;
 </pre></div>
@@ -293,7 +293,7 @@ interpreter needs a new import.</p>
 
 <p>As always, interpretation starts with a new visit method for our new call
 expression node.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitBinaryExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitCallExpr</span>(<span class="t">Expr</span>.<span class="t">Call</span> <span class="i">expr</span>) {
@@ -333,7 +333,7 @@ We&rsquo;ll also use it for one more purpose shortly.</p>
 own Callable interface. Alas, all the good simple names are already taken.</p>
 </aside>
 <p>There isn&rsquo;t too much to this new interface.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxCallable.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/LoxCallable.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -353,13 +353,13 @@ then to return the value that the call expression produces.</p>
 little more robust. It currently ignores a couple of failure modes that we can&rsquo;t
 pretend won&rsquo;t occur. First, what happens if the callee isn&rsquo;t actually something
 you can call? What if you try to do this:</p>
-<div class="codehilite"><pre><span class="s">&quot;totally not a function&quot;</span>();
+<div class="codehilite" translate="no"><pre><span class="s">&quot;totally not a function&quot;</span>();
 </pre></div>
 <p>Strings aren&rsquo;t callable in Lox. The runtime representation of a Lox string is a
 Java string, so when we cast that to LoxCallable, the JVM will throw a
 ClassCastException. We don&rsquo;t want our interpreter to vomit out some nasty Java
 stack trace and die. Instead, we need to check the type ourselves first.</p>
-<div class="codehilite"><pre class="insert-before">    }
+<div class="codehilite" translate="no"><pre class="insert-before">    }
 
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitCallExpr</em>()</div>
@@ -379,13 +379,13 @@ that the interpreter knows to catch and report gracefully.</p>
 for the number of arguments a function or operation expects. Unary operators
 have arity one, binary operators two, etc. With functions, the arity is
 determined by the number of parameters it declares.</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">add</span>(<span class="i">a</span>, <span class="i">b</span>, <span class="i">c</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">add</span>(<span class="i">a</span>, <span class="i">b</span>, <span class="i">c</span>) {
   <span class="k">print</span> <span class="i">a</span> + <span class="i">b</span> + <span class="i">c</span>;
 }
 </pre></div>
 <p>This function defines three parameters, <code>a</code>, <code>b</code>, and <code>c</code>, so its arity is
 three and it expects three arguments. So what if you try to call it like this:</p>
-<div class="codehilite"><pre><span class="i">add</span>(<span class="n">1</span>, <span class="n">2</span>, <span class="n">3</span>, <span class="n">4</span>); <span class="c">// Too many.</span>
+<div class="codehilite" translate="no"><pre><span class="i">add</span>(<span class="n">1</span>, <span class="n">2</span>, <span class="n">3</span>, <span class="n">4</span>); <span class="c">// Too many.</span>
 <span class="i">add</span>(<span class="n">1</span>, <span class="n">2</span>);       <span class="c">// Too few.</span>
 </pre></div>
 <p>Different languages take different approaches to this problem. Of course, most
@@ -400,7 +400,7 @@ is almost always a bug, and it&rsquo;s a mistake I do make in practice. Given th
 the sooner the implementation draws my attention to it, the better. So for Lox,
 we&rsquo;ll take Python&rsquo;s approach. Before invoking the callable, we check to see if
 the argument list&rsquo;s length matches the callable&rsquo;s arity.</p>
-<div class="codehilite"><pre class="insert-before">    LoxCallable function = (LoxCallable)callee;
+<div class="codehilite" translate="no"><pre class="insert-before">    LoxCallable function = (LoxCallable)callee;
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitCallExpr</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">arguments</span>.<span class="i">size</span>() != <span class="i">function</span>.<span class="i">arity</span>()) {
@@ -414,7 +414,7 @@ in <em>visitCallExpr</em>()</div>
 <div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitCallExpr</em>()</div>
 
 <p>That requires a new method on the LoxCallable interface to ask it its arity.</p>
-<div class="codehilite"><pre class="insert-before">interface LoxCallable {
+<div class="codehilite" translate="no"><pre class="insert-before">interface LoxCallable {
 </pre><div class="source-file"><em>lox/LoxCallable.java</em><br>
 in interface <em>LoxCallable</em></div>
 <pre class="insert">  <span class="t">int</span> <span class="i">arity</span>();
@@ -493,7 +493,7 @@ that have passed since some fixed point in time. The difference between two
 successive invocations tells you how much time elapsed between the two calls.
 This function is defined in the global scope, so let&rsquo;s ensure the interpreter
 has access to that.</p>
-<div class="codehilite"><pre class="insert-before">class Interpreter implements Expr.Visitor&lt;Object&gt;,
+<div class="codehilite" translate="no"><pre class="insert-before">class Interpreter implements Expr.Visitor&lt;Object&gt;,
                              Stmt.Visitor&lt;Void&gt; {
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em><br>
@@ -511,7 +511,7 @@ scopes. It tracks the <em>current</em> environment. This new <code>globals</code
 fixed reference to the outermost global environment.</p>
 <p>When we instantiate an Interpreter, we stuff the native function in that global
 scope.</p>
-<div class="codehilite"><pre class="insert-before">  private Environment environment = globals;
+<div class="codehilite" translate="no"><pre class="insert-before">  private Environment environment = globals;
 
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
@@ -566,19 +566,19 @@ a declaration is permitted.</p>
 syntactic sugar for two distinct steps: (1) creating a new function object, and
 (2) binding a new variable to it. If Lox had syntax for anonymous functions, we
 wouldn&rsquo;t need function declaration statements. You could just do:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">add</span> = <span class="k">fun</span> (<span class="i">a</span>, <span class="i">b</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">add</span> = <span class="k">fun</span> (<span class="i">a</span>, <span class="i">b</span>) {
   <span class="k">print</span> <span class="i">a</span> + <span class="i">b</span>;
 };
 </pre></div>
 <p>However, since named functions are the common case, I went ahead and gave Lox
 nice syntax for them.</p>
 </aside>
-<div class="codehilite"><pre><span class="i">declaration</span>    → <span class="i">funDecl</span>
+<div class="codehilite" translate="no"><pre><span class="i">declaration</span>    → <span class="i">funDecl</span>
                | <span class="i">varDecl</span>
                | <span class="i">statement</span> ;
 </pre></div>
 <p>The updated <code>declaration</code> rule references this new rule:</p>
-<div class="codehilite"><pre><span class="i">funDecl</span>        → <span class="s">&quot;fun&quot;</span> <span class="i">function</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">funDecl</span>        → <span class="s">&quot;fun&quot;</span> <span class="i">function</span> ;
 <span class="i">function</span>       → <span class="t">IDENTIFIER</span> <span class="s">&quot;(&quot;</span> <span class="i">parameters</span>? <span class="s">&quot;)&quot;</span> <span class="i">block</span> ;
 </pre></div>
 <p>The main <code>funDecl</code> rule uses a separate helper rule <code>function</code>. A function
@@ -592,12 +592,12 @@ methods. Those look similar to function declarations, but aren&rsquo;t preceded 
 <p>The function itself is a name followed by the parenthesized parameter list and
 the body. The body is always a braced block, using the same grammar rule that
 block statements use. The parameter list uses this rule:</p>
-<div class="codehilite"><pre><span class="i">parameters</span>     → <span class="t">IDENTIFIER</span> ( <span class="s">&quot;,&quot;</span> <span class="t">IDENTIFIER</span> )* ;
+<div class="codehilite" translate="no"><pre><span class="i">parameters</span>     → <span class="t">IDENTIFIER</span> ( <span class="s">&quot;,&quot;</span> <span class="t">IDENTIFIER</span> )* ;
 </pre></div>
 <p>It&rsquo;s like the earlier <code>arguments</code> rule, except that each parameter is an
 identifier, not an expression. That&rsquo;s a lot of new syntax for the parser to chew
 through, but the resulting AST <span name="fun-ast">node</span> isn&rsquo;t too bad.</p>
-<div class="codehilite"><pre class="insert-before">      &quot;Expression : Expr expression&quot;,
+<div class="codehilite" translate="no"><pre class="insert-before">      &quot;Expression : Expr expression&quot;,
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Function   : Token name, List&lt;Token&gt; params,&quot;</span> +
@@ -613,7 +613,7 @@ in <em>main</em>()</div>
 body. We store the body as the list of statements contained inside the curly
 braces.</p>
 <p>Over in the parser, we weave in the new declaration.</p>
-<div class="codehilite"><pre class="insert-before">    try {
+<div class="codehilite" translate="no"><pre class="insert-before">    try {
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>declaration</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">match</span>(<span class="i">FUN</span>)) <span class="k">return</span> <span class="i">function</span>(<span class="s">&quot;function&quot;</span>);
@@ -625,7 +625,7 @@ in <em>declaration</em>()</div>
 encounter <code>fun</code>, we call <code>function</code>. That corresponds to the <code>function</code> grammar
 rule since we already matched and consumed the <code>fun</code> keyword. We&rsquo;ll build the
 method up a piece at a time, starting with this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>expressionStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span>.<span class="t">Function</span> <span class="i">function</span>(<span class="t">String</span> <span class="i">kind</span>) {
     <span class="t">Token</span> <span class="i">name</span> = <span class="i">consume</span>(<span class="i">IDENTIFIER</span>, <span class="s">&quot;Expect &quot;</span> + <span class="i">kind</span> + <span class="s">&quot; name.&quot;</span>);
@@ -639,7 +639,7 @@ the grammar rule, we&rsquo;ll reuse the <code>function()</code> method later to 
 inside classes. When we do that, we&rsquo;ll pass in &ldquo;method&rdquo; for <code>kind</code> so that the
 error messages are specific to the kind of declaration being parsed.</p>
 <p>Next, we parse the parameter list and the pair of parentheses wrapped around it.</p>
-<div class="codehilite"><pre class="insert-before">    Token name = consume(IDENTIFIER, &quot;Expect &quot; + kind + &quot; name.&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">    Token name = consume(IDENTIFIER, &quot;Expect &quot; + kind + &quot; name.&quot;);
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>function</em>()</div>
 <pre class="insert">    <span class="i">consume</span>(<span class="i">LEFT_PAREN</span>, <span class="s">&quot;Expect &#39;(&#39; after &quot;</span> + <span class="i">kind</span> + <span class="s">&quot; name.&quot;</span>);
@@ -667,7 +667,7 @@ separate them. The result is the list of tokens for each parameter&rsquo;s name.
 that you don&rsquo;t exceed the maximum number of parameters a function is allowed to
 have.</p>
 <p>Finally, we parse the body and wrap it all up in a function node.</p>
-<div class="codehilite"><pre class="insert-before">    consume(RIGHT_PAREN, &quot;Expect ')' after parameters.&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">    consume(RIGHT_PAREN, &quot;Expect ')' after parameters.&quot;);
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>function</em>()</div>
 <pre class="insert">
@@ -694,7 +694,7 @@ Almost, but not quite. We also need a class that implements LoxCallable so that
 we can call it. We don&rsquo;t want the runtime phase of the interpreter to bleed into
 the front end&rsquo;s syntax classes so we don&rsquo;t want Stmt.Function itself to
 implement that. Instead, we wrap it in a new class.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/LoxFunction.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -710,7 +710,7 @@ create new file</div>
 <div class="source-file-narrow"><em>lox/LoxFunction.java</em>, create new file</div>
 
 <p>We implement the <code>call()</code> of LoxCallable like so:</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/LoxFunction.java</em><br>
 add after <em>LoxFunction</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">call</span>(<span class="t">Interpreter</span> <span class="i">interpreter</span>,
@@ -743,7 +743,7 @@ its own environment. Otherwise, recursion would break. If there are multiple
 calls to the same function in play at the same time, each needs its <em>own</em>
 environment, even though they are all calls to the same function.</p>
 <p>For example, here&rsquo;s a convoluted way to count to three:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">count</span>(<span class="i">n</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">count</span>(<span class="i">n</span>) {
   <span class="k">if</span> (<span class="i">n</span> &gt; <span class="n">1</span>) <span class="i">count</span>(<span class="i">n</span> - <span class="n">1</span>);
   <span class="k">print</span> <span class="i">n</span>;
 }
@@ -761,7 +761,7 @@ the call, it creates a new environment. Then it walks the parameter and argument
 lists in lockstep. For each pair, it creates a new variable with the parameter&rsquo;s
 name and binds it to the argument&rsquo;s value.</p>
 <p>So, for a program like this:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">add</span>(<span class="i">a</span>, <span class="i">b</span>, <span class="i">c</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">add</span>(<span class="i">a</span>, <span class="i">b</span>, <span class="i">c</span>) {
   <span class="k">print</span> <span class="i">a</span> + <span class="i">b</span> + <span class="i">c</span>;
 }
 
@@ -789,7 +789,7 @@ it if you&rsquo;re so inclined.</p>
 lists have the same length. This is safe because <code>visitCallExpr()</code> checks the
 arity before calling <code>call()</code>. It relies on the function reporting its arity to
 do that.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/LoxFunction.java</em><br>
 add after <em>LoxFunction</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">int</span> <span class="i">arity</span>() {
@@ -800,7 +800,7 @@ add after <em>LoxFunction</em>()</div>
 
 <p>That&rsquo;s most of our object representation. While we&rsquo;re in here, we may as well
 implement <code>toString()</code>.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/LoxFunction.java</em><br>
 add after <em>LoxFunction</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">String</span> <span class="i">toString</span>() {
@@ -810,7 +810,7 @@ add after <em>LoxFunction</em>()</div>
 <div class="source-file-narrow"><em>lox/LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
 
 <p>This gives nicer output if a user decides to print a function value.</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">add</span>(<span class="i">a</span>, <span class="i">b</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">add</span>(<span class="i">a</span>, <span class="i">b</span>) {
   <span class="k">print</span> <span class="i">a</span> + <span class="i">b</span>;
 }
 
@@ -819,7 +819,7 @@ add after <em>LoxFunction</em>()</div>
 <h3><a href="#interpreting-function-declarations" id="interpreting-function-declarations"><small>10&#8202;.&#8202;4&#8202;.&#8202;1</small>Interpreting function declarations</a></h3>
 <p>We&rsquo;ll come back and refine LoxFunction soon, but that&rsquo;s enough to get started.
 Now we can visit a function declaration.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitExpressionStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitFunctionStmt</span>(<span class="t">Stmt</span>.<span class="t">Function</span> <span class="i">stmt</span>) {
@@ -840,7 +840,7 @@ creating the LoxFunction, we create a new binding in the current environment and
 store a reference to it there.</p>
 <p>With that, we can define and call our own functions all within Lox. Give it a
 try:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">sayHi</span>(<span class="i">first</span>, <span class="i">last</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">sayHi</span>(<span class="i">first</span>, <span class="i">last</span>) {
   <span class="k">print</span> <span class="s">&quot;Hi, &quot;</span> + <span class="i">first</span> + <span class="s">&quot; &quot;</span> + <span class="i">last</span> + <span class="s">&quot;!&quot;</span>;
 }
 
@@ -859,7 +859,7 @@ sure you can guess the grammar already.</p>
 <aside name="hotel">
 <p>The Hotel California of data.</p>
 </aside>
-<div class="codehilite"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
+<div class="codehilite" translate="no"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
                | <span class="i">forStmt</span>
                | <span class="i">ifStmt</span>
                | <span class="i">printStmt</span>
@@ -878,7 +878,7 @@ don&rsquo;t return a value and non-void ones do. Since Lox is dynamically typed,
 are no true void functions. The compiler has no way of preventing you from
 taking the result value of a call to a function that doesn&rsquo;t contain a <code>return</code>
 statement.</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">procedure</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">procedure</span>() {
   <span class="k">print</span> <span class="s">&quot;don&#39;t return anything&quot;</span>;
 }
 
@@ -889,10 +889,10 @@ statement.</p>
 <code>return</code> statements at all. We use <code>nil</code> for this, which is why LoxFunction&rsquo;s
 implementation of <code>call()</code> returns <code>null</code> at the end. In that same vein, if you
 omit the value in a <code>return</code> statement, we simply treat it as equivalent to:</p>
-<div class="codehilite"><pre><span class="k">return</span> <span class="k">nil</span>;
+<div class="codehilite" translate="no"><pre><span class="k">return</span> <span class="k">nil</span>;
 </pre></div>
 <p>Over in our AST generator, we add a <span name="return-ast">new node</span>.</p>
-<div class="codehilite"><pre class="insert-before">      &quot;Print      : Expr expression&quot;,
+<div class="codehilite" translate="no"><pre class="insert-before">      &quot;Print      : Expr expression&quot;,
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Return     : Token keyword, Expr value&quot;</span>,
@@ -906,7 +906,7 @@ in <em>main</em>()</div>
 <p>It keeps the <code>return</code> keyword token so we can use its location for error
 reporting, and the value being returned, if any. We parse it like other
 statements, first by recognizing the initial keyword.</p>
-<div class="codehilite"><pre class="insert-before">    if (match(PRINT)) return printStatement();
+<div class="codehilite" translate="no"><pre class="insert-before">    if (match(PRINT)) return printStatement();
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">match</span>(<span class="i">RETURN</span>)) <span class="k">return</span> <span class="i">returnStatement</span>();
@@ -915,7 +915,7 @@ in <em>statement</em>()</div>
 <div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>statement</em>()</div>
 
 <p>That branches out to:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>printStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">returnStatement</span>() {
     <span class="t">Token</span> <span class="i">keyword</span> = <span class="i">previous</span>();
@@ -943,7 +943,7 @@ context it&rsquo;s currently in and cause the function call to complete, like so
 kind of jacked up control flow construct.</p>
 <p>For example, say we&rsquo;re running this program and we&rsquo;re about to execute the
 <code>return</code> statement:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">count</span>(<span class="i">n</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">count</span>(<span class="i">n</span>) {
   <span class="k">while</span> (<span class="i">n</span> &lt; <span class="n">100</span>) {
     <span class="k">if</span> (<span class="i">n</span> == <span class="n">3</span>) <span class="k">return</span> <span class="i">n</span>; <span class="c">// &lt;--</span>
     <span class="k">print</span> <span class="i">n</span>;
@@ -954,7 +954,7 @@ kind of jacked up control flow construct.</p>
 <span class="i">count</span>(<span class="n">1</span>);
 </pre></div>
 <p>The Java call stack currently looks roughly like this:</p>
-<div class="codehilite"><pre>Interpreter.visitReturnStmt()
+<div class="codehilite" translate="no"><pre>Interpreter.visitReturnStmt()
 Interpreter.visitIfStmt()
 Interpreter.executeBlock()
 Interpreter.visitBlockStmt()
@@ -969,7 +969,7 @@ know about you, but to me that sounds like exceptions. When we execute a
 visit methods of all of the containing statements back to the code that began
 executing the body.</p>
 <p>The visit method for our new AST node looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitPrintStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitReturnStmt</span>(<span class="t">Stmt</span>.<span class="t">Return</span> <span class="i">stmt</span>) {
@@ -983,7 +983,7 @@ add after <em>visitPrintStmt</em>()</div>
 
 <p>If we have a return value, we evaluate it, otherwise, we use <code>nil</code>. Then we take
 that value and wrap it in a custom exception class and throw it.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Return.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Return.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -1012,7 +1012,7 @@ exceptions are a handy tool for that.</p>
 </aside>
 <p>We want this to unwind all the way to where the function call began, the
 <code>call()</code> method in LoxFunction.</p>
-<div class="codehilite"><pre class="insert-before">          arguments.get(i));
+<div class="codehilite" translate="no"><pre class="insert-before">          arguments.get(i));
     }
 
 </pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
@@ -1035,7 +1035,7 @@ it implicitly returns <code>nil</code>.</p>
 <p>Let&rsquo;s try it out. We finally have enough power to support this classic
 example<span class="em">&mdash;</span>a recursive function to calculate Fibonacci numbers:</p>
 <p><span name="slow"></span></p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">fib</span>(<span class="i">n</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">fib</span>(<span class="i">n</span>) {
   <span class="k">if</span> (<span class="i">n</span> &lt;= <span class="n">1</span>) <span class="k">return</span> <span class="i">n</span>;
   <span class="k">return</span> <span class="i">fib</span>(<span class="i">n</span> - <span class="n">2</span>) + <span class="i">fib</span>(<span class="i">n</span> - <span class="n">1</span>);
 }
@@ -1071,7 +1071,7 @@ be bound. That includes the top level of a Lox script, but also the inside of
 blocks or other functions. Lox supports <strong>local functions</strong> that are defined
 inside another function, or nested inside a block.</p>
 <p>Consider this classic example:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">makeCounter</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">makeCounter</span>() {
   <span class="k">var</span> <span class="i">i</span> = <span class="n">0</span>;
   <span class="k">fun</span> <span class="i">count</span>() {
     <span class="i">i</span> = <span class="i">i</span> + <span class="n">1</span>;
@@ -1117,7 +1117,7 @@ environment.</p>
 along that computer scientists communicated with each other using only primitive
 grunts and pawing hand gestures.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">  private final Stmt.Function declaration;
+<div class="codehilite" translate="no"><pre class="insert-before">  private final Stmt.Function declaration;
 </pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
 in class <em>LoxFunction</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">Environment</span> <span class="i">closure</span>;
@@ -1127,7 +1127,7 @@ in class <em>LoxFunction</em></div>
 <div class="source-file-narrow"><em>lox/LoxFunction.java</em>, in class <em>LoxFunction</em></div>
 
 <p>We initialize that in the constructor.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/LoxFunction.java</em><br>
 constructor <em>LoxFunction</em>()<br>
 replace 1 line</div>
 <pre class="insert">  <span class="t">LoxFunction</span>(<span class="t">Stmt</span>.<span class="t">Function</span> <span class="i">declaration</span>, <span class="t">Environment</span> <span class="i">closure</span>) {
@@ -1137,7 +1137,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>lox/LoxFunction.java</em>, constructor <em>LoxFunction</em>(), replace 1 line</div>
 
 <p>When we create a LoxFunction, we capture the current environment.</p>
-<div class="codehilite"><pre class="insert-before">  public Void visitFunctionStmt(Stmt.Function stmt) {
+<div class="codehilite" translate="no"><pre class="insert-before">  public Void visitFunctionStmt(Stmt.Function stmt) {
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitFunctionStmt</em>()<br>
 replace 1 line</div>
@@ -1150,7 +1150,7 @@ replace 1 line</div>
 it&rsquo;s <em>called</em>, which is what we want. It represents the lexical scope
 surrounding the function declaration. Finally, when we call the function, we use
 that environment as the call&rsquo;s parent instead of going straight to <code>globals</code>.</p>
-<div class="codehilite"><pre class="insert-before">                     List&lt;Object&gt; arguments) {
+<div class="codehilite" translate="no"><pre class="insert-before">                     List&lt;Object&gt; arguments) {
 </pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
 in <em>call</em>()<br>
 replace 1 line</div>
@@ -1191,7 +1191,7 @@ doesn&rsquo;t need a name.</p>
 functions</strong> or <strong>lambdas</strong><span class="em">&mdash;</span>an expression syntax that creates a function
 without binding it to a name. Add anonymous function syntax to Lox so that
 this works:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">thrice</span>(<span class="i">fn</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">thrice</span>(<span class="i">fn</span>) {
   <span class="k">for</span> (<span class="k">var</span> <span class="i">i</span> = <span class="n">1</span>; <span class="i">i</span> &lt;= <span class="n">3</span>; <span class="i">i</span> = <span class="i">i</span> + <span class="n">1</span>) {
     <span class="i">fn</span>(<span class="i">i</span>);
   }
@@ -1206,12 +1206,12 @@ this works:</p>
 </pre></div>
 <p>How do you handle the tricky case of an anonymous function expression
 occurring in an expression statement:</p>
-<div class="codehilite"><pre><span class="k">fun</span> () {};
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> () {};
 </pre></div>
 </li>
 <li>
 <p>Is this program valid?</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">scope</span>(<span class="i">a</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">scope</span>(<span class="i">a</span>) {
   <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;local&quot;</span>;
 }
 </pre></div>

--- a/site/garbage-collection.html
+++ b/site/garbage-collection.html
@@ -155,7 +155,7 @@ values like numbers or strings.</p>
 <p>That sounds <em>too</em> conservative. Couldn&rsquo;t <em>any</em> bit of memory potentially be
 read? Actually, no, at least not in a memory-safe language like Lox. Here&rsquo;s an
 example:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;first value&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;first value&quot;</span>;
 <span class="i">a</span> = <span class="s">&quot;updated&quot;</span>;
 <span class="c">// GC here.</span>
 <span class="k">print</span> <span class="i">a</span>;
@@ -167,7 +167,7 @@ reference to that string. We can safely free it. A value is <strong>reachable</s
 there is some way for a user program to reference it. Otherwise, like the string
 &ldquo;first value&rdquo; here, it is <strong>unreachable</strong>.</p>
 <p>Many values can be directly accessed by the VM. Take a look at:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">global</span> = <span class="s">&quot;string&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">global</span> = <span class="s">&quot;string&quot;</span>;
 {
   <span class="k">var</span> <span class="i">local</span> = <span class="s">&quot;another&quot;</span>;
   <span class="k">print</span> <span class="i">global</span> + <span class="i">local</span>;
@@ -191,7 +191,7 @@ references. Consider:</p>
 <aside name="class">
 <p>We&rsquo;ll get there <a href="classes-and-instances.html">soon</a>, though!</p>
 </aside>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">makeClosure</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">makeClosure</span>() {
   <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;data&quot;</span>;
 
   <span class="k">fun</span> <span class="i">f</span>() { <span class="k">print</span> <span class="i">a</span>; }
@@ -294,7 +294,7 @@ name="one">function</span>:</p>
 <aside name="one">
 <p>Of course, we&rsquo;ll end up adding a bunch of helper functions too.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">void* reallocate(void* pointer, size_t oldSize, size_t newSize);
+<div class="codehilite" translate="no"><pre class="insert-before">void* reallocate(void* pointer, size_t oldSize, size_t newSize);
 </pre><div class="source-file"><em>memory.h</em><br>
 add after <em>reallocate</em>()</div>
 <pre class="insert"><span class="t">void</span> <span class="i">collectGarbage</span>();
@@ -303,7 +303,7 @@ add after <em>reallocate</em>()</div>
 <div class="source-file-narrow"><em>memory.h</em>, add after <em>reallocate</em>()</div>
 
 <p>We&rsquo;ll work our way up to a full implementation starting with this empty shell:</p>
-<div class="codehilite"><div class="source-file"><em>memory.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>memory.c</em><br>
 add after <em>freeObject</em>()</div>
 <pre><span class="t">void</span> <span class="i">collectGarbage</span>() {
 }
@@ -314,7 +314,7 @@ add after <em>freeObject</em>()</div>
 turns out that&rsquo;s a subtle question that we&rsquo;ll spend some time on later in the
 chapter. For now we&rsquo;ll sidestep the issue and build ourselves a handy diagnostic
 tool in the process.</p>
-<div class="codehilite"><pre class="insert-before">#define DEBUG_TRACE_EXECUTION
+<div class="codehilite" translate="no"><pre class="insert-before">#define DEBUG_TRACE_EXECUTION
 </pre><div class="source-file"><em>common.h</em></div>
 <pre class="insert">
 
@@ -330,7 +330,7 @@ flag is defined, the GC runs as often as it possibly can. This is, obviously,
 horrendous for performance. But it&rsquo;s great for flushing out memory management
 bugs that occur only when a GC is triggered at just the right moment. If <em>every</em>
 moment triggers a GC, you&rsquo;re likely to find those bugs.</p>
-<div class="codehilite"><pre class="insert-before">void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
+<div class="codehilite" translate="no"><pre class="insert-before">void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>reallocate</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">newSize</span> &gt; <span class="i">oldSize</span>) {
@@ -367,7 +367,7 @@ running lots of Lox programs just fine without any GC <em>at all</em> so far. On
 add one, how do we tell if it&rsquo;s doing anything useful? Can we tell only if we
 write programs that plow through acres of memory? How do we debug that?</p>
 <p>An easy way to shine a light into the GC&rsquo;s inner workings is with some logging.</p>
-<div class="codehilite"><pre class="insert-before">#define DEBUG_STRESS_GC
+<div class="codehilite" translate="no"><pre class="insert-before">#define DEBUG_STRESS_GC
 </pre><div class="source-file"><em>common.h</em></div>
 <pre class="insert"><span class="a">#define DEBUG_LOG_GC</span>
 </pre><pre class="insert-after">
@@ -379,7 +379,7 @@ write programs that plow through acres of memory? How do we debug that?</p>
 <p>When this is enabled, clox prints information to the console when it does
 something with dynamic memory.</p>
 <p>We need a couple of includes.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;vm.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;vm.h&quot;
 </pre><div class="source-file"><em>memory.c</em></div>
 <pre class="insert">
 
@@ -395,7 +395,7 @@ void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
 
 <p>We don&rsquo;t have a collector yet, but we can start putting in some of the logging
 now. We&rsquo;ll want to know when a collection run starts.</p>
-<div class="codehilite"><pre class="insert-before">void collectGarbage() {
+<div class="codehilite" translate="no"><pre class="insert-before">void collectGarbage() {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>collectGarbage</em>()</div>
 <pre class="insert"><span class="a">#ifdef DEBUG_LOG_GC</span>
@@ -407,7 +407,7 @@ in <em>collectGarbage</em>()</div>
 
 <p>Eventually we will log some other operations during the collection, so we&rsquo;ll
 also want to know when the show&rsquo;s over.</p>
-<div class="codehilite"><pre class="insert-before">  printf(&quot;-- gc begin\n&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">  printf(&quot;-- gc begin\n&quot;);
 #endif
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>collectGarbage</em>()</div>
@@ -422,7 +422,7 @@ in <em>collectGarbage</em>()</div>
 
 <p>We don&rsquo;t have any code for the collector yet, but we do have functions for
 allocating and freeing, so we can instrument those now.</p>
-<div class="codehilite"><pre class="insert-before">  vm.objects = object;
+<div class="codehilite" translate="no"><pre class="insert-before">  vm.objects = object;
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>allocateObject</em>()</div>
 <pre class="insert">
@@ -436,7 +436,7 @@ in <em>allocateObject</em>()</div>
 <div class="source-file-narrow"><em>object.c</em>, in <em>allocateObject</em>()</div>
 
 <p>And at the end of an object&rsquo;s lifespan:</p>
-<div class="codehilite"><pre class="insert-before">static void freeObject(Obj* object) {
+<div class="codehilite" translate="no"><pre class="insert-before">static void freeObject(Obj* object) {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>freeObject</em>()</div>
 <pre class="insert"><span class="a">#ifdef DEBUG_LOG_GC</span>
@@ -454,7 +454,7 @@ work through the rest of the chapter.</p>
 reference from one object to another forms a connection, and these
 constellations are the graph that the mark phase traverses. Marking begins at
 the roots.</p>
-<div class="codehilite"><pre class="insert-before">#ifdef DEBUG_LOG_GC
+<div class="codehilite" translate="no"><pre class="insert-before">#ifdef DEBUG_LOG_GC
   printf(&quot;-- gc begin\n&quot;);
 #endif
 </pre><div class="source-file"><em>memory.c</em><br>
@@ -470,7 +470,7 @@ in <em>collectGarbage</em>()</div>
 
 <p>Most roots are local variables or temporaries sitting right in the VM&rsquo;s stack,
 so we start by walking that.</p>
-<div class="codehilite"><div class="source-file"><em>memory.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>memory.c</em><br>
 add after <em>freeObject</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">markRoots</span>() {
   <span class="k">for</span> (<span class="t">Value</span>* <span class="i">slot</span> = <span class="i">vm</span>.<span class="i">stack</span>; <span class="i">slot</span> &lt; <span class="i">vm</span>.<span class="i">stackTop</span>; <span class="i">slot</span>++) {
@@ -481,7 +481,7 @@ add after <em>freeObject</em>()</div>
 <div class="source-file-narrow"><em>memory.c</em>, add after <em>freeObject</em>()</div>
 
 <p>To mark a Lox value, we use this new function:</p>
-<div class="codehilite"><pre class="insert-before">void* reallocate(void* pointer, size_t oldSize, size_t newSize);
+<div class="codehilite" translate="no"><pre class="insert-before">void* reallocate(void* pointer, size_t oldSize, size_t newSize);
 </pre><div class="source-file"><em>memory.h</em><br>
 add after <em>reallocate</em>()</div>
 <pre class="insert"><span class="t">void</span> <span class="i">markValue</span>(<span class="t">Value</span> <span class="i">value</span>);
@@ -490,7 +490,7 @@ add after <em>reallocate</em>()</div>
 <div class="source-file-narrow"><em>memory.h</em>, add after <em>reallocate</em>()</div>
 
 <p>Its implementation is here:</p>
-<div class="codehilite"><div class="source-file"><em>memory.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>memory.c</em><br>
 add after <em>reallocate</em>()</div>
 <pre><span class="t">void</span> <span class="i">markValue</span>(<span class="t">Value</span> <span class="i">value</span>) {
   <span class="k">if</span> (<span class="a">IS_OBJ</span>(<span class="i">value</span>)) <span class="i">markObject</span>(<span class="a">AS_OBJ</span>(<span class="i">value</span>));
@@ -502,7 +502,7 @@ add after <em>reallocate</em>()</div>
 Value and require no heap allocation. The garbage collector doesn&rsquo;t need to
 worry about them at all, so the first thing we do is ensure that the value is an
 actual heap object. If so, the real work happens in this function:</p>
-<div class="codehilite"><pre class="insert-before">void* reallocate(void* pointer, size_t oldSize, size_t newSize);
+<div class="codehilite" translate="no"><pre class="insert-before">void* reallocate(void* pointer, size_t oldSize, size_t newSize);
 </pre><div class="source-file"><em>memory.h</em><br>
 add after <em>reallocate</em>()</div>
 <pre class="insert"><span class="t">void</span> <span class="i">markObject</span>(<span class="t">Obj</span>* <span class="i">object</span>);
@@ -511,7 +511,7 @@ add after <em>reallocate</em>()</div>
 <div class="source-file-narrow"><em>memory.h</em>, add after <em>reallocate</em>()</div>
 
 <p>Which is defined here:</p>
-<div class="codehilite"><div class="source-file"><em>memory.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>memory.c</em><br>
 add after <em>reallocate</em>()</div>
 <pre><span class="t">void</span> <span class="i">markObject</span>(<span class="t">Obj</span>* <span class="i">object</span>) {
   <span class="k">if</span> (<span class="i">object</span> == <span class="a">NULL</span>) <span class="k">return</span>;
@@ -526,7 +526,7 @@ call this function directly from other code, and in some of those places, the
 object being pointed to is optional.</p>
 <p>Assuming we do have a valid object, we mark it by setting a flag. That new field
 lives in the Obj header struct all objects share.</p>
-<div class="codehilite"><pre class="insert-before">  ObjType type;
+<div class="codehilite" translate="no"><pre class="insert-before">  ObjType type;
 </pre><div class="source-file"><em>object.h</em><br>
 in struct <em>Obj</em></div>
 <pre class="insert">  <span class="t">bool</span> <span class="i">isMarked</span>;
@@ -536,7 +536,7 @@ in struct <em>Obj</em></div>
 
 <p>Every new object begins life unmarked because we haven&rsquo;t yet determined if it is
 reachable or not.</p>
-<div class="codehilite"><pre class="insert-before">  object-&gt;type = type;
+<div class="codehilite" translate="no"><pre class="insert-before">  object-&gt;type = type;
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>allocateObject</em>()</div>
 <pre class="insert">  <span class="i">object</span>-&gt;<span class="i">isMarked</span> = <span class="k">false</span>;
@@ -547,7 +547,7 @@ in <em>allocateObject</em>()</div>
 <div class="source-file-narrow"><em>object.c</em>, in <em>allocateObject</em>()</div>
 
 <p>Before we go any farther, let&rsquo;s add some logging to <code>markObject()</code>.</p>
-<div class="codehilite"><pre class="insert-before">void markObject(Obj* object) {
+<div class="codehilite" translate="no"><pre class="insert-before">void markObject(Obj* object) {
   if (object == NULL) return;
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>markObject</em>()</div>
@@ -564,7 +564,7 @@ in <em>markObject</em>()</div>
 <p>This way we can see what the mark phase is doing. Marking the stack takes care
 of local variables and temporaries. The other main source of roots are the
 global variables.</p>
-<div class="codehilite"><pre class="insert-before">    markValue(*slot);
+<div class="codehilite" translate="no"><pre class="insert-before">    markValue(*slot);
   }
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>markRoots</em>()</div>
@@ -577,7 +577,7 @@ in <em>markRoots</em>()</div>
 
 <p>Those live in a hash table owned by the VM, so we&rsquo;ll declare another helper
 function for marking all of the objects in a table.</p>
-<div class="codehilite"><pre class="insert-before">ObjString* tableFindString(Table* table, const char* chars,
+<div class="codehilite" translate="no"><pre class="insert-before">ObjString* tableFindString(Table* table, const char* chars,
                            int length, uint32_t hash);
 </pre><div class="source-file"><em>table.h</em><br>
 add after <em>tableFindString</em>()</div>
@@ -589,7 +589,7 @@ add after <em>tableFindString</em>()</div>
 <div class="source-file-narrow"><em>table.h</em>, add after <em>tableFindString</em>()</div>
 
 <p>We implement that in the &ldquo;table&rdquo; module here:</p>
-<div class="codehilite"><div class="source-file"><em>table.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>table.c</em><br>
 add after <em>tableFindString</em>()</div>
 <pre><span class="t">void</span> <span class="i">markTable</span>(<span class="t">Table</span>* <span class="i">table</span>) {
   <span class="k">for</span> (<span class="t">int</span> <span class="i">i</span> = <span class="n">0</span>; <span class="i">i</span> &lt; <span class="i">table</span>-&gt;<span class="i">capacity</span>; <span class="i">i</span>++) {
@@ -613,7 +613,7 @@ references to values that it directly accesses.</p>
 separate stack of CallFrames. Each CallFrame contains a pointer to the closure
 being called. The VM uses those pointers to access constants and upvalues, so
 those closures need to be kept around too.</p>
-<div class="codehilite"><pre class="insert-before">  }
+<div class="codehilite" translate="no"><pre class="insert-before">  }
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>markRoots</em>()</div>
 <pre class="insert">
@@ -629,7 +629,7 @@ in <em>markRoots</em>()</div>
 
 <p>Speaking of upvalues, the open upvalue list is another set of values that the
 VM can directly reach.</p>
-<div class="codehilite"><pre class="insert-before">  for (int i = 0; i &lt; vm.frameCount; i++) {
+<div class="codehilite" translate="no"><pre class="insert-before">  for (int i = 0; i &lt; vm.frameCount; i++) {
     markObject((Obj*)vm.frames[i].closure);
   }
 </pre><div class="source-file"><em>memory.c</em><br>
@@ -654,7 +654,7 @@ table. If the GC runs while we&rsquo;re in the middle of compiling, then any val
 the compiler directly accesses need to be treated as roots too.</p>
 <p>To keep the compiler module cleanly separated from the rest of the VM, we&rsquo;ll do
 that in a separate function.</p>
-<div class="codehilite"><pre class="insert-before">  markTable(&amp;vm.globals);
+<div class="codehilite" translate="no"><pre class="insert-before">  markTable(&amp;vm.globals);
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>markRoots</em>()</div>
 <pre class="insert">  <span class="i">markCompilerRoots</span>();
@@ -663,7 +663,7 @@ in <em>markRoots</em>()</div>
 <div class="source-file-narrow"><em>memory.c</em>, in <em>markRoots</em>()</div>
 
 <p>It&rsquo;s declared here:</p>
-<div class="codehilite"><pre class="insert-before">ObjFunction* compile(const char* source);
+<div class="codehilite" translate="no"><pre class="insert-before">ObjFunction* compile(const char* source);
 </pre><div class="source-file"><em>compiler.h</em><br>
 add after <em>compile</em>()</div>
 <pre class="insert"><span class="t">void</span> <span class="i">markCompilerRoots</span>();
@@ -674,7 +674,7 @@ add after <em>compile</em>()</div>
 <div class="source-file-narrow"><em>compiler.h</em>, add after <em>compile</em>()</div>
 
 <p>Which means the &ldquo;memory&rdquo; module needs an include.</p>
-<div class="codehilite"><pre class="insert-before">#include &lt;stdlib.h&gt;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &lt;stdlib.h&gt;
 
 </pre><div class="source-file"><em>memory.c</em></div>
 <pre class="insert"><span class="a">#include &quot;compiler.h&quot;</span>
@@ -683,7 +683,7 @@ add after <em>compile</em>()</div>
 <div class="source-file-narrow"><em>memory.c</em></div>
 
 <p>And the definition is over in the &ldquo;compiler&rdquo; module.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>compile</em>()</div>
 <pre><span class="t">void</span> <span class="i">markCompilerRoots</span>() {
   <span class="t">Compiler</span>* <span class="i">compiler</span> = <span class="i">current</span>;
@@ -700,7 +700,7 @@ only object it uses is the ObjFunction it is compiling into. Since function
 declarations can nest, the compiler has a linked list of those and we walk the
 whole list.</p>
 <p>Since the &ldquo;compiler&rdquo; module is calling <code>markObject()</code>, it also needs an include.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;compiler.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;compiler.h&quot;
 </pre><div class="source-file"><em>compiler.c</em></div>
 <pre class="insert"><span class="a">#include &quot;memory.h&quot;</span>
 </pre><pre class="insert-after">#include &quot;scanner.h&quot;
@@ -821,7 +821,7 @@ that field set.</p>
 <p>Instead, we&rsquo;ll create a separate worklist to keep track of all of the gray
 objects. When an object turns gray, in addition to setting the mark field we&rsquo;ll
 also add it to the worklist.</p>
-<div class="codehilite"><pre class="insert-before">  object-&gt;isMarked = true;
+<div class="codehilite" translate="no"><pre class="insert-before">  object-&gt;isMarked = true;
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>markObject</em>()</div>
 <pre class="insert">
@@ -846,7 +846,7 @@ managed by the garbage collector. We don&rsquo;t want growing the gray stack dur
 GC to cause the GC to recursively start a new GC. That could tear a hole in the
 space-time continuum.</p>
 <p>We&rsquo;ll manage its memory ourselves, explicitly. The VM owns the gray stack.</p>
-<div class="codehilite"><pre class="insert-before">  Obj* objects;
+<div class="codehilite" translate="no"><pre class="insert-before">  Obj* objects;
 </pre><div class="source-file"><em>vm.h</em><br>
 in struct <em>VM</em></div>
 <pre class="insert">  <span class="t">int</span> <span class="i">grayCount</span>;
@@ -857,7 +857,7 @@ in struct <em>VM</em></div>
 <div class="source-file-narrow"><em>vm.h</em>, in struct <em>VM</em></div>
 
 <p>It starts out empty.</p>
-<div class="codehilite"><pre class="insert-before">  vm.objects = NULL;
+<div class="codehilite" translate="no"><pre class="insert-before">  vm.objects = NULL;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>initVM</em>()</div>
 <pre class="insert">
@@ -872,7 +872,7 @@ in <em>initVM</em>()</div>
 <div class="source-file-narrow"><em>vm.c</em>, in <em>initVM</em>()</div>
 
 <p>And we need to free it when the VM shuts down.</p>
-<div class="codehilite"><pre class="insert-before">    object = next;
+<div class="codehilite" translate="no"><pre class="insert-before">    object = next;
   }
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>freeObjects</em>()</div>
@@ -895,7 +895,7 @@ start the VM. If the gray stack allocation fails, we free the rainy day block
 and try again. That may give us enough wiggle room on the heap to create the
 gray stack, finish the GC, and free up more memory.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">    vm.grayStack = (Obj**)realloc(vm.grayStack,
+<div class="codehilite" translate="no"><pre class="insert-before">    vm.grayStack = (Obj**)realloc(vm.grayStack,
                                   sizeof(Obj*) * vm.grayCapacity);
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>markObject</em>()</div>
@@ -910,7 +910,7 @@ in <em>markObject</em>()</div>
 <p>OK, now when we&rsquo;re done marking the roots, we have both set a bunch of fields
 and filled our work list with objects to chew through. It&rsquo;s time for the next
 phase.</p>
-<div class="codehilite"><pre class="insert-before">  markRoots();
+<div class="codehilite" translate="no"><pre class="insert-before">  markRoots();
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>collectGarbage</em>()</div>
 <pre class="insert">  <span class="i">traceReferences</span>();
@@ -921,7 +921,7 @@ in <em>collectGarbage</em>()</div>
 <div class="source-file-narrow"><em>memory.c</em>, in <em>collectGarbage</em>()</div>
 
 <p>Here&rsquo;s the implementation:</p>
-<div class="codehilite"><div class="source-file"><em>memory.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>memory.c</em><br>
 add after <em>markRoots</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">traceReferences</span>() {
   <span class="k">while</span> (<span class="i">vm</span>.<span class="i">grayCount</span> &gt; <span class="n">0</span>) {
@@ -939,7 +939,7 @@ get marked gray and added to the stack. So this function swings back and forth
 between turning white objects gray and gray objects black, gradually advancing
 the entire wavefront forward.</p>
 <p>Here&rsquo;s where we traverse a single object&rsquo;s references:</p>
-<div class="codehilite"><div class="source-file"><em>memory.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>memory.c</em><br>
 add after <em>markValue</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">blackenObject</span>(<span class="t">Obj</span>* <span class="i">object</span>) {
   <span class="k">switch</span> (<span class="i">object</span>-&gt;<span class="i">type</span>) {
@@ -969,7 +969,7 @@ the gray stack.</p>
 time, friend.</p>
 </aside>
 <p>Now let&rsquo;s start adding in the other object types. The simplest is upvalues.</p>
-<div class="codehilite"><pre class="insert-before">static void blackenObject(Obj* object) {
+<div class="codehilite" translate="no"><pre class="insert-before">static void blackenObject(Obj* object) {
   switch (object-&gt;type) {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>blackenObject</em>()</div>
@@ -984,7 +984,7 @@ in <em>blackenObject</em>()</div>
 Since the value is no longer on the stack, we need to make sure we trace the
 reference to it from the upvalue.</p>
 <p>Next are functions.</p>
-<div class="codehilite"><pre class="insert-before">  switch (object-&gt;type) {
+<div class="codehilite" translate="no"><pre class="insert-before">  switch (object-&gt;type) {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>blackenObject</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OBJ_FUNCTION</span>: {
@@ -1000,7 +1000,7 @@ in <em>blackenObject</em>()</div>
 <p>Each function has a reference to an ObjString containing the function&rsquo;s name.
 More importantly, the function has a constant table packed full of references to
 other objects. We trace all of those using this helper:</p>
-<div class="codehilite"><div class="source-file"><em>memory.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>memory.c</em><br>
 add after <em>markValue</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">markArray</span>(<span class="t">ValueArray</span>* <span class="i">array</span>) {
   <span class="k">for</span> (<span class="t">int</span> <span class="i">i</span> = <span class="n">0</span>; <span class="i">i</span> &lt; <span class="i">array</span>-&gt;<span class="i">count</span>; <span class="i">i</span>++) {
@@ -1012,7 +1012,7 @@ add after <em>markValue</em>()</div>
 
 <p>The last object type we have now<span class="em">&mdash;</span>we&rsquo;ll add more in later chapters<span class="em">&mdash;</span>is
 closures.</p>
-<div class="codehilite"><pre class="insert-before">  switch (object-&gt;type) {
+<div class="codehilite" translate="no"><pre class="insert-before">  switch (object-&gt;type) {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>blackenObject</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OBJ_CLOSURE</span>: {
@@ -1031,7 +1031,7 @@ in <em>blackenObject</em>()</div>
 of pointers to the upvalues it captures. We trace all of those.</p>
 <p>That&rsquo;s the basic mechanism for processing a gray object, but there are two loose
 ends to tie up. First, some logging.</p>
-<div class="codehilite"><pre class="insert-before">static void blackenObject(Obj* object) {
+<div class="codehilite" translate="no"><pre class="insert-before">static void blackenObject(Obj* object) {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>blackenObject</em>()</div>
 <pre class="insert"><span class="a">#ifdef DEBUG_LOG_GC</span>
@@ -1051,7 +1051,7 @@ objects. When that happens, we need to ensure our collector doesn&rsquo;t get st
 an infinite loop as it continually re-adds the same series of objects to the
 gray stack.</p>
 <p>The fix is easy.</p>
-<div class="codehilite"><pre class="insert-before">  if (object == NULL) return;
+<div class="codehilite" translate="no"><pre class="insert-before">  if (object == NULL) return;
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>markObject</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">object</span>-&gt;<span class="i">isMarked</span>) <span class="k">return</span>;
@@ -1070,7 +1070,7 @@ could get our hands on. The gray stack is empty, and every object in the heap is
 either black or white. The black objects are reachable, and we want to hang on to
 them. Anything still white never got touched by the trace and is thus garbage.
 All that&rsquo;s left is to reclaim them.</p>
-<div class="codehilite"><pre class="insert-before">  traceReferences();
+<div class="codehilite" translate="no"><pre class="insert-before">  traceReferences();
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>collectGarbage</em>()</div>
 <pre class="insert">  <span class="i">sweep</span>();
@@ -1081,7 +1081,7 @@ in <em>collectGarbage</em>()</div>
 <div class="source-file-narrow"><em>memory.c</em>, in <em>collectGarbage</em>()</div>
 
 <p>All of the logic lives in one function.</p>
-<div class="codehilite"><div class="source-file"><em>memory.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>memory.c</em><br>
 add after <em>traceReferences</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">sweep</span>() {
   <span class="t">Obj</span>* <span class="i">previous</span> = <span class="a">NULL</span>;
@@ -1117,7 +1117,7 @@ singly linked list is cumbersome. We have to continuously remember the previous
 node so we can unlink its next pointer, and we have to handle the edge case
 where we are freeing the first node. But, otherwise, it&rsquo;s pretty simple<span class="em">&mdash;</span>delete every node in a linked list that doesn&rsquo;t have a bit set in it.</p>
 <p>There&rsquo;s one little addition:</p>
-<div class="codehilite"><pre class="insert-before">    if (object-&gt;isMarked) {
+<div class="codehilite" translate="no"><pre class="insert-before">    if (object-&gt;isMarked) {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>sweep</em>()</div>
 <pre class="insert">      <span class="i">object</span>-&gt;<span class="i">isMarked</span> = <span class="k">false</span>;
@@ -1166,7 +1166,7 @@ out any dangling pointers for strings that are freed.</p>
 unreachable. We don&rsquo;t know that until after the mark phase has completed. But we
 can&rsquo;t wait until after the sweep phase is done because by then the objects<span class="em">&mdash;</span>and their mark bits<span class="em">&mdash;</span>are no longer around to check. So the right time is
 exactly between the marking and sweeping phases.</p>
-<div class="codehilite"><pre class="insert-before">  traceReferences();
+<div class="codehilite" translate="no"><pre class="insert-before">  traceReferences();
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>collectGarbage</em>()</div>
 <pre class="insert">  <span class="i">tableRemoveWhite</span>(&amp;<span class="i">vm</span>.<span class="i">strings</span>);
@@ -1176,7 +1176,7 @@ in <em>collectGarbage</em>()</div>
 
 <p>The logic for removing the about-to-be-deleted strings exists in a new function
 in the &ldquo;table&rdquo; module.</p>
-<div class="codehilite"><pre class="insert-before">ObjString* tableFindString(Table* table, const char* chars,
+<div class="codehilite" translate="no"><pre class="insert-before">ObjString* tableFindString(Table* table, const char* chars,
                            int length, uint32_t hash);
 </pre><div class="source-file"><em>table.h</em><br>
 add after <em>tableFindString</em>()</div>
@@ -1189,7 +1189,7 @@ add after <em>tableFindString</em>()</div>
 <div class="source-file-narrow"><em>table.h</em>, add after <em>tableFindString</em>()</div>
 
 <p>The implementation is here:</p>
-<div class="codehilite"><div class="source-file"><em>table.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>table.c</em><br>
 add after <em>tableFindString</em>()</div>
 <pre><span class="t">void</span> <span class="i">tableRemoveWhite</span>(<span class="t">Table</span>* <span class="i">table</span>) {
   <span class="k">for</span> (<span class="t">int</span> <span class="i">i</span> = <span class="n">0</span>; <span class="i">i</span> &lt; <span class="i">table</span>-&gt;<span class="i">capacity</span>; <span class="i">i</span>++) {
@@ -1361,7 +1361,7 @@ frequently in order to avoid sacrificing throughput by re-traversing the growing
 pile of live objects. As the amount of live memory goes down, we collect more
 frequently so that we don&rsquo;t lose too much latency by waiting too long.</p>
 <p>The implementation requires two new bookkeeping fields in the VM.</p>
-<div class="codehilite"><pre class="insert-before">  ObjUpvalue* openUpvalues;
+<div class="codehilite" translate="no"><pre class="insert-before">  ObjUpvalue* openUpvalues;
 </pre><div class="source-file"><em>vm.h</em><br>
 in struct <em>VM</em></div>
 <pre class="insert">
@@ -1375,7 +1375,7 @@ in struct <em>VM</em></div>
 <p>The first is a running total of the number of bytes of managed memory the VM has
 allocated. The second is the threshold that triggers the next collection. We
 initialize them when the VM starts up.</p>
-<div class="codehilite"><pre class="insert-before">  vm.objects = NULL;
+<div class="codehilite" translate="no"><pre class="insert-before">  vm.objects = NULL;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>initVM</em>()</div>
 <pre class="insert">  <span class="i">vm</span>.<span class="i">bytesAllocated</span> = <span class="n">0</span>;
@@ -1398,7 +1398,7 @@ collector actually performs unless you run it on the kind of large, messy
 real-world programs it is actually intended for. It&rsquo;s like tuning a rally car<span class="em">&mdash;</span>you need to take it out on the course.</p>
 </aside>
 <p>Every time we allocate or free some memory, we adjust the counter by that delta.</p>
-<div class="codehilite"><pre class="insert-before">void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
+<div class="codehilite" translate="no"><pre class="insert-before">void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>reallocate</em>()</div>
 <pre class="insert">  <span class="i">vm</span>.<span class="i">bytesAllocated</span> += <span class="i">newSize</span> - <span class="i">oldSize</span>;
@@ -1407,7 +1407,7 @@ in <em>reallocate</em>()</div>
 <div class="source-file-narrow"><em>memory.c</em>, in <em>reallocate</em>()</div>
 
 <p>When the total crosses the limit, we run the collector.</p>
-<div class="codehilite"><pre class="insert-before">    collectGarbage();
+<div class="codehilite" translate="no"><pre class="insert-before">    collectGarbage();
 #endif
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>reallocate</em>()</div>
@@ -1425,7 +1425,7 @@ program without our hidden diagnostic flag enabled. The sweep phase frees
 objects by calling <code>reallocate()</code>, which lowers the value of <code>bytesAllocated</code>,
 so after the collection completes, we know how many live bytes remain. We adjust
 the threshold of the next GC based on that.</p>
-<div class="codehilite"><pre class="insert-before">  sweep();
+<div class="codehilite" translate="no"><pre class="insert-before">  sweep();
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>collectGarbage</em>()</div>
 <pre class="insert">
@@ -1441,7 +1441,7 @@ in <em>collectGarbage</em>()</div>
 the program uses grows, the threshold moves farther out to limit the total time
 spent re-traversing the larger live set. Like other numbers in this chapter, the
 scaling factor is basically arbitrary.</p>
-<div class="codehilite"><pre class="insert-before">#endif
+<div class="codehilite" translate="no"><pre class="insert-before">#endif
 </pre><div class="source-file"><em>memory.c</em></div>
 <pre class="insert">
 
@@ -1455,7 +1455,7 @@ void* reallocate(void* pointer, size_t oldSize, size_t newSize) {
 <p>You&rsquo;d want to tune this in your implementation once you had some real programs
 to benchmark it on. Right now, we can at least log some of the statistics that
 we have. We capture the heap size before the collection.</p>
-<div class="codehilite"><pre class="insert-before">  printf(&quot;-- gc begin\n&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">  printf(&quot;-- gc begin\n&quot;);
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>collectGarbage</em>()</div>
 <pre class="insert">  <span class="t">size_t</span> <span class="i">before</span> = <span class="i">vm</span>.<span class="i">bytesAllocated</span>;
@@ -1464,7 +1464,7 @@ in <em>collectGarbage</em>()</div>
 <div class="source-file-narrow"><em>memory.c</em>, in <em>collectGarbage</em>()</div>
 
 <p>And then print the results at the end.</p>
-<div class="codehilite"><pre class="insert-before">  printf(&quot;-- gc end\n&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">  printf(&quot;-- gc end\n&quot;);
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>collectGarbage</em>()</div>
 <pre class="insert">  <span class="i">printf</span>(<span class="s">&quot;   collected %zu bytes (from %zu to %zu) next at %zu</span><span class="e">\n</span><span class="s">&quot;</span>,
@@ -1536,7 +1536,7 @@ That in turn triggers a GC, which fails to mark the new constant object and
 thus sweeps it right before we have a chance to add it to the table. Crash.</p>
 <p>The fix, as you&rsquo;ve seen in other places, is to push the constant onto the stack
 temporarily.</p>
-<div class="codehilite"><pre class="insert-before">int addConstant(Chunk* chunk, Value value) {
+<div class="codehilite" translate="no"><pre class="insert-before">int addConstant(Chunk* chunk, Value value) {
 </pre><div class="source-file"><em>chunk.c</em><br>
 in <em>addConstant</em>()</div>
 <pre class="insert">  <span class="i">push</span>(<span class="i">value</span>);
@@ -1545,7 +1545,7 @@ in <em>addConstant</em>()</div>
 <div class="source-file-narrow"><em>chunk.c</em>, in <em>addConstant</em>()</div>
 
 <p>Once the constant table contains the object, we pop it off the stack.</p>
-<div class="codehilite"><pre class="insert-before">  writeValueArray(&amp;chunk-&gt;constants, value);
+<div class="codehilite" translate="no"><pre class="insert-before">  writeValueArray(&amp;chunk-&gt;constants, value);
 </pre><div class="source-file"><em>chunk.c</em><br>
 in <em>addConstant</em>()</div>
 <pre class="insert">  <span class="i">pop</span>();
@@ -1556,7 +1556,7 @@ in <em>addConstant</em>()</div>
 <p>When the GC is marking roots, it walks the chain of compilers and marks each of
 their functions, so the new constant is reachable now. We do need an include
 to call into the VM from the &ldquo;chunk&rdquo; module.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;memory.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;memory.h&quot;
 </pre><div class="source-file"><em>chunk.c</em></div>
 <pre class="insert"><span class="a">#include &quot;vm.h&quot;</span>
 </pre><pre class="insert-after">
@@ -1571,7 +1571,7 @@ create a new string, we also add it to the intern table. You can see where this
 is going. Since the string is brand new, it isn&rsquo;t reachable anywhere. And
 resizing the string pool can trigger a collection. Again, we go ahead and stash
 the string on the stack first.</p>
-<div class="codehilite"><pre class="insert-before">  string-&gt;chars = chars;
+<div class="codehilite" translate="no"><pre class="insert-before">  string-&gt;chars = chars;
   string-&gt;hash = hash;
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>allocateString</em>()</div>
@@ -1583,7 +1583,7 @@ in <em>allocateString</em>()</div>
 <div class="source-file-narrow"><em>object.c</em>, in <em>allocateString</em>()</div>
 
 <p>And then pop it back off once it&rsquo;s safely nestled in the table.</p>
-<div class="codehilite"><pre class="insert-before">  tableSet(&amp;vm.strings, string, NIL_VAL);
+<div class="codehilite" translate="no"><pre class="insert-before">  tableSet(&amp;vm.strings, string, NIL_VAL);
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>allocateString</em>()</div>
 <pre class="insert">  <span class="i">pop</span>();
@@ -1606,7 +1606,7 @@ stack. For numbers that&rsquo;s perfectly safe.</p>
 heap, which can in turn trigger a GC. Since we&rsquo;ve already popped the operand
 strings by that point, they can potentially be missed by the mark phase and get
 swept away. Instead of popping them off the stack eagerly, we peek them.</p>
-<div class="codehilite"><pre class="insert-before">static void concatenate() {
+<div class="codehilite" translate="no"><pre class="insert-before">static void concatenate() {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>concatenate</em>()<br>
 replace 2 lines</div>
@@ -1621,7 +1621,7 @@ replace 2 lines</div>
 <p>That way, they are still hanging out on the stack when we create the result
 string. Once that&rsquo;s done, we can safely pop them off and replace them with the
 result.</p>
-<div class="codehilite"><pre class="insert-before">  ObjString* result = takeString(chars, length);
+<div class="codehilite" translate="no"><pre class="insert-before">  ObjString* result = takeString(chars, length);
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>concatenate</em>()</div>
 <pre class="insert">  <span class="i">pop</span>();

--- a/site/global-variables.html
+++ b/site/global-variables.html
@@ -127,7 +127,7 @@ resolved dynamically. This means you can compile a chunk of code that refers to
 a global variable before it&rsquo;s defined. As long as the code doesn&rsquo;t <em>execute</em>
 before the definition happens, everything is fine. In practice, that means you
 can refer to later variables inside the body of functions.</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">showVariable</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">showVariable</span>() {
   <span class="k">print</span> <span class="i">global</span>;
 }
 
@@ -149,13 +149,13 @@ splits statements into two categories. &ldquo;Declarations&rdquo; are those stat
 bind a new name to a value. The other kinds of statements<span class="em">&mdash;</span>control flow,
 print, etc.<span class="em">&mdash;</span>are just called &ldquo;statements&rdquo;. We disallow declarations directly
 inside control flow statements, like this:</p>
-<div class="codehilite"><pre><span class="k">if</span> (<span class="i">monday</span>) <span class="k">var</span> <span class="i">croissant</span> = <span class="s">&quot;yes&quot;</span>; <span class="c">// Error.</span>
+<div class="codehilite" translate="no"><pre><span class="k">if</span> (<span class="i">monday</span>) <span class="k">var</span> <span class="i">croissant</span> = <span class="s">&quot;yes&quot;</span>; <span class="c">// Error.</span>
 </pre></div>
 <p>Allowing it would raise confusing questions around the scope of the variable.
 So, like other languages, we prohibit it syntactically by having a separate
 grammar rule for the subset of statements that <em>are</em> allowed inside a control
 flow body.</p>
-<div class="codehilite"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
+<div class="codehilite" translate="no"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
                | <span class="i">forStmt</span>
                | <span class="i">ifStmt</span>
                | <span class="i">printStmt</span>
@@ -164,7 +164,7 @@ flow body.</p>
                | <span class="i">block</span> ;
 </pre></div>
 <p>Then we use a separate rule for the top level of a script and inside a block.</p>
-<div class="codehilite"><pre><span class="i">declaration</span>    → <span class="i">classDecl</span>
+<div class="codehilite" translate="no"><pre><span class="i">declaration</span>    → <span class="i">classDecl</span>
                | <span class="i">funDecl</span>
                | <span class="i">varDecl</span>
                | <span class="i">statement</span> ;
@@ -181,7 +181,7 @@ the &ldquo;lower-precedence&rdquo; declaration statements in places where only a
 </aside>
 <p>In this chapter, we&rsquo;ll cover only a couple of statements and one
 declaration.</p>
-<div class="codehilite"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
+<div class="codehilite" translate="no"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
                | <span class="i">printStmt</span> ;
 
 <span class="i">declaration</span>    → <span class="i">varDecl</span>
@@ -190,7 +190,7 @@ declaration.</p>
 <p>Up to now, our VM considered a &ldquo;program&rdquo; to be a single expression since that&rsquo;s
 all we could parse and compile. In a full Lox implementation, a program is a
 sequence of declarations. We&rsquo;re ready to support that now.</p>
-<div class="codehilite"><pre class="insert-before">  advance();
+<div class="codehilite" translate="no"><pre class="insert-before">  advance();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>compile</em>()<br>
 replace 2 lines</div>
@@ -206,7 +206,7 @@ replace 2 lines</div>
 
 <p>We keep compiling declarations until we hit the end of the source file. We
 compile a single declaration using this:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>expression</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">declaration</span>() {
   <span class="i">statement</span>();
@@ -216,7 +216,7 @@ add after <em>expression</em>()</div>
 
 <p>We&rsquo;ll get to variable declarations later in the chapter, so for now, we simply
 forward to <code>statement()</code>.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>declaration</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">statement</span>() {
   <span class="k">if</span> (<span class="i">match</span>(<span class="a">TOKEN_PRINT</span>)) {
@@ -229,7 +229,7 @@ add after <em>declaration</em>()</div>
 <p>Blocks can contain declarations, and control flow statements can contain other
 statements. That means these two functions will eventually be recursive. We may
 as well write out the forward declarations now.</p>
-<div class="codehilite"><pre class="insert-before">static void expression();
+<div class="codehilite" translate="no"><pre class="insert-before">static void expression();
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after <em>expression</em>()</div>
 <pre class="insert"><span class="k">static</span> <span class="t">void</span> <span class="i">statement</span>();
@@ -242,7 +242,7 @@ add after <em>expression</em>()</div>
 <p>We have two statement types to support in this chapter. Let&rsquo;s start with <code>print</code>
 statements, which begin, naturally enough, with a <code>print</code> token. We detect that
 using this helper function:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>consume</em>()</div>
 <pre><span class="k">static</span> <span class="t">bool</span> <span class="i">match</span>(<span class="t">TokenType</span> <span class="i">type</span>) {
   <span class="k">if</span> (!<span class="i">check</span>(<span class="i">type</span>)) <span class="k">return</span> <span class="k">false</span>;
@@ -259,7 +259,7 @@ in terms of this other helper:</p>
 <aside name="turtles">
 <p>It&rsquo;s helpers all the way down!</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>consume</em>()</div>
 <pre><span class="k">static</span> <span class="t">bool</span> <span class="i">check</span>(<span class="t">TokenType</span> <span class="i">type</span>) {
   <span class="k">return</span> <span class="i">parser</span>.<span class="i">current</span>.<span class="i">type</span> == <span class="i">type</span>;
@@ -279,7 +279,7 @@ keep.</p>
 </aside>
 <p>If we did match the <code>print</code> token, then we compile the rest of the statement
 here:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>expression</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">printStatement</span>() {
   <span class="i">expression</span>();
@@ -292,7 +292,7 @@ add after <em>expression</em>()</div>
 <p>A <code>print</code> statement evaluates an expression and prints the result, so we first
 parse and compile that expression. The grammar expects a semicolon after that,
 so we consume it. Finally, we emit a new instruction to print the result.</p>
-<div class="codehilite"><pre class="insert-before">  OP_NEGATE,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_NEGATE,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_PRINT</span>,
@@ -301,7 +301,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>At runtime, we execute this instruction like so:</p>
-<div class="codehilite"><pre class="insert-before">        break;
+<div class="codehilite" translate="no"><pre class="insert-before">        break;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_PRINT</span>: {
@@ -335,7 +335,7 @@ because when we get to control flow and looping, a program might execute a long
 series of statements. If each statement grew or shrank the stack, it might
 eventually overflow or underflow.</p>
 <p>While we&rsquo;re in the interpreter loop, we should delete a bit of code.</p>
-<div class="codehilite"><pre class="insert-before">      case OP_RETURN: {
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_RETURN: {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
 replace 2 lines</div>
@@ -353,7 +353,7 @@ name="return">step</span> closer to the complete implementation of clox.</p>
 add functions. Right now, it exits the entire interpreter loop.</p>
 </aside>
 <p>As usual, a new instruction needs support in the disassembler.</p>
-<div class="codehilite"><pre class="insert-before">      return simpleInstruction(&quot;OP_NEGATE&quot;, offset);
+<div class="codehilite" translate="no"><pre class="insert-before">      return simpleInstruction(&quot;OP_NEGATE&quot;, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OP_PRINT</span>:
@@ -363,7 +363,7 @@ in <em>disassembleInstruction</em>()</div>
 <div class="source-file-narrow"><em>debug.c</em>, in <em>disassembleInstruction</em>()</div>
 
 <p>That&rsquo;s our <code>print</code> statement. If you want, give it a whirl:</p>
-<div class="codehilite"><pre><span class="k">print</span> <span class="n">1</span> + <span class="n">2</span>;
+<div class="codehilite" translate="no"><pre><span class="k">print</span> <span class="n">1</span> + <span class="n">2</span>;
 <span class="k">print</span> <span class="n">3</span> * <span class="n">4</span>;
 </pre></div>
 <p>Exciting! OK, maybe not thrilling, but we can build scripts that contain as many
@@ -371,7 +371,7 @@ statements as we want now, which feels like progress.</p>
 <h3><a href="#expression-statements" id="expression-statements"><small>21&#8202;.&#8202;1&#8202;.&#8202;2</small>Expression statements</a></h3>
 <p>Wait until you see the next statement. If we <em>don&rsquo;t</em> see a <code>print</code> keyword, then
 we must be looking at an expression statement.</p>
-<div class="codehilite"><pre class="insert-before">    printStatement();
+<div class="codehilite" translate="no"><pre class="insert-before">    printStatement();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">  } <span class="k">else</span> {
@@ -381,7 +381,7 @@ in <em>statement</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>statement</em>()</div>
 
 <p>It&rsquo;s parsed like so:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>expression</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">expressionStatement</span>() {
   <span class="i">expression</span>();
@@ -395,13 +395,13 @@ add after <em>expression</em>()</div>
 They&rsquo;re how you write an expression in a context where a statement is expected.
 Usually, it&rsquo;s so that you can call a function or evaluate an assignment for its
 side effect, like this:</p>
-<div class="codehilite"><pre><span class="i">brunch</span> = <span class="s">&quot;quiche&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="i">brunch</span> = <span class="s">&quot;quiche&quot;</span>;
 <span class="i">eat</span>(<span class="i">brunch</span>);
 </pre></div>
 <p>Semantically, an expression statement evaluates the expression and discards the
 result. The compiler directly encodes that behavior. It compiles the expression,
 and then emits an <code>OP_POP</code> instruction.</p>
-<div class="codehilite"><pre class="insert-before">  OP_FALSE,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_FALSE,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_POP</span>,
@@ -411,7 +411,7 @@ in enum <em>OpCode</em></div>
 
 <p>As the name implies, that instruction pops the top value off the stack and
 forgets it.</p>
-<div class="codehilite"><pre class="insert-before">      case OP_FALSE: push(BOOL_VAL(false)); break;
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_FALSE: push(BOOL_VAL(false)); break;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_POP</span>: <span class="i">pop</span>(); <span class="k">break</span>;
@@ -420,7 +420,7 @@ in <em>run</em>()</div>
 <div class="source-file-narrow"><em>vm.c</em>, in <em>run</em>()</div>
 
 <p>We can disassemble it too.</p>
-<div class="codehilite"><pre class="insert-before">      return simpleInstruction(&quot;OP_FALSE&quot;, offset);
+<div class="codehilite" translate="no"><pre class="insert-before">      return simpleInstruction(&quot;OP_FALSE&quot;, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OP_POP</span>:
@@ -444,7 +444,7 @@ mode error recovery to minimize the number of cascaded compile errors that it
 reports. The compiler exits panic mode when it reaches a synchronization point.
 For Lox, we chose statement boundaries as that point. Now that we have
 statements, we can implement synchronization.</p>
-<div class="codehilite"><pre class="insert-before">  statement();
+<div class="codehilite" translate="no"><pre class="insert-before">  statement();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>declaration</em>()</div>
 <pre class="insert">
@@ -456,7 +456,7 @@ in <em>declaration</em>()</div>
 
 <p>If we hit a compile error while parsing the previous statement, we enter panic
 mode. When that happens, after the statement we start synchronizing.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>printStatement</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">synchronize</span>() {
   <span class="i">parser</span>.<span class="i">panicMode</span> = <span class="k">false</span>;
@@ -505,7 +505,7 @@ straw-lined stalls full of baby languages <em>moo</em>ing and <em>baa</em>ing at
 </ul>
 <p>We can&rsquo;t do either of the last two until we have some variables, so we start
 with declarations.</p>
-<div class="codehilite"><pre class="insert-before">static void declaration() {
+<div class="codehilite" translate="no"><pre class="insert-before">static void declaration() {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>declaration</em>()<br>
 replace 1 line</div>
@@ -522,7 +522,7 @@ replace 1 line</div>
 
 <p>The placeholder parsing function we sketched out for the declaration grammar
 rule has an actual production now. If we match a <code>var</code> token, we jump here:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>expression</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">varDeclaration</span>() {
   <span class="t">uint8_t</span> <span class="i">global</span> = <span class="i">parseVariable</span>(<span class="s">&quot;Expect variable name.&quot;</span>);
@@ -548,17 +548,17 @@ name="nil"><code>nil</code></span> by emitting an <code>OP_NIL</code> instructio
 expect the statement to be terminated with a semicolon.</p>
 <aside name="nil" class="bottom">
 <p>Essentially, the compiler desugars a variable declaration like:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span>;
 </pre></div>
 <p>into:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="k">nil</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="k">nil</span>;
 </pre></div>
 <p>The code it generates for the former is identical to what it produces for the
 latter.</p>
 </aside>
 <p>There are two new functions here for working with variables and identifiers.
 Here is the first:</p>
-<div class="codehilite"><pre class="insert-before">static void parsePrecedence(Precedence precedence);
+<div class="codehilite" translate="no"><pre class="insert-before">static void parsePrecedence(Precedence precedence);
 
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after <em>parsePrecedence</em>()</div>
@@ -571,7 +571,7 @@ add after <em>parsePrecedence</em>()</div>
 
 <p>It requires the next token to be an identifier, which it consumes and sends
 here:</p>
-<div class="codehilite"><pre class="insert-before">static void parsePrecedence(Precedence precedence);
+<div class="codehilite" translate="no"><pre class="insert-before">static void parsePrecedence(Precedence precedence);
 
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after <em>parsePrecedence</em>()</div>
@@ -592,7 +592,7 @@ the constant table and the instruction then refers to the name by its index in
 the table.</p>
 <p>This function returns that index all the way to <code>varDeclaration()</code> which later
 hands it over to here:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>parseVariable</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">defineVariable</span>(<span class="t">uint8_t</span> <span class="i">global</span>) {
   <span class="i">emitBytes</span>(<span class="a">OP_DEFINE_GLOBAL</span>, <span class="i">global</span>);
@@ -613,7 +613,7 @@ names. Function and class declarations both declare new variables, and variable
 and assignment expressions access them.</p>
 </aside>
 <p>Over in the runtime, we begin with this new instruction:</p>
-<div class="codehilite"><pre class="insert-before">  OP_POP,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_POP,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_DEFINE_GLOBAL</span>,
@@ -622,7 +622,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>Thanks to our handy-dandy hash table, the implementation isn&rsquo;t too hard.</p>
-<div class="codehilite"><pre class="insert-before">      case OP_POP: pop(); break;
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_POP: pop(); break;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_DEFINE_GLOBAL</span>: {
@@ -649,7 +649,7 @@ lax with global variables and lets you redefine them without error. That&rsquo;s
 useful in a REPL session, so the VM supports that by simply overwriting the
 value if the key happens to already be in the hash table.</p>
 <p>There&rsquo;s another little helper macro:</p>
-<div class="codehilite"><pre class="insert-before">#define READ_CONSTANT() (vm.chunk-&gt;constants.values[READ_BYTE()])
+<div class="codehilite" translate="no"><pre class="insert-before">#define READ_CONSTANT() (vm.chunk-&gt;constants.values[READ_BYTE()])
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert"><span class="a">#define READ_STRING() AS_STRING(READ_CONSTANT())</span>
@@ -664,7 +664,7 @@ safe because the compiler never emits an instruction that refers to a non-string
 constant.</p>
 <p>Because we care about lexical hygiene, we also undefine this macro at the end of
 the interpret function.</p>
-<div class="codehilite"><pre class="insert-before">#undef READ_CONSTANT
+<div class="codehilite" translate="no"><pre class="insert-before">#undef READ_CONSTANT
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert"><span class="a">#undef READ_STRING</span>
@@ -675,7 +675,7 @@ in <em>run</em>()</div>
 <p>I keep saying &ldquo;the hash table&rdquo;, but we don&rsquo;t actually have one yet. We need a
 place to store these globals. Since we want them to persist as long as clox is
 running, we store them right in the VM.</p>
-<div class="codehilite"><pre class="insert-before">  Value* stackTop;
+<div class="codehilite" translate="no"><pre class="insert-before">  Value* stackTop;
 </pre><div class="source-file"><em>vm.h</em><br>
 in struct <em>VM</em></div>
 <pre class="insert">  <span class="t">Table</span> <span class="i">globals</span>;
@@ -685,7 +685,7 @@ in struct <em>VM</em></div>
 
 <p>As we did with the string table, we need to initialize the hash table to a valid
 state when the VM boots up.</p>
-<div class="codehilite"><pre class="insert-before">  vm.objects = NULL;
+<div class="codehilite" translate="no"><pre class="insert-before">  vm.objects = NULL;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>initVM</em>()</div>
 <pre class="insert">
@@ -700,7 +700,7 @@ in <em>initVM</em>()</div>
 <p>The process will free everything on exit, but it feels undignified to require
 the operating system to clean up our mess.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">void freeVM() {
+<div class="codehilite" translate="no"><pre class="insert-before">void freeVM() {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>freeVM</em>()</div>
 <pre class="insert">  <span class="i">freeTable</span>(&amp;<span class="i">vm</span>.<span class="i">globals</span>);
@@ -709,7 +709,7 @@ in <em>freeVM</em>()</div>
 <div class="source-file-narrow"><em>vm.c</em>, in <em>freeVM</em>()</div>
 
 <p>As usual, we want to be able to disassemble the new instruction too.</p>
-<div class="codehilite"><pre class="insert-before">      return simpleInstruction(&quot;OP_POP&quot;, offset);
+<div class="codehilite" translate="no"><pre class="insert-before">      return simpleInstruction(&quot;OP_POP&quot;, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OP_DEFINE_GLOBAL</span>:
@@ -724,7 +724,7 @@ they&rsquo;ve done so, because they can&rsquo;t actually <em>use</em> them. So l
 <h2><a href="#reading-variables" id="reading-variables"><small>21&#8202;.&#8202;3</small>Reading Variables</a></h2>
 <p>As in every programming language ever, we access a variable&rsquo;s value using its
 name. We hook up identifier tokens to the expression parser here:</p>
-<div class="codehilite"><pre class="insert-before">  [TOKEN_LESS_EQUAL]    = {NULL,     binary, PREC_COMPARISON},
+<div class="codehilite" translate="no"><pre class="insert-before">  [TOKEN_LESS_EQUAL]    = {NULL,     binary, PREC_COMPARISON},
 </pre><div class="source-file"><em>compiler.c</em><br>
 replace 1 line</div>
 <pre class="insert">  [<span class="a">TOKEN_IDENTIFIER</span>]    = {<span class="i">variable</span>, <span class="a">NULL</span>,   <span class="a">PREC_NONE</span>},
@@ -733,7 +733,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, replace 1 line</div>
 
 <p>That calls this new parser function:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>string</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">variable</span>() {
   <span class="i">namedVariable</span>(<span class="i">parser</span>.<span class="i">previous</span>);
@@ -743,7 +743,7 @@ add after <em>string</em>()</div>
 
 <p>Like with declarations, there are a couple of tiny helper functions that seem
 pointless now but will become more useful in later chapters. I promise.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>string</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">namedVariable</span>(<span class="t">Token</span> <span class="i">name</span>) {
   <span class="t">uint8_t</span> <span class="i">arg</span> = <span class="i">identifierConstant</span>(&amp;<span class="i">name</span>);
@@ -756,7 +756,7 @@ add after <em>string</em>()</div>
 given identifier token and add its lexeme to the chunk&rsquo;s constant table as a
 string. All that remains is to emit an instruction that loads the global
 variable with that name. Here&rsquo;s the instruction:</p>
-<div class="codehilite"><pre class="insert-before">  OP_POP,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_POP,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_GET_GLOBAL</span>,
@@ -765,7 +765,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>Over in the interpreter, the implementation mirrors <code>OP_DEFINE_GLOBAL</code>.</p>
-<div class="codehilite"><pre class="insert-before">      case OP_POP: pop(); break;
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_POP: pop(); break;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_GET_GLOBAL</span>: {
@@ -789,7 +789,7 @@ globals hash table.</p>
 never been defined. That&rsquo;s a runtime error in Lox, so we report it and exit the
 interpreter loop if that happens. Otherwise, we take the value and push it
 onto the stack.</p>
-<div class="codehilite"><pre class="insert-before">      return simpleInstruction(&quot;OP_POP&quot;, offset);
+<div class="codehilite" translate="no"><pre class="insert-before">      return simpleInstruction(&quot;OP_POP&quot;, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OP_GET_GLOBAL</span>:
@@ -800,7 +800,7 @@ in <em>disassembleInstruction</em>()</div>
 
 <p>A little bit of disassembling, and we&rsquo;re done. Our interpreter is now able to
 run code like this:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">beverage</span> = <span class="s">&quot;cafe au lait&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">beverage</span> = <span class="s">&quot;cafe au lait&quot;</span>;
 <span class="k">var</span> <span class="i">breakfast</span> = <span class="s">&quot;beignets with &quot;</span> + <span class="i">beverage</span>;
 <span class="k">print</span> <span class="i">breakfast</span>;
 </pre></div>
@@ -816,7 +816,7 @@ name="jlox">bytecode</span> compiler make assignment annoying to implement.</p>
 <p>Our bytecode VM uses a single-pass compiler. It parses and generates bytecode
 on the fly without any intermediate AST. As soon as it recognizes a piece of
 syntax, it emits code for it. Assignment doesn&rsquo;t naturally fit that. Consider:</p>
-<div class="codehilite"><pre><span class="i">menu</span>.<span class="i">brunch</span>(<span class="i">sunday</span>).<span class="i">beverage</span> = <span class="s">&quot;mimosa&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="i">menu</span>.<span class="i">brunch</span>(<span class="i">sunday</span>).<span class="i">beverage</span> = <span class="s">&quot;mimosa&quot;</span>;
 </pre></div>
 <p>In this code, the parser doesn&rsquo;t realize <code>menu.brunch(sunday).beverage</code> is the
 target of an assignment and not a normal expression until it reaches <code>=</code>, many
@@ -839,7 +839,7 @@ be used as an assignment target, we look for a subsequent <code>=</code> token. 
 one, we compile it as an assignment or setter instead of a variable access or
 getter.</p>
 <p>We don&rsquo;t have setters to worry about yet, so all we need to handle are variables.</p>
-<div class="codehilite"><pre class="insert-before">  uint8_t arg = identifierConstant(&amp;name);
+<div class="codehilite" translate="no"><pre class="insert-before">  uint8_t arg = identifierConstant(&amp;name);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>namedVariable</em>()<br>
 replace 1 line</div>
@@ -859,7 +859,7 @@ replace 1 line</div>
 after the identifier. If we find one, instead of emitting code for a variable
 access, we compile the assigned value and then emit an assignment instruction.</p>
 <p>That&rsquo;s the last instruction we need to add in this chapter.</p>
-<div class="codehilite"><pre class="insert-before">  OP_DEFINE_GLOBAL,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_DEFINE_GLOBAL,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_SET_GLOBAL</span>,
@@ -868,7 +868,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>As you&rsquo;d expect, its runtime behavior is similar to defining a new variable.</p>
-<div class="codehilite"><pre class="insert-before">      }
+<div class="codehilite" translate="no"><pre class="insert-before">      }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_SET_GLOBAL</span>: {
@@ -898,7 +898,7 @@ care to delete that zombie value from the table.</p>
 stack. Remember, assignment is an expression, so it needs to leave that value
 there in case the assignment is nested inside some larger expression.</p>
 <p>Add a dash of disassembly:</p>
-<div class="codehilite"><pre class="insert-before">      return constantInstruction(&quot;OP_DEFINE_GLOBAL&quot;, chunk,
+<div class="codehilite" translate="no"><pre class="insert-before">      return constantInstruction(&quot;OP_DEFINE_GLOBAL&quot;, chunk,
                                  offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
@@ -909,7 +909,7 @@ in <em>disassembleInstruction</em>()</div>
 <div class="source-file-narrow"><em>debug.c</em>, in <em>disassembleInstruction</em>()</div>
 
 <p>So we&rsquo;re done, right? Well<span class="ellipse">&thinsp;.&thinsp;.&thinsp;.&nbsp;</span>not quite. We&rsquo;ve made a mistake! Take a gander at:</p>
-<div class="codehilite"><pre><span class="i">a</span> * <span class="i">b</span> = <span class="i">c</span> + <span class="i">d</span>;
+<div class="codehilite" translate="no"><pre><span class="i">a</span> * <span class="i">b</span> = <span class="i">c</span> + <span class="i">d</span>;
 </pre></div>
 <p>According to Lox&rsquo;s grammar, <code>=</code> has the lowest precedence, so this should be
 parsed roughly like:</p><img src="image/global-variables/ast-good.png" alt="The expected parse, like '(a * b) = (c + d)'." />
@@ -941,7 +941,7 @@ the context of a low-precedence expression. The code that knows the current
 precedence is, logically enough, <code>parsePrecedence()</code>. The <code>variable()</code> function
 doesn&rsquo;t need to know the actual level. It just cares that the precedence is low
 enough to allow assignment, so we pass that fact in as a Boolean.</p>
-<div class="codehilite"><pre class="insert-before">    error(&quot;Expect expression.&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">    error(&quot;Expect expression.&quot;);
     return;
   }
 
@@ -959,7 +959,7 @@ replace 1 line</div>
 <p>Since assignment is the lowest-precedence expression, the only time we allow an
 assignment is when parsing an assignment expression or top-level expression like
 in an expression statement. That flag makes its way to the parser function here:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 function <em>variable</em>()<br>
 replace 3 lines</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">variable</span>(<span class="t">bool</span> <span class="i">canAssign</span>) {
@@ -969,7 +969,7 @@ replace 3 lines</div>
 <div class="source-file-narrow"><em>compiler.c</em>, function <em>variable</em>(), replace 3 lines</div>
 
 <p>Which passes it through a new parameter:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 function <em>namedVariable</em>()<br>
 replace 1 line</div>
 <pre class="insert"><span class="k">static</span> <span class="t">void</span> <span class="i">namedVariable</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">bool</span> <span class="i">canAssign</span>) {
@@ -978,7 +978,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, function <em>namedVariable</em>(), replace 1 line</div>
 
 <p>And then finally uses it here:</p>
-<div class="codehilite"><pre class="insert-before">  uint8_t arg = identifierConstant(&amp;name);
+<div class="codehilite" translate="no"><pre class="insert-before">  uint8_t arg = identifierConstant(&amp;name);
 
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>namedVariable</em>()<br>
@@ -1001,7 +1001,7 @@ associated with <code>=</code>, so it skips that loop.</p>
 <p>Then <code>parsePrecedence()</code> silently returns back to the caller. That also isn&rsquo;t
 right. If the <code>=</code> doesn&rsquo;t get consumed as part of the expression, nothing else
 is going to consume it. It&rsquo;s an error and we should report it.</p>
-<div class="codehilite"><pre class="insert-before">    infixRule();
+<div class="codehilite" translate="no"><pre class="insert-before">    infixRule();
   }
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>parsePrecedence</em>()</div>
@@ -1027,7 +1027,7 @@ would also allow assignment to support <code>array[index] = value</code>.</p>
 </aside>
 <p>So we&rsquo;re going to finish off this chapter with some grunt work. First, let&rsquo;s go
 ahead and pass the flag to the infix parse functions.</p>
-<div class="codehilite"><pre class="insert-before">    ParseFn infixRule = getRule(parser.previous.type)-&gt;infix;
+<div class="codehilite" translate="no"><pre class="insert-before">    ParseFn infixRule = getRule(parser.previous.type)-&gt;infix;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>parsePrecedence</em>()<br>
 replace 1 line</div>
@@ -1038,7 +1038,7 @@ replace 1 line</div>
 
 <p>We&rsquo;ll need that for setters eventually. Then we&rsquo;ll fix the typedef for the
 function type.</p>
-<div class="codehilite"><pre class="insert-before">} Precedence;
+<div class="codehilite" translate="no"><pre class="insert-before">} Precedence;
 
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after enum <em>Precedence</em><br>
@@ -1052,7 +1052,7 @@ typedef struct {
 
 <p>And some completely tedious code to accept this parameter in all of our existing
 parse functions. Here:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 function <em>binary</em>()<br>
 replace 1 line</div>
 <pre class="insert"><span class="k">static</span> <span class="t">void</span> <span class="i">binary</span>(<span class="t">bool</span> <span class="i">canAssign</span>) {
@@ -1061,7 +1061,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, function <em>binary</em>(), replace 1 line</div>
 
 <p>And here:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 function <em>literal</em>()<br>
 replace 1 line</div>
 <pre class="insert"><span class="k">static</span> <span class="t">void</span> <span class="i">literal</span>(<span class="t">bool</span> <span class="i">canAssign</span>) {
@@ -1070,7 +1070,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, function <em>literal</em>(), replace 1 line</div>
 
 <p>And here:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 function <em>grouping</em>()<br>
 replace 1 line</div>
 <pre class="insert"><span class="k">static</span> <span class="t">void</span> <span class="i">grouping</span>(<span class="t">bool</span> <span class="i">canAssign</span>) {
@@ -1079,7 +1079,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, function <em>grouping</em>(), replace 1 line</div>
 
 <p>And here:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 function <em>number</em>()<br>
 replace 1 line</div>
 <pre class="insert"><span class="k">static</span> <span class="t">void</span> <span class="i">number</span>(<span class="t">bool</span> <span class="i">canAssign</span>) {
@@ -1088,7 +1088,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, function <em>number</em>(), replace 1 line</div>
 
 <p>And here too:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 function <em>string</em>()<br>
 replace 1 line</div>
 <pre class="insert"><span class="k">static</span> <span class="t">void</span> <span class="i">string</span>(<span class="t">bool</span> <span class="i">canAssign</span>) {
@@ -1097,7 +1097,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, function <em>string</em>(), replace 1 line</div>
 
 <p>And, finally:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 function <em>unary</em>()<br>
 replace 1 line</div>
 <pre class="insert"><span class="k">static</span> <span class="t">void</span> <span class="i">unary</span>(<span class="t">bool</span> <span class="i">canAssign</span>) {
@@ -1107,7 +1107,7 @@ replace 1 line</div>
 
 <p>Phew! We&rsquo;re back to a C program we can compile. Fire it up and now you can run
 this:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">breakfast</span> = <span class="s">&quot;beignets&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">breakfast</span> = <span class="s">&quot;beignets&quot;</span>;
 <span class="k">var</span> <span class="i">beverage</span> = <span class="s">&quot;cafe au lait&quot;</span>;
 <span class="i">breakfast</span> = <span class="s">&quot;beignets with &quot;</span> + <span class="i">beverage</span>;
 
@@ -1141,7 +1141,7 @@ Lox should handle this gracefully by not reporting an &ldquo;unknown variable&rd
 compile error when the function is first defined.</p>
 <p>But when a user runs a Lox <em>script</em>, the compiler has access to the full
 text of the entire program before any code is run. Consider this program:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">useVar</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">useVar</span>() {
   <span class="k">print</span> <span class="i">oops</span>;
 }
 

--- a/site/hash-tables.html
+++ b/site/hash-tables.html
@@ -395,7 +395,7 @@ up, it will all click into place.</p>
 <p>The great thing about hash tables compared to other classic techniques like
 balanced search trees is that the actual data structure is so simple. Ours goes
 into a new module.</p>
-<div class="codehilite"><div class="source-file"><em>table.h</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>table.h</em><br>
 create new file</div>
 <pre><span class="a">#ifndef clox_table_h</span>
 <span class="a">#define clox_table_h</span>
@@ -418,7 +418,7 @@ track of both the allocated size of the array (<code>capacity</code>) and the nu
 key/value pairs currently stored in it (<code>count</code>). The ratio of count to capacity
 is exactly the load factor of the hash table.</p>
 <p>Each entry is one of these:</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;value.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;value.h&quot;
 </pre><div class="source-file"><em>table.h</em></div>
 <pre class="insert">
 
@@ -442,7 +442,7 @@ equality and reduce them to sequences of bits, it&rsquo;s easy to use them as ha
 keys.</p>
 </aside>
 <p>To create a new, empty hash table, we declare a constructor-like function.</p>
-<div class="codehilite"><pre class="insert-before">} Table;
+<div class="codehilite" translate="no"><pre class="insert-before">} Table;
 
 </pre><div class="source-file"><em>table.h</em><br>
 add after struct <em>Table</em></div>
@@ -454,7 +454,7 @@ add after struct <em>Table</em></div>
 
 <p>We need a new implementation file to define that. While we&rsquo;re at it, let&rsquo;s get
 all of the pesky includes out of the way.</p>
-<div class="codehilite"><div class="source-file"><em>table.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>table.c</em><br>
 create new file</div>
 <pre><span class="a">#include &lt;stdlib.h&gt;</span>
 <span class="a">#include &lt;string.h&gt;</span>
@@ -475,7 +475,7 @@ create new file</div>
 <p>As in our dynamic value array type, a hash table initially starts with zero
 capacity and a <code>NULL</code> array. We don&rsquo;t allocate anything until needed. Assuming
 we do eventually allocate something, we need to be able to free it too.</p>
-<div class="codehilite"><pre class="insert-before">void initTable(Table* table);
+<div class="codehilite" translate="no"><pre class="insert-before">void initTable(Table* table);
 </pre><div class="source-file"><em>table.h</em><br>
 add after <em>initTable</em>()</div>
 <pre class="insert"><span class="t">void</span> <span class="i">freeTable</span>(<span class="t">Table</span>* <span class="i">table</span>);
@@ -486,7 +486,7 @@ add after <em>initTable</em>()</div>
 <div class="source-file-narrow"><em>table.h</em>, add after <em>initTable</em>()</div>
 
 <p>And its glorious implementation:</p>
-<div class="codehilite"><div class="source-file"><em>table.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>table.c</em><br>
 add after <em>initTable</em>()</div>
 <pre><span class="t">void</span> <span class="i">freeTable</span>(<span class="t">Table</span>* <span class="i">table</span>) {
   <span class="a">FREE_ARRAY</span>(<span class="t">Entry</span>, <span class="i">table</span>-&gt;<span class="i">entries</span>, <span class="i">table</span>-&gt;<span class="i">capacity</span>);
@@ -510,7 +510,7 @@ slow. We&rsquo;d lose some of the performance benefit of the hash table if we ha
 walk the string every time we looked for a key in the table. So we&rsquo;ll do the
 obvious thing: cache it.</p>
 <p>Over in the &ldquo;object&rdquo; module in ObjString, we add:</p>
-<div class="codehilite"><pre class="insert-before">  char* chars;
+<div class="codehilite" translate="no"><pre class="insert-before">  char* chars;
 </pre><div class="source-file"><em>object.h</em><br>
 in struct <em>ObjString</em></div>
 <pre class="insert">  <span class="t">uint32_t</span> <span class="i">hash</span>;
@@ -525,7 +525,7 @@ string and copying its characters over is already an <em>O(n)</em> operation, so
 good time to also do the <em>O(n)</em> calculation of the string&rsquo;s hash.</p>
 <p>Whenever we call the internal function to allocate a string, we pass in its
 hash code.</p>
-<div class="codehilite"><div class="source-file"><em>object.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.c</em><br>
 function <em>allocateString</em>()<br>
 replace 1 line</div>
 <pre class="insert"><span class="k">static</span> <span class="t">ObjString</span>* <span class="i">allocateString</span>(<span class="t">char</span>* <span class="i">chars</span>, <span class="t">int</span> <span class="i">length</span>,
@@ -535,7 +535,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>object.c</em>, function <em>allocateString</em>(), replace 1 line</div>
 
 <p>That function simply stores the hash in the struct.</p>
-<div class="codehilite"><pre class="insert-before">  string-&gt;chars = chars;
+<div class="codehilite" translate="no"><pre class="insert-before">  string-&gt;chars = chars;
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>allocateString</em>()</div>
 <pre class="insert">  <span class="i">string</span>-&gt;<span class="i">hash</span> = <span class="i">hash</span>;
@@ -547,7 +547,7 @@ in <em>allocateString</em>()</div>
 <p>The fun happens over at the callers. <code>allocateString()</code> is called from two
 places: the function that copies a string and the one that takes ownership of an
 existing dynamically allocated string. We&rsquo;ll start with the first.</p>
-<div class="codehilite"><pre class="insert-before">ObjString* copyString(const char* chars, int length) {
+<div class="codehilite" translate="no"><pre class="insert-before">ObjString* copyString(const char* chars, int length) {
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>copyString</em>()</div>
 <pre class="insert">  <span class="t">uint32_t</span> <span class="i">hash</span> = <span class="i">hashString</span>(<span class="i">chars</span>, <span class="i">length</span>);
@@ -556,7 +556,7 @@ in <em>copyString</em>()</div>
 <div class="source-file-narrow"><em>object.c</em>, in <em>copyString</em>()</div>
 
 <p>No magic here. We calculate the hash code and then pass it along.</p>
-<div class="codehilite"><pre class="insert-before">  memcpy(heapChars, chars, length);
+<div class="codehilite" translate="no"><pre class="insert-before">  memcpy(heapChars, chars, length);
   heapChars[length] = '\0';
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>copyString</em>()<br>
@@ -567,7 +567,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>object.c</em>, in <em>copyString</em>(), replace 1 line</div>
 
 <p>The other string function is similar.</p>
-<div class="codehilite"><pre class="insert-before">ObjString* takeString(char* chars, int length) {
+<div class="codehilite" translate="no"><pre class="insert-before">ObjString* takeString(char* chars, int length) {
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>takeString</em>()<br>
 replace 1 line</div>
@@ -578,7 +578,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>object.c</em>, in <em>takeString</em>(), replace 1 line</div>
 
 <p>The interesting code is over here:</p>
-<div class="codehilite"><div class="source-file"><em>object.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.c</em><br>
 add after <em>allocateString</em>()</div>
 <pre><span class="k">static</span> <span class="t">uint32_t</span> <span class="i">hashString</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">key</span>, <span class="t">int</span> <span class="i">length</span>) {
   <span class="t">uint32_t</span> <span class="i">hash</span> = <span class="n">2166136261u</span>;
@@ -606,7 +606,7 @@ and clustering.</p>
 <h3><a href="#inserting-entries" id="inserting-entries"><small>20&#8202;.&#8202;4&#8202;.&#8202;2</small>Inserting entries</a></h3>
 <p>Now that string objects know their hash code, we can start putting them into
 hash tables.</p>
-<div class="codehilite"><pre class="insert-before">void freeTable(Table* table);
+<div class="codehilite" translate="no"><pre class="insert-before">void freeTable(Table* table);
 </pre><div class="source-file"><em>table.h</em><br>
 add after <em>freeTable</em>()</div>
 <pre class="insert"><span class="t">bool</span> <span class="i">tableSet</span>(<span class="t">Table</span>* <span class="i">table</span>, <span class="t">ObjString</span>* <span class="i">key</span>, <span class="t">Value</span> <span class="i">value</span>);
@@ -619,7 +619,7 @@ add after <em>freeTable</em>()</div>
 <p>This function adds the given key/value pair to the given hash table. If an entry
 for that key is already present, the new value overwrites the old value. The
 function returns <code>true</code> if a new entry was added. Here&rsquo;s the implementation:</p>
-<div class="codehilite"><div class="source-file"><em>table.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>table.c</em><br>
 add after <em>freeTable</em>()</div>
 <pre><span class="t">bool</span> <span class="i">tableSet</span>(<span class="t">Table</span>* <span class="i">table</span>, <span class="t">ObjString</span>* <span class="i">key</span>, <span class="t">Value</span> <span class="i">value</span>) {
   <span class="t">Entry</span>* <span class="i">entry</span> = <span class="i">findEntry</span>(<span class="i">table</span>-&gt;<span class="i">entries</span>, <span class="i">table</span>-&gt;<span class="i">capacity</span>, <span class="i">key</span>);
@@ -644,7 +644,7 @@ fields in the Entry.</p>
 <p>We&rsquo;re missing a little something here, though. We haven&rsquo;t actually allocated the
 Entry array yet. Oops! Before we can insert anything, we need to make sure we
 have an array, and that it&rsquo;s big enough.</p>
-<div class="codehilite"><pre class="insert-before">bool tableSet(Table* table, ObjString* key, Value value) {
+<div class="codehilite" translate="no"><pre class="insert-before">bool tableSet(Table* table, ObjString* key, Value value) {
 </pre><div class="source-file"><em>table.c</em><br>
 in <em>tableSet</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">table</span>-&gt;<span class="i">count</span> + <span class="n">1</span> &gt; <span class="i">table</span>-&gt;<span class="i">capacity</span> * <span class="a">TABLE_MAX_LOAD</span>) {
@@ -662,7 +662,7 @@ array. The <code>GROW_CAPACITY()</code> macro takes an existing capacity and gro
 a multiple to ensure that we get amortized constant performance over a series
 of inserts.</p>
 <p>The interesting difference here is that <code>TABLE_MAX_LOAD</code> constant.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;value.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;value.h&quot;
 
 </pre><div class="source-file"><em>table.c</em></div>
 <pre class="insert"><span class="a">#define TABLE_MAX_LOAD 0.75</span>
@@ -683,7 +683,7 @@ this.</p>
 </aside>
 <p>We&rsquo;ll get to the implementation of <code>adjustCapacity()</code> soon. First, let&rsquo;s look
 at that <code>findEntry()</code> function you&rsquo;ve been wondering about.</p>
-<div class="codehilite"><div class="source-file"><em>table.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>table.c</em><br>
 add after <em>freeTable</em>()</div>
 <pre><span class="k">static</span> <span class="t">Entry</span>* <span class="i">findEntry</span>(<span class="t">Entry</span>* <span class="i">entries</span>, <span class="t">int</span> <span class="i">capacity</span>,
                         <span class="t">ObjString</span>* <span class="i">key</span>) {
@@ -752,7 +752,7 @@ that returned bucket and we&rsquo;re done.</p>
 <p>Before we can put entries in the hash table, we do need a place to actually
 store them. We need to allocate an array of buckets. That happens in this
 function:</p>
-<div class="codehilite"><div class="source-file"><em>table.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>table.c</em><br>
 add after <em>findEntry</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">adjustCapacity</span>(<span class="t">Table</span>* <span class="i">table</span>, <span class="t">int</span> <span class="i">capacity</span>) {
   <span class="t">Entry</span>* <span class="i">entries</span> = <span class="a">ALLOCATE</span>(<span class="t">Entry</span>, <span class="i">capacity</span>);
@@ -780,7 +780,7 @@ in different buckets.</p>
 <p>Those new buckets may have new collisions that we need to deal with. So the
 simplest way to get every entry where it belongs is to rebuild the table from
 scratch by re-inserting every entry into the new empty array.</p>
-<div class="codehilite"><pre class="insert-before">    entries[i].value = NIL_VAL;
+<div class="codehilite" translate="no"><pre class="insert-before">    entries[i].value = NIL_VAL;
   }
 </pre><div class="source-file"><em>table.c</em><br>
 in <em>adjustCapacity</em>()</div>
@@ -807,7 +807,7 @@ why <code>findEntry()</code> takes a pointer directly to an Entry array and not 
 <code>Table</code> struct. That way, we can pass the new array and capacity before we&rsquo;ve
 stored those in the struct.)</p>
 <p>After that&rsquo;s done, we can release the memory for the old array.</p>
-<div class="codehilite"><pre class="insert-before">    dest-&gt;value = entry-&gt;value;
+<div class="codehilite" translate="no"><pre class="insert-before">    dest-&gt;value = entry-&gt;value;
   }
 
 </pre><div class="source-file"><em>table.c</em><br>
@@ -822,7 +822,7 @@ like. It handles overwriting existing keys and growing itself as needed to
 maintain the desired load capacity.</p>
 <p>While we&rsquo;re at it, let&rsquo;s also define a helper function for copying all of the
 entries of one hash table into another.</p>
-<div class="codehilite"><pre class="insert-before">bool tableSet(Table* table, ObjString* key, Value value);
+<div class="codehilite" translate="no"><pre class="insert-before">bool tableSet(Table* table, ObjString* key, Value value);
 </pre><div class="source-file"><em>table.h</em><br>
 add after <em>tableSet</em>()</div>
 <pre class="insert"><span class="t">void</span> <span class="i">tableAddAll</span>(<span class="t">Table</span>* <span class="i">from</span>, <span class="t">Table</span>* <span class="i">to</span>);
@@ -835,7 +835,7 @@ add after <em>tableSet</em>()</div>
 <p>We won&rsquo;t need this until much later when we support method inheritance, but we
 may as well implement it now while we&rsquo;ve got all the hash table stuff fresh in
 our minds.</p>
-<div class="codehilite"><div class="source-file"><em>table.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>table.c</em><br>
 add after <em>tableSet</em>()</div>
 <pre><span class="t">void</span> <span class="i">tableAddAll</span>(<span class="t">Table</span>* <span class="i">from</span>, <span class="t">Table</span>* <span class="i">to</span>) {
   <span class="k">for</span> (<span class="t">int</span> <span class="i">i</span> = <span class="n">0</span>; <span class="i">i</span> &lt; <span class="i">from</span>-&gt;<span class="i">capacity</span>; <span class="i">i</span>++) {
@@ -855,7 +855,7 @@ destination hash table using the <code>tableSet()</code> function we recently de
 <p>Now that our hash table contains some stuff, let&rsquo;s start pulling things back
 out. Given a key, we can look up the corresponding value, if there is one, with
 this function:</p>
-<div class="codehilite"><pre class="insert-before">void freeTable(Table* table);
+<div class="codehilite" translate="no"><pre class="insert-before">void freeTable(Table* table);
 </pre><div class="source-file"><em>table.h</em><br>
 add after <em>freeTable</em>()</div>
 <pre class="insert"><span class="t">bool</span> <span class="i">tableGet</span>(<span class="t">Table</span>* <span class="i">table</span>, <span class="t">ObjString</span>* <span class="i">key</span>, <span class="t">Value</span>* <span class="i">value</span>);
@@ -867,7 +867,7 @@ add after <em>freeTable</em>()</div>
 <code>true</code>, otherwise it returns <code>false</code>. If the entry exists, the <code>value</code> output
 parameter points to the resulting value.</p>
 <p>Since <code>findEntry()</code> already does the hard work, the implementation isn&rsquo;t bad.</p>
-<div class="codehilite"><div class="source-file"><em>table.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>table.c</em><br>
 add after <em>findEntry</em>()</div>
 <pre><span class="t">bool</span> <span class="i">tableGet</span>(<span class="t">Table</span>* <span class="i">table</span>, <span class="t">ObjString</span>* <span class="i">key</span>, <span class="t">Value</span>* <span class="i">value</span>) {
   <span class="k">if</span> (<span class="i">table</span>-&gt;<span class="i">count</span> == <span class="n">0</span>) <span class="k">return</span> <span class="k">false</span>;
@@ -904,7 +904,7 @@ their desire to overlook it. As we&rsquo;ll see, deleting from a hash table that
 list.</p>
 </aside>
 <p>At least the declaration is simple.</p>
-<div class="codehilite"><pre class="insert-before">bool tableSet(Table* table, ObjString* key, Value value);
+<div class="codehilite" translate="no"><pre class="insert-before">bool tableSet(Table* table, ObjString* key, Value value);
 </pre><div class="source-file"><em>table.h</em><br>
 add after <em>tableSet</em>()</div>
 <pre class="insert"><span class="t">bool</span> <span class="i">tableDelete</span>(<span class="t">Table</span>* <span class="i">table</span>, <span class="t">ObjString</span>* <span class="i">key</span>);
@@ -936,7 +936,7 @@ we are following a probe sequence during a lookup, and we hit a tombstone, we
 so that deleting an entry doesn&rsquo;t break any implicit collision chains and we can
 still find entries after it.</p><img src="image/hash-tables/delete-3.png" alt="Instead of deleting 'biscuit', it's replaced with a tombstone." />
 <p>The code looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>table.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>table.c</em><br>
 add after <em>tableSet</em>()</div>
 <pre><span class="t">bool</span> <span class="i">tableDelete</span>(<span class="t">Table</span>* <span class="i">table</span>, <span class="t">ObjString</span>* <span class="i">key</span>) {
   <span class="k">if</span> (<span class="i">table</span>-&gt;<span class="i">count</span> == <span class="n">0</span>) <span class="k">return</span> <span class="k">false</span>;
@@ -966,7 +966,7 @@ of &ldquo;half&rdquo; entry. It has some of the characteristics of a present ent
 of the characteristics of an empty one.</p>
 <p>When we are following a probe sequence during a lookup, and we hit a tombstone,
 we note it and keep going.</p>
-<div class="codehilite"><pre class="insert-before">  for (;;) {
+<div class="codehilite" translate="no"><pre class="insert-before">  for (;;) {
     Entry* entry = &amp;entries[index];
 </pre><div class="source-file"><em>table.c</em><br>
 in <em>findEntry</em>()<br>
@@ -990,7 +990,7 @@ replace 3 lines</div>
 <div class="source-file-narrow"><em>table.c</em>, in <em>findEntry</em>(), replace 3 lines</div>
 
 <p>The first time we pass a tombstone, we store it in this local variable:</p>
-<div class="codehilite"><pre class="insert-before">  uint32_t index = key-&gt;hash % capacity;
+<div class="codehilite" translate="no"><pre class="insert-before">  uint32_t index = key-&gt;hash % capacity;
 </pre><div class="source-file"><em>table.c</em><br>
 in <em>findEntry</em>()</div>
 <pre class="insert">  <span class="t">Entry</span>* <span class="i">tombstone</span> = <span class="a">NULL</span>;
@@ -1028,7 +1028,7 @@ array slots, so for load factor, we consider tombstones to be full buckets.</p>
 code. The count is no longer the number of entries in the hash table, it&rsquo;s the
 number of entries plus tombstones. That implies that we increment the count
 during insertion only if the new entry goes into an entirely empty bucket.</p>
-<div class="codehilite"><pre class="insert-before">  bool isNewKey = entry-&gt;key == NULL;
+<div class="codehilite" translate="no"><pre class="insert-before">  bool isNewKey = entry-&gt;key == NULL;
 </pre><div class="source-file"><em>table.c</em><br>
 in <em>tableSet</em>()<br>
 replace 1 line</div>
@@ -1046,7 +1046,7 @@ existing entries into it. During that process, we <em>don&rsquo;t</em> copy the 
 over. They don&rsquo;t add any value since we&rsquo;re rebuilding the probe sequences
 anyway, and would just slow down lookups. That means we need to recalculate the
 count since it may change during a resize. So we clear it out:</p>
-<div class="codehilite"><pre class="insert-before">  }
+<div class="codehilite" translate="no"><pre class="insert-before">  }
 
 </pre><div class="source-file"><em>table.c</em><br>
 in <em>adjustCapacity</em>()</div>
@@ -1056,7 +1056,7 @@ in <em>adjustCapacity</em>()</div>
 <div class="source-file-narrow"><em>table.c</em>, in <em>adjustCapacity</em>()</div>
 
 <p>Then each time we find a non-tombstone entry, we increment it.</p>
-<div class="codehilite"><pre class="insert-before">    dest-&gt;value = entry-&gt;value;
+<div class="codehilite" translate="no"><pre class="insert-before">    dest-&gt;value = entry-&gt;value;
 </pre><div class="source-file"><em>table.c</em><br>
 in <em>adjustCapacity</em>()</div>
 <pre class="insert">    <span class="i">table</span>-&gt;<span class="i">count</span>++;
@@ -1140,7 +1140,7 @@ our existing <code>==</code> in <code>findEntry()</code> does the right thing. O
 once we intern all the strings. In order to reliably deduplicate all strings,
 the VM needs to be able to find every string that&rsquo;s created. We do that by
 giving it a hash table to store them all.</p>
-<div class="codehilite"><pre class="insert-before">  Value* stackTop;
+<div class="codehilite" translate="no"><pre class="insert-before">  Value* stackTop;
 </pre><div class="source-file"><em>vm.h</em><br>
 in struct <em>VM</em></div>
 <pre class="insert">  <span class="t">Table</span> <span class="i">strings</span>;
@@ -1149,7 +1149,7 @@ in struct <em>VM</em></div>
 <div class="source-file-narrow"><em>vm.h</em>, in struct <em>VM</em></div>
 
 <p>As usual, we need an include.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;chunk.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;chunk.h&quot;
 </pre><div class="source-file"><em>vm.h</em></div>
 <pre class="insert"><span class="a">#include &quot;table.h&quot;</span>
 </pre><pre class="insert-after">#include &quot;value.h&quot;
@@ -1157,7 +1157,7 @@ in struct <em>VM</em></div>
 <div class="source-file-narrow"><em>vm.h</em></div>
 
 <p>When we spin up a new VM, the string table is empty.</p>
-<div class="codehilite"><pre class="insert-before">  vm.objects = NULL;
+<div class="codehilite" translate="no"><pre class="insert-before">  vm.objects = NULL;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>initVM</em>()</div>
 <pre class="insert">  <span class="i">initTable</span>(&amp;<span class="i">vm</span>.<span class="i">strings</span>);
@@ -1166,7 +1166,7 @@ in <em>initVM</em>()</div>
 <div class="source-file-narrow"><em>vm.c</em>, in <em>initVM</em>()</div>
 
 <p>And when we shut down the VM, we clean up any resources used by the table.</p>
-<div class="codehilite"><pre class="insert-before">void freeVM() {
+<div class="codehilite" translate="no"><pre class="insert-before">void freeVM() {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>freeVM</em>()</div>
 <pre class="insert">  <span class="i">freeTable</span>(&amp;<span class="i">vm</span>.<span class="i">strings</span>);
@@ -1177,7 +1177,7 @@ in <em>freeVM</em>()</div>
 <p>Some languages have a separate type or an explicit step to intern a string. For
 clox, we&rsquo;ll automatically intern every one. That means whenever we create a new
 unique string, we add it to the table.</p>
-<div class="codehilite"><pre class="insert-before">  string-&gt;hash = hash;
+<div class="codehilite" translate="no"><pre class="insert-before">  string-&gt;hash = hash;
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>allocateString</em>()</div>
 <pre class="insert">  <span class="i">tableSet</span>(&amp;<span class="i">vm</span>.<span class="i">strings</span>, <span class="i">string</span>, <span class="a">NIL_VAL</span>);
@@ -1191,7 +1191,7 @@ values.</p>
 <p>This gets a string into the table assuming that it&rsquo;s unique, but we need to
 actually check for duplication before we get here. We do that in the two
 higher-level functions that call <code>allocateString()</code>. Here&rsquo;s one:</p>
-<div class="codehilite"><pre class="insert-before">  uint32_t hash = hashString(chars, length);
+<div class="codehilite" translate="no"><pre class="insert-before">  uint32_t hash = hashString(chars, length);
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>copyString</em>()</div>
 <pre class="insert">  <span class="t">ObjString</span>* <span class="i">interned</span> = <span class="i">tableFindString</span>(&amp;<span class="i">vm</span>.<span class="i">strings</span>, <span class="i">chars</span>, <span class="i">length</span>,
@@ -1207,7 +1207,7 @@ first. If we find it, instead of &ldquo;copying&rdquo;, we just return a referen
 string. Otherwise, we fall through, allocate a new string, and store it in the
 string table.</p>
 <p>Taking ownership of a string is a little different.</p>
-<div class="codehilite"><pre class="insert-before">  uint32_t hash = hashString(chars, length);
+<div class="codehilite" translate="no"><pre class="insert-before">  uint32_t hash = hashString(chars, length);
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>takeString</em>()</div>
 <pre class="insert">  <span class="t">ObjString</span>* <span class="i">interned</span> = <span class="i">tableFindString</span>(&amp;<span class="i">vm</span>.<span class="i">strings</span>, <span class="i">chars</span>, <span class="i">length</span>,
@@ -1226,7 +1226,7 @@ return it, we free the memory for the string that was passed in. Since ownership
 is being passed to this function and we no longer need the duplicate string,
 it&rsquo;s up to us to free it.</p>
 <p>Before we get to the new function we need to write, there&rsquo;s one more include.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;object.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;object.h&quot;
 </pre><div class="source-file"><em>object.c</em></div>
 <pre class="insert"><span class="a">#include &quot;table.h&quot;</span>
 </pre><pre class="insert-after">#include &quot;value.h&quot;
@@ -1236,7 +1236,7 @@ it&rsquo;s up to us to free it.</p>
 <p>To look for a string in the table, we can&rsquo;t use the normal <code>tableGet()</code> function
 because that calls <code>findEntry()</code>, which has the exact problem with duplicate
 strings that we&rsquo;re trying to fix right now. Instead, we use this new function:</p>
-<div class="codehilite"><pre class="insert-before">void tableAddAll(Table* from, Table* to);
+<div class="codehilite" translate="no"><pre class="insert-before">void tableAddAll(Table* from, Table* to);
 </pre><div class="source-file"><em>table.h</em><br>
 add after <em>tableAddAll</em>()</div>
 <pre class="insert"><span class="t">ObjString</span>* <span class="i">tableFindString</span>(<span class="t">Table</span>* <span class="i">table</span>, <span class="k">const</span> <span class="t">char</span>* <span class="i">chars</span>,
@@ -1248,7 +1248,7 @@ add after <em>tableAddAll</em>()</div>
 <div class="source-file-narrow"><em>table.h</em>, add after <em>tableAddAll</em>()</div>
 
 <p>The implementation looks like so:</p>
-<div class="codehilite"><div class="source-file"><em>table.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>table.c</em><br>
 add after <em>tableAddAll</em>()</div>
 <pre><span class="t">ObjString</span>* <span class="i">tableFindString</span>(<span class="t">Table</span>* <span class="i">table</span>, <span class="k">const</span> <span class="t">char</span>* <span class="i">chars</span>,
                            <span class="t">int</span> <span class="i">length</span>, <span class="t">uint32_t</span> <span class="i">hash</span>) {
@@ -1288,7 +1288,7 @@ must have different contents.</p>
 <p>In fact, now that we&rsquo;ve interned all the strings, we can take advantage of it in
 the bytecode interpreter. When a user does <code>==</code> on two objects that happen to be
 strings, we don&rsquo;t need to test the characters any more.</p>
-<div class="codehilite"><pre class="insert-before">    case VAL_NUMBER: return AS_NUMBER(a) == AS_NUMBER(b);
+<div class="codehilite" translate="no"><pre class="insert-before">    case VAL_NUMBER: return AS_NUMBER(a) == AS_NUMBER(b);
 </pre><div class="source-file"><em>value.c</em><br>
 in <em>valuesEqual</em>()<br>
 replace 7 lines</div>

--- a/site/inheritance.html
+++ b/site/inheritance.html
@@ -151,7 +151,7 @@ the <code>class</code> keyword.</p>
 <p>This late in the game, I&rsquo;d rather not add a new reserved word or token to the
 lexer. We don&rsquo;t have <code>extends</code> or even <code>:</code>, so we&rsquo;ll follow Ruby and use a
 less-than sign (<code>&lt;</code>).</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Doughnut</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Doughnut</span> {
   <span class="c">// General doughnut stuff...</span>
 }
 
@@ -161,7 +161,7 @@ less-than sign (<code>&lt;</code>).</p>
 </pre></div>
 <p>To work this into the grammar, we add a new optional clause in our existing
 <code>classDecl</code> rule.</p>
-<div class="codehilite"><pre><span class="i">classDecl</span>      → <span class="s">&quot;class&quot;</span> <span class="t">IDENTIFIER</span> ( <span class="s">&quot;&lt;&quot;</span> <span class="t">IDENTIFIER</span> )?
+<div class="codehilite" translate="no"><pre><span class="i">classDecl</span>      → <span class="s">&quot;class&quot;</span> <span class="t">IDENTIFIER</span> ( <span class="s">&quot;&lt;&quot;</span> <span class="t">IDENTIFIER</span> )?
                  <span class="s">&quot;{&quot;</span> <span class="i">function</span>* <span class="s">&quot;}&quot;</span> ;
 </pre></div>
 <p>After the class name, you can have a <code>&lt;</code> followed by the superclass&rsquo;s name. The
@@ -170,7 +170,7 @@ Unlike some other object-oriented languages like Java, Lox has no root &ldquo;Ob
 class that everything inherits from, so when you omit the superclass clause, the
 class has <em>no</em> superclass, not even an implicit one.</p>
 <p>We want to capture this new syntax in the class declaration&rsquo;s AST node.</p>
-<div class="codehilite"><pre class="insert-before">      &quot;Block      : List&lt;Stmt&gt; statements&quot;,
+<div class="codehilite" translate="no"><pre class="insert-before">      &quot;Block      : List&lt;Stmt&gt; statements&quot;,
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()<br>
 replace 1 line</div>
@@ -186,7 +186,7 @@ but at runtime, that identifier is evaluated as a variable access. Wrapping the
 name in an Expr.Variable early on in the parser gives us an object that the
 resolver can hang the resolution information off of.</p>
 <p>The new parser code follows the grammar directly.</p>
-<div class="codehilite"><pre class="insert-before">    Token name = consume(IDENTIFIER, &quot;Expect class name.&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">    Token name = consume(IDENTIFIER, &quot;Expect class name.&quot;);
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>classDeclaration</em>()</div>
 <pre class="insert">
@@ -202,7 +202,7 @@ in <em>classDeclaration</em>()</div>
 <div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>classDeclaration</em>()</div>
 
 <p>Once we&rsquo;ve (possibly) parsed a superclass declaration, we store it in the AST.</p>
-<div class="codehilite"><pre class="insert-before">    consume(RIGHT_BRACE, &quot;Expect '}' after class body.&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">    consume(RIGHT_BRACE, &quot;Expect '}' after class body.&quot;);
 
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>classDeclaration</em>()<br>
@@ -215,7 +215,7 @@ replace 1 line</div>
 <p>If we didn&rsquo;t parse a superclass clause, the superclass expression will be
 <code>null</code>. We&rsquo;ll have to make sure the later passes check for that. The first of
 those is the resolver.</p>
-<div class="codehilite"><pre class="insert-before">    define(stmt.name);
+<div class="codehilite" translate="no"><pre class="insert-before">    define(stmt.name);
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">
@@ -237,13 +237,13 @@ so it&rsquo;s possible the superclass name refers to a local variable. In that c
 we need to make sure it&rsquo;s resolved.</p>
 <p>Because even well-intentioned programmers sometimes write weird code, there&rsquo;s a
 silly edge case we need to worry about while we&rsquo;re in here. Take a look at this:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Oops</span> &lt; <span class="t">Oops</span> {}
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Oops</span> &lt; <span class="t">Oops</span> {}
 </pre></div>
 <p>There&rsquo;s no way this will do anything useful, and if we let the runtime try to
 run this, it will break the expectation the interpreter has about there not
 being cycles in the inheritance chain. The safest thing is to detect this case
 statically and report it as an error.</p>
-<div class="codehilite"><pre class="insert-before">    define(stmt.name);
+<div class="codehilite" translate="no"><pre class="insert-before">    define(stmt.name);
 
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
@@ -258,7 +258,7 @@ in <em>visitClassStmt</em>()</div>
 <div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>Assuming the code resolves without error, the AST travels to the interpreter.</p>
-<div class="codehilite"><pre class="insert-before">  public Void visitClassStmt(Stmt.Class stmt) {
+<div class="codehilite" translate="no"><pre class="insert-before">  public Void visitClassStmt(Stmt.Class stmt) {
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="t">Object</span> <span class="i">superclass</span> = <span class="k">null</span>;
@@ -278,7 +278,7 @@ in <em>visitClassStmt</em>()</div>
 potentially evaluate to some other kind of object, we have to check at runtime
 that the thing we want to be the superclass is actually a class. Bad things
 would happen if we allowed code like:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="t">NotAClass</span> = <span class="s">&quot;I am totally not a class&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="t">NotAClass</span> = <span class="s">&quot;I am totally not a class&quot;</span>;
 
 <span class="k">class</span> <span class="t">Subclass</span> &lt; <span class="t">NotAClass</span> {} <span class="c">// ?!</span>
 </pre></div>
@@ -286,7 +286,7 @@ would happen if we allowed code like:</p>
 the syntactic representation of a class<span class="em">&mdash;</span>its AST node<span class="em">&mdash;</span>into its runtime
 representation, a LoxClass object. We need to plumb the superclass through to
 that too. We pass the superclass to the constructor.</p>
-<div class="codehilite"><pre class="insert-before">      methods.put(method.name.lexeme, function);
+<div class="codehilite" translate="no"><pre class="insert-before">      methods.put(method.name.lexeme, function);
     }
 
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
@@ -300,7 +300,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitClassStmt</em>(), replace 1 line</div>
 
 <p>The constructor stores it in a field.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxClass.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/LoxClass.java</em><br>
 constructor <em>LoxClass</em>()<br>
 replace 1 line</div>
 <pre class="insert">  <span class="t">LoxClass</span>(<span class="t">String</span> <span class="i">name</span>, <span class="t">LoxClass</span> <span class="i">superclass</span>,
@@ -311,7 +311,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>lox/LoxClass.java</em>, constructor <em>LoxClass</em>(), replace 1 line</div>
 
 <p>Which we declare here:</p>
-<div class="codehilite"><pre class="insert-before">  final String name;
+<div class="codehilite" translate="no"><pre class="insert-before">  final String name;
 </pre><div class="source-file"><em>lox/LoxClass.java</em><br>
 in class <em>LoxClass</em></div>
 <pre class="insert">  <span class="k">final</span> <span class="t">LoxClass</span> <span class="i">superclass</span>;
@@ -340,7 +340,7 @@ subclass. In other words, methods are inherited from the superclass.</p>
 <p>This lines up with one of the goals of inheritance<span class="em">&mdash;</span>to give users a way to
 reuse code across classes. Implementing this in our interpreter is
 astonishingly easy.</p>
-<div class="codehilite"><pre class="insert-before">      return methods.get(name);
+<div class="codehilite" translate="no"><pre class="insert-before">      return methods.get(name);
     }
 
 </pre><div class="source-file"><em>lox/LoxClass.java</em><br>
@@ -356,7 +356,7 @@ in <em>findMethod</em>()</div>
 <p>That&rsquo;s literally all there is to it. When we are looking up a method on an
 instance, if we don&rsquo;t find it on the instance&rsquo;s class, we recurse up through the
 superclass chain and look there. Give it a try:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Doughnut</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Doughnut</span> {
   <span class="i">cook</span>() {
     <span class="k">print</span> <span class="s">&quot;Fry until golden brown.&quot;</span>;
   }
@@ -382,7 +382,7 @@ to the original one. If the subclass method tries to call it by name, it will
 just recursively hit its own override. We need a way to say &ldquo;Call this method,
 but look for it directly on my superclass and ignore my override&rdquo;. Java uses
 <code>super</code> for this, and we&rsquo;ll use that same syntax in Lox. Here is an example:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Doughnut</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Doughnut</span> {
   <span class="i">cook</span>() {
     <span class="k">print</span> <span class="s">&quot;Fry until golden brown.&quot;</span>;
   }
@@ -398,7 +398,7 @@ but look for it directly on my superclass and ignore my override&rdquo;. Java us
 <span class="t">BostonCream</span>().<span class="i">cook</span>();
 </pre></div>
 <p>If you run this, it should print:</p>
-<div class="codehilite"><pre>Fry until golden brown.
+<div class="codehilite" translate="no"><pre>Fry until golden brown.
 Pipe full of custard and coat with chocolate.
 </pre></div>
 <p>We have a new expression form. The <code>super</code> keyword, followed by a dot and an
@@ -409,11 +409,11 @@ starts at the superclass.</p>
 is that one lone token. But with <code>super</code>, the subsequent <code>.</code> and property name
 are inseparable parts of the <code>super</code> expression. You can&rsquo;t have a bare <code>super</code>
 token all by itself.</p>
-<div class="codehilite"><pre><span class="k">print</span> <span class="k">super</span>; <span class="c">// Syntax error.</span>
+<div class="codehilite" translate="no"><pre><span class="k">print</span> <span class="k">super</span>; <span class="c">// Syntax error.</span>
 </pre></div>
 <p>So the new clause we add to the <code>primary</code> rule in our grammar includes the
 property access as well.</p>
-<div class="codehilite"><pre><span class="i">primary</span>        → <span class="s">&quot;true&quot;</span> | <span class="s">&quot;false&quot;</span> | <span class="s">&quot;nil&quot;</span> | <span class="s">&quot;this&quot;</span>
+<div class="codehilite" translate="no"><pre><span class="i">primary</span>        → <span class="s">&quot;true&quot;</span> | <span class="s">&quot;false&quot;</span> | <span class="s">&quot;nil&quot;</span> | <span class="s">&quot;this&quot;</span>
                | <span class="t">NUMBER</span> | <span class="t">STRING</span> | <span class="t">IDENTIFIER</span> | <span class="s">&quot;(&quot;</span> <span class="i">expression</span> <span class="s">&quot;)&quot;</span>
                | <span class="s">&quot;super&quot;</span> <span class="s">&quot;.&quot;</span> <span class="t">IDENTIFIER</span> ;
 </pre></div>
@@ -421,13 +421,13 @@ property access as well.</p>
 methods, the argument list is <em>not</em> part of the expression. Instead, a super
 <em>call</em> is a super <em>access</em> followed by a function call. Like other method calls,
 you can get a handle to a superclass method and invoke it separately.</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">method</span> = <span class="k">super</span>.<span class="i">cook</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">method</span> = <span class="k">super</span>.<span class="i">cook</span>;
 <span class="i">method</span>();
 </pre></div>
 <p>So the <code>super</code> expression itself contains only the token for the <code>super</code> keyword
 and the name of the method being looked up. The corresponding <span
 name="super-ast">syntax tree node</span> is thus:</p>
-<div class="codehilite"><pre class="insert-before">      &quot;Set      : Expr object, Token name, Expr value&quot;,
+<div class="codehilite" translate="no"><pre class="insert-before">      &quot;Set      : Expr object, Token name, Expr value&quot;,
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Super    : Token keyword, Token method&quot;</span>,
@@ -440,7 +440,7 @@ in <em>main</em>()</div>
 </aside>
 <p>Following the grammar, the new parsing code goes inside our existing <code>primary()</code>
 method.</p>
-<div class="codehilite"><pre class="insert-before">      return new Expr.Literal(previous().literal);
+<div class="codehilite" translate="no"><pre class="insert-before">      return new Expr.Literal(previous().literal);
     }
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>primary</em>()</div>
@@ -467,7 +467,7 @@ superclass&rdquo;, but <em>which</em> superclass? The naïve answer is the super
 <code>this</code>, the object the surrounding method was called on. That coincidentally
 produces the right behavior in a lot of cases, but that&rsquo;s not actually correct.
 Gaze upon:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">A</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">A</span> {
   <span class="i">method</span>() {
     <span class="k">print</span> <span class="s">&quot;A method&quot;</span>;
   }
@@ -544,7 +544,7 @@ the method&rsquo;s environment, like so:</p><img src="image/inheritance/environm
 <p>That&rsquo;s a lot of machinery, but we&rsquo;ll get through it a step at a time. Before we
 can get to creating the environment at runtime, we need to handle the
 corresponding scope chain in the resolver.</p>
-<div class="codehilite"><pre class="insert-before">      resolve(stmt.superclass);
+<div class="codehilite" translate="no"><pre class="insert-before">      resolve(stmt.superclass);
     }
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
@@ -563,7 +563,7 @@ in <em>visitClassStmt</em>()</div>
 <p>If the class declaration has a superclass, then we create a new scope
 surrounding all of its methods. In that scope, we define the name &ldquo;super&rdquo;. Once
 we&rsquo;re done resolving the class&rsquo;s methods, we discard that scope.</p>
-<div class="codehilite"><pre class="insert-before">    endScope();
+<div class="codehilite" translate="no"><pre class="insert-before">    endScope();
 
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
@@ -578,7 +578,7 @@ class actually <em>has</em> a superclass. There&rsquo;s no point creating it whe
 a superclass since there&rsquo;d be no superclass to store in it anyway.</p>
 <p>With &ldquo;super&rdquo; defined in a scope chain, we are able to resolve the <code>super</code>
 expression itself.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitSetExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitSuperExpr</span>(<span class="t">Expr</span>.<span class="t">Super</span> <span class="i">expr</span>) {
@@ -593,7 +593,7 @@ stores the number of hops along the environment chain that the interpreter needs
 to walk to find the environment where the superclass is stored.</p>
 <p>This code is mirrored in the interpreter. When we evaluate a subclass
 definition, we create a new environment.</p>
-<div class="codehilite"><pre class="insert-before">        throw new RuntimeError(stmt.superclass.name,
+<div class="codehilite" translate="no"><pre class="insert-before">        throw new RuntimeError(stmt.superclass.name,
             &quot;Superclass must be a class.&quot;);
       }
     }
@@ -618,7 +618,7 @@ LoxClass object for the superclass which we have now that we are in the runtime.
 Then we create the LoxFunctions for each method. Those will capture the current
 environment<span class="em">&mdash;</span>the one where we just bound &ldquo;super&rdquo;<span class="em">&mdash;</span>as their closure, holding
 on to the superclass like we need. Once that&rsquo;s done, we pop the environment.</p>
-<div class="codehilite"><pre class="insert-before">    LoxClass klass = new LoxClass(stmt.name.lexeme,
+<div class="codehilite" translate="no"><pre class="insert-before">    LoxClass klass = new LoxClass(stmt.name.lexeme,
         (LoxClass)superclass, methods);
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitClassStmt</em>()</div>
@@ -635,7 +635,7 @@ in <em>visitClassStmt</em>()</div>
 
 <p>We&rsquo;re ready to interpret <code>super</code> expressions themselves. There are a few moving
 parts, so we&rsquo;ll build this method up in pieces.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitSetExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitSuperExpr</span>(<span class="t">Expr</span>.<span class="t">Super</span> <span class="i">expr</span>) {
@@ -658,7 +658,7 @@ superclass, the <em>instance</em> is still <code>this</code>.</p>
 for the resolver to hang the number of hops to <code>this</code> on. Fortunately, we do
 control the layout of the environment chains. The environment where &ldquo;this&rdquo; is
 bound is always right inside the environment where we store &ldquo;super&rdquo;.</p>
-<div class="codehilite"><pre class="insert-before">    LoxClass superclass = (LoxClass)environment.getAt(
+<div class="codehilite" translate="no"><pre class="insert-before">    LoxClass superclass = (LoxClass)environment.getAt(
         distance, &quot;super&quot;);
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitSuperExpr</em>()</div>
@@ -678,7 +678,7 @@ works.</p>
 can&rsquo;t hide the hacks by leaving them as an &ldquo;exercise for the reader&rdquo;.</p>
 </aside>
 <p>Now we&rsquo;re ready to look up and bind the method, starting at the superclass.</p>
-<div class="codehilite"><pre class="insert-before">    LoxInstance object = (LoxInstance)environment.getAt(
+<div class="codehilite" translate="no"><pre class="insert-before">    LoxInstance object = (LoxInstance)environment.getAt(
         distance - 1, &quot;this&quot;);
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitSuperExpr</em>()</div>
@@ -695,7 +695,7 @@ expression, except that we call <code>findMethod()</code> on the superclass inst
 the class of the current object.</p>
 <p>That&rsquo;s basically it. Except, of course, that we might <em>fail</em> to find the method.
 So we check for that too.</p>
-<div class="codehilite"><pre class="insert-before">
+<div class="codehilite" translate="no"><pre class="insert-before">
 
     LoxFunction method = superclass.findMethod(expr.method.lexeme);
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
@@ -719,7 +719,7 @@ with cream.</p>
 <p>As with previous language features, our implementation does the right thing when
 the user writes correct code, but we haven&rsquo;t bulletproofed the intepreter
 against bad code. In particular, consider:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Eclair</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Eclair</span> {
   <span class="i">cook</span>() {
     <span class="k">super</span>.<span class="i">cook</span>();
     <span class="k">print</span> <span class="s">&quot;Pipe full of crème pâtissière.&quot;</span>;
@@ -732,7 +732,7 @@ and will be found in the environment. That&rsquo;s going to fail here because th
 no surrounding environment for the superclass since there is no superclass. The
 JVM will throw an exception and bring our interpreter to its knees.</p>
 <p>Heck, there are even simpler broken uses of super:</p>
-<div class="codehilite"><pre><span class="k">super</span>.<span class="i">notEvenInAClass</span>();
+<div class="codehilite" translate="no"><pre><span class="k">super</span>.<span class="i">notEvenInAClass</span>();
 </pre></div>
 <p>We could handle errors like these at runtime by checking to see if the lookup
 of &ldquo;super&rdquo; succeeded. But we can tell statically<span class="em">&mdash;</span>just by looking at the
@@ -745,7 +745,7 @@ it sooner rather than later. So we&rsquo;ll report these errors statically, in t
 resolver.</p>
 <p>First, we add a new case to the enum we use to keep track of what kind of class
 is surrounding the current code being visited.</p>
-<div class="codehilite"><pre class="insert-before">    NONE,
+<div class="codehilite" translate="no"><pre class="insert-before">    NONE,
 </pre><pre class="insert-before">    <span class="i">CLASS</span><span class="insert-comma">,</span>
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in enum <em>ClassType</em><br>
@@ -758,7 +758,7 @@ add <em>&ldquo;,&rdquo;</em> to previous line</div>
 <p>We&rsquo;ll use that to distinguish when we&rsquo;re inside a class that has a superclass
 versus one that doesn&rsquo;t. When we resolve a class declaration, we set that if the
 class is a subclass.</p>
-<div class="codehilite"><pre class="insert-before">    if (stmt.superclass != null) {
+<div class="codehilite" translate="no"><pre class="insert-before">    if (stmt.superclass != null) {
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">      <span class="i">currentClass</span> = <span class="t">ClassType</span>.<span class="i">SUBCLASS</span>;
@@ -768,7 +768,7 @@ in <em>visitClassStmt</em>()</div>
 
 <p>Then, when we resolve a <code>super</code> expression, we check to see that we are
 currently inside a scope where that&rsquo;s allowed.</p>
-<div class="codehilite"><pre class="insert-before">  public Void visitSuperExpr(Expr.Super expr) {
+<div class="codehilite" translate="no"><pre class="insert-before">  public Void visitSuperExpr(Expr.Super expr) {
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitSuperExpr</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">currentClass</span> == <span class="t">ClassType</span>.<span class="i">NONE</span>) {
@@ -860,7 +860,7 @@ there is no matching method, the <code>inner</code> call does nothing.</p>
 </li>
 </ul>
 <p>For example:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Doughnut</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Doughnut</span> {
   <span class="i">cook</span>() {
     <span class="k">print</span> <span class="s">&quot;Fry until golden brown.&quot;</span>;
     <span class="i">inner</span>();
@@ -877,7 +877,7 @@ there is no matching method, the <code>inner</code> call does nothing.</p>
 <span class="t">BostonCream</span>().<span class="i">cook</span>();
 </pre></div>
 <p>This should print:</p>
-<div class="codehilite"><pre>Fry until golden brown.
+<div class="codehilite" translate="no"><pre>Fry until golden brown.
 Pipe full of custard and coat with chocolate.
 Place in a nice box.
 </pre></div>

--- a/site/introduction.html
+++ b/site/introduction.html
@@ -269,7 +269,7 @@ implementations, the snippets are quite precise. Also, because I try to keep the
 program in a runnable state even when major features are missing, sometimes we
 add temporary code that gets replaced in later snippets.</p>
 <p>A snippet with all the bells and whistles looks like this:</p>
-<div class="codehilite"><pre class="insert-before">
+<div class="codehilite" translate="no"><pre class="insert-before">
       default:
 </pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()<br>

--- a/site/jumping-back-and-forth.html
+++ b/site/jumping-back-and-forth.html
@@ -119,7 +119,7 @@ value of that field is exactly &ldquo;where we are&rdquo; in the program.</p>
 variable however we want to. In order to implement control flow, all that&rsquo;s
 necessary is to change the <code>ip</code> in more interesting ways. The simplest control
 flow construct is an <code>if</code> statement with no <code>else</code> clause:</p>
-<div class="codehilite"><pre><span class="k">if</span> (<span class="i">condition</span>) <span class="k">print</span>(<span class="s">&quot;condition was truthy&quot;</span>);
+<div class="codehilite" translate="no"><pre><span class="k">if</span> (<span class="i">condition</span>) <span class="k">print</span>(<span class="s">&quot;condition was truthy&quot;</span>);
 </pre></div>
 <p>The VM evaluates the bytecode for the condition expression. If the result is
 truthy, then it continues along and executes the <code>print</code> statement in the body.
@@ -152,7 +152,7 @@ and get started with that.</p>
 <p>This many chapters in, you know the drill. Any new feature starts in the front
 end and works its way through the pipeline. An <code>if</code> statement is, well, a
 statement, so that&rsquo;s where we hook it into the parser.</p>
-<div class="codehilite"><pre class="insert-before">  if (match(TOKEN_PRINT)) {
+<div class="codehilite" translate="no"><pre class="insert-before">  if (match(TOKEN_PRINT)) {
     printStatement();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>statement</em>()</div>
@@ -163,7 +163,7 @@ in <em>statement</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>statement</em>()</div>
 
 <p>When we see an <code>if</code> keyword, we hand off compilation to this function:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>expressionStatement</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">ifStatement</span>() {
   <span class="i">consume</span>(<span class="a">TOKEN_LEFT_PAREN</span>, <span class="s">&quot;Expect &#39;(&#39; after &#39;if&#39;.&quot;</span>);
@@ -182,7 +182,7 @@ add after <em>expressionStatement</em>()</div>
 <p>Have you ever noticed that the <code>(</code> after the <code>if</code> keyword doesn&rsquo;t actually do
 anything useful? The language would be just as unambiguous and easy to parse
 without it, like:</p>
-<div class="codehilite"><pre><span class="k">if</span> <span class="i">condition</span>) <span class="k">print</span>(<span class="s">&quot;looks weird&quot;</span>);
+<div class="codehilite" translate="no"><pre><span class="k">if</span> <span class="i">condition</span>) <span class="k">print</span>(<span class="s">&quot;looks weird&quot;</span>);
 </pre></div>
 <p>The closing <code>)</code> is useful because it separates the condition expression from the
 body. Some languages use a <code>then</code> keyword instead. But the opening <code>(</code> doesn&rsquo;t
@@ -212,7 +212,7 @@ we know how far to jump. So we go back and replace that placeholder offset with
 the real one now that we can calculate it. Sort of like sewing a patch onto the
 existing fabric of the compiled code.</p><img src="image/jumping-back-and-forth/patch.png" alt="A patch containing a number being sewn onto a sheet of bytecode." />
 <p>We encode this trick into two helper functions.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>emitBytes</em>()</div>
 <pre><span class="k">static</span> <span class="t">int</span> <span class="i">emitJump</span>(<span class="t">uint8_t</span> <span class="i">instruction</span>) {
   <span class="i">emitByte</span>(<span class="i">instruction</span>);
@@ -234,7 +234,7 @@ operands for when you need to jump a greater distance.</p>
 </aside>
 <p>The function returns the offset of the emitted instruction in the chunk. After
 compiling the then branch, we take that offset and pass it to this:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>emitConstant</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">patchJump</span>(<span class="t">int</span> <span class="i">offset</span>) {
   <span class="c">// -2 to adjust for the bytecode for the jump offset itself.</span>
@@ -257,7 +257,7 @@ bytecode count to determine how far to jump. In the case of an <code>if</code> s
 that means right after we compile the then branch and before we compile the next
 statement.</p>
 <p>That&rsquo;s all we need at compile time. Let&rsquo;s define the new instruction.</p>
-<div class="codehilite"><pre class="insert-before">  OP_PRINT,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_PRINT,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_JUMP_IF_FALSE</span>,
@@ -266,7 +266,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>Over in the VM, we get it working like so:</p>
-<div class="codehilite"><pre class="insert-before">        break;
+<div class="codehilite" translate="no"><pre class="insert-before">        break;
       }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
@@ -281,7 +281,7 @@ in <em>run</em>()</div>
 
 <p>This is the first instruction we&rsquo;ve added that takes a 16-bit operand. To read
 that from the chunk, we use a new macro.</p>
-<div class="codehilite"><pre class="insert-before">#define READ_CONSTANT() (vm.chunk-&gt;constants.values[READ_BYTE()])
+<div class="codehilite" translate="no"><pre class="insert-before">#define READ_CONSTANT() (vm.chunk-&gt;constants.values[READ_BYTE()])
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert"><span class="a">#define READ_SHORT() \</span>
@@ -292,7 +292,7 @@ in <em>run</em>()</div>
 
 <p>It yanks the next two bytes from the chunk and builds a 16-bit unsigned integer
 out of them. As usual, we clean up our macro when we&rsquo;re done with it.</p>
-<div class="codehilite"><pre class="insert-before">#undef READ_BYTE
+<div class="codehilite" translate="no"><pre class="insert-before">#undef READ_BYTE
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert"><span class="a">#undef READ_SHORT</span>
@@ -315,7 +315,7 @@ pointer. But we aren&rsquo;t really using C for <em>control flow</em>. If we wan
 could do the same thing purely arithmetically. Let&rsquo;s assume we have a function
 <code>falsey()</code> that takes a Lox Value and returns 1 if it&rsquo;s falsey or 0 otherwise.
 Then we could implement the jump instruction like:</p>
-<div class="codehilite"><pre><span class="k">case</span> <span class="a">OP_JUMP_IF_FALSE</span>: {
+<div class="codehilite" translate="no"><pre><span class="k">case</span> <span class="a">OP_JUMP_IF_FALSE</span>: {
   <span class="t">uint16_t</span> <span class="i">offset</span> = <span class="a">READ_SHORT</span>();
   <span class="i">vm</span>.<span class="i">ip</span> += <span class="i">falsey</span>() * <span class="i">offset</span>;
   <span class="k">break</span>;
@@ -334,7 +334,7 @@ support it at runtime in the VM.</p>
 <p>An <code>if</code> statement without support for <code>else</code> clauses is like Morticia Addams
 without Gomez. So, after we compile the then branch, we look for an <code>else</code>
 keyword. If we find one, we compile the else branch.</p>
-<div class="codehilite"><pre class="insert-before">  patchJump(thenJump);
+<div class="codehilite" translate="no"><pre class="insert-before">  patchJump(thenJump);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>ifStatement</em>()</div>
 <pre class="insert">
@@ -352,7 +352,7 @@ that, execution rolls right on through into the else branch. Oops! When the
 condition is true, after we run the then branch, we need to jump over the else
 branch. That way, in either case, we only execute a single branch, like this:</p><img src="image/jumping-back-and-forth/if-else.png" alt="Flowchart of the compiled bytecode for an if with an else clause." />
 <p>To implement that, we need another jump from the end of the then branch.</p>
-<div class="codehilite"><pre class="insert-before">  statement();
+<div class="codehilite" translate="no"><pre class="insert-before">  statement();
 
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>ifStatement</em>()</div>
@@ -363,7 +363,7 @@ in <em>ifStatement</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>ifStatement</em>()</div>
 
 <p>We patch that offset after the end of the else body.</p>
-<div class="codehilite"><pre class="insert-before">  if (match(TOKEN_ELSE)) statement();
+<div class="codehilite" translate="no"><pre class="insert-before">  if (match(TOKEN_ELSE)) statement();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>ifStatement</em>()</div>
 <pre class="insert">  <span class="i">patchJump</span>(<span class="i">elseJump</span>);
@@ -374,7 +374,7 @@ in <em>ifStatement</em>()</div>
 <p>After executing the then branch, this jumps to the next statement after the else
 branch. Unlike the other jump, this jump is unconditional. We always take it, so
 we need another instruction that expresses that.</p>
-<div class="codehilite"><pre class="insert-before">  OP_PRINT,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_PRINT,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_JUMP</span>,
@@ -383,7 +383,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>We interpret it like so:</p>
-<div class="codehilite"><pre class="insert-before">        break;
+<div class="codehilite" translate="no"><pre class="insert-before">        break;
       }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
@@ -409,7 +409,7 @@ explicit <code>OP_POP</code> instructions when compiling an <code>if</code> stat
 care that every execution path through the generated code pops the condition.</p>
 <p>When the condition is truthy, we pop it right before the code inside the then
 branch.</p>
-<div class="codehilite"><pre class="insert-before">  int thenJump = emitJump(OP_JUMP_IF_FALSE);
+<div class="codehilite" translate="no"><pre class="insert-before">  int thenJump = emitJump(OP_JUMP_IF_FALSE);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>ifStatement</em>()</div>
 <pre class="insert">  <span class="i">emitByte</span>(<span class="a">OP_POP</span>);
@@ -418,7 +418,7 @@ in <em>ifStatement</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>ifStatement</em>()</div>
 
 <p>Otherwise, we pop it at the beginning of the else branch.</p>
-<div class="codehilite"><pre class="insert-before">  patchJump(thenJump);
+<div class="codehilite" translate="no"><pre class="insert-before">  patchJump(thenJump);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>ifStatement</em>()</div>
 <pre class="insert">  <span class="i">emitByte</span>(<span class="a">OP_POP</span>);
@@ -435,7 +435,7 @@ where they left it off, all the branch does is discard the condition value.</p>
 <p>If you trace through, you can see that it always executes a single branch and
 ensures the condition is popped first. All that remains is a little disassembler
 support.</p>
-<div class="codehilite"><pre class="insert-before">      return simpleInstruction(&quot;OP_PRINT&quot;, offset);
+<div class="codehilite" translate="no"><pre class="insert-before">      return simpleInstruction(&quot;OP_PRINT&quot;, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OP_JUMP</span>:
@@ -448,7 +448,7 @@ in <em>disassembleInstruction</em>()</div>
 
 <p>These two instructions have a new format with a 16-bit operand, so we add a new
 utility function to disassemble them.</p>
-<div class="codehilite"><div class="source-file"><em>debug.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>debug.c</em><br>
 add after <em>byteInstruction</em>()</div>
 <pre><span class="k">static</span> <span class="t">int</span> <span class="i">jumpInstruction</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">name</span>, <span class="t">int</span> <span class="i">sign</span>,
                            <span class="t">Chunk</span>* <span class="i">chunk</span>, <span class="t">int</span> <span class="i">offset</span>) {
@@ -477,7 +477,7 @@ the left one, they work more like control flow expressions.</p>
 The easiest way to explain them is to just show you the compiler code and the
 control flow it produces in the resulting bytecode. Starting with <code>and</code>, we hook
 it into the expression parsing table here:</p>
-<div class="codehilite"><pre class="insert-before">  [TOKEN_NUMBER]        = {number,   NULL,   PREC_NONE},
+<div class="codehilite" translate="no"><pre class="insert-before">  [TOKEN_NUMBER]        = {number,   NULL,   PREC_NONE},
 </pre><div class="source-file"><em>compiler.c</em><br>
 replace 1 line</div>
 <pre class="insert">  [<span class="a">TOKEN_AND</span>]           = {<span class="a">NULL</span>,     <span class="i">and_</span>,   <span class="a">PREC_AND</span>},
@@ -486,7 +486,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, replace 1 line</div>
 
 <p>That hands off to a new parser function.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>defineVariable</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">and_</span>(<span class="t">bool</span> <span class="i">canAssign</span>) {
   <span class="t">int</span> <span class="i">endJump</span> = <span class="i">emitJump</span>(<span class="a">OP_JUMP_IF_FALSE</span>);
@@ -519,7 +519,7 @@ they affect performance.</p>
 </aside>
 <h3><a href="#logical-or-operator" id="logical-or-operator"><small>23&#8202;.&#8202;2&#8202;.&#8202;1</small>Logical or operator</a></h3>
 <p>The <code>or</code> operator is a little more complex. First we add it to the parse table.</p>
-<div class="codehilite"><pre class="insert-before">  [TOKEN_NIL]           = {literal,  NULL,   PREC_NONE},
+<div class="codehilite" translate="no"><pre class="insert-before">  [TOKEN_NIL]           = {literal,  NULL,   PREC_NONE},
 </pre><div class="source-file"><em>compiler.c</em><br>
 replace 1 line</div>
 <pre class="insert">  [<span class="a">TOKEN_OR</span>]            = {<span class="a">NULL</span>,     <span class="i">or_</span>,    <span class="a">PREC_OR</span>},
@@ -528,7 +528,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, replace 1 line</div>
 
 <p>When that parser consumes an infix <code>or</code> token, it calls this:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>number</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">or_</span>(<span class="t">bool</span> <span class="i">canAssign</span>) {
   <span class="t">int</span> <span class="i">elseJump</span> = <span class="i">emitJump</span>(<span class="a">OP_JUMP_IF_FALSE</span>);
@@ -565,7 +565,7 @@ and maybe a conditional expression like <code>?:</code>, but Lox keeps it simple
 <p>That takes us to the <em>looping</em> statements, which jump <em>backward</em> so that code
 can be executed more than once. Lox only has two loop constructs, <code>while</code> and
 <code>for</code>. A <code>while</code> loop is (much) simpler, so we start the party there.</p>
-<div class="codehilite"><pre class="insert-before">    ifStatement();
+<div class="codehilite" translate="no"><pre class="insert-before">    ifStatement();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">  } <span class="k">else</span> <span class="k">if</span> (<span class="i">match</span>(<span class="a">TOKEN_WHILE</span>)) {
@@ -575,7 +575,7 @@ in <em>statement</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>statement</em>()</div>
 
 <p>When we reach a <code>while</code> token, we call:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>printStatement</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">whileStatement</span>() {
   <span class="i">consume</span>(<span class="a">TOKEN_LEFT_PAREN</span>, <span class="s">&quot;Expect &#39;(&#39; after &#39;while&#39;.&quot;</span>);
@@ -602,7 +602,7 @@ only difference from an <code>if</code> statement is the loop. That looks like t
 <p>Really starting to second-guess my decision to use the same jump instructions
 for the logical operators.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">  statement();
+<div class="codehilite" translate="no"><pre class="insert-before">  statement();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>whileStatement</em>()</div>
 <pre class="insert">  <span class="i">emitLoop</span>(<span class="i">loopStart</span>);
@@ -618,7 +618,7 @@ emit the instruction in two stages since we didn&rsquo;t know how far we were go
 jump until after we emitted the jump instruction. We don&rsquo;t have that problem
 now. We&rsquo;ve already compiled the point in code that we want to jump back to<span class="em">&mdash;</span>it&rsquo;s right before the condition expression.</p>
 <p>All we need to do is capture that location as we compile it.</p>
-<div class="codehilite"><pre class="insert-before">static void whileStatement() {
+<div class="codehilite" translate="no"><pre class="insert-before">static void whileStatement() {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>whileStatement</em>()</div>
 <pre class="insert">  <span class="t">int</span> <span class="i">loopStart</span> = <span class="i">currentChunk</span>()-&gt;<span class="i">count</span>;
@@ -631,7 +631,7 @@ the condition. That way, we re-evaluate the condition expression on each
 iteration. We store the chunk&rsquo;s current instruction count in <code>loopStart</code> to
 record the offset in the bytecode right before the condition expression we&rsquo;re
 about to compile. Then we pass that into this helper function:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>emitBytes</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">emitLoop</span>(<span class="t">int</span> <span class="i">loopStart</span>) {
   <span class="i">emitByte</span>(<span class="a">OP_LOOP</span>);
@@ -658,7 +658,7 @@ figured it was a little easier to sidestep the annoying bit twiddling required
 to manually pack a signed 16-bit integer into two bytes, and we&rsquo;ve got the
 opcode space available, so why not use it?</p>
 <p>The new instruction is here:</p>
-<div class="codehilite"><pre class="insert-before">  OP_JUMP_IF_FALSE,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_JUMP_IF_FALSE,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_LOOP</span>,
@@ -667,7 +667,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>And in the VM, we implement it thusly:</p>
-<div class="codehilite"><pre class="insert-before">      }
+<div class="codehilite" translate="no"><pre class="insert-before">      }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_LOOP</span>: {
@@ -681,7 +681,7 @@ in <em>run</em>()</div>
 
 <p>The only difference from <code>OP_JUMP</code> is a subtraction instead of an addition.
 Disassembly is similar too.</p>
-<div class="codehilite"><pre class="insert-before">      return jumpInstruction(&quot;OP_JUMP_IF_FALSE&quot;, 1, chunk, offset);
+<div class="codehilite" translate="no"><pre class="insert-before">      return jumpInstruction(&quot;OP_JUMP_IF_FALSE&quot;, 1, chunk, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OP_LOOP</span>:
@@ -721,7 +721,7 @@ something similar, though we won&rsquo;t go through anything like an AST. Instea
 our bytecode compiler will use the jump and loop instructions we already have.</p>
 <p>We&rsquo;ll work our way through the implementation a piece at a time, starting with
 the <code>for</code> keyword.</p>
-<div class="codehilite"><pre class="insert-before">    printStatement();
+<div class="codehilite" translate="no"><pre class="insert-before">    printStatement();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">  } <span class="k">else</span> <span class="k">if</span> (<span class="i">match</span>(<span class="a">TOKEN_FOR</span>)) {
@@ -732,7 +732,7 @@ in <em>statement</em>()</div>
 
 <p>It calls a helper function. If we only supported <code>for</code> loops with empty clauses
 like <code>for (;;)</code>, then we could implement it like this:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>expressionStatement</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">forStatement</span>() {
   <span class="i">consume</span>(<span class="a">TOKEN_LEFT_PAREN</span>, <span class="s">&quot;Expect &#39;(&#39; after &#39;for&#39;.&quot;</span>);
@@ -759,7 +759,7 @@ a runtime error.</p>
 <h3><a href="#initializer-clause" id="initializer-clause"><small>23&#8202;.&#8202;4&#8202;.&#8202;1</small>Initializer clause</a></h3>
 <p>Now we&rsquo;ll add the first clause, the initializer. It executes only once, before
 the body, so compiling is straightforward.</p>
-<div class="codehilite"><pre class="insert-before">  consume(TOKEN_LEFT_PAREN, &quot;Expect '(' after 'for'.&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">  consume(TOKEN_LEFT_PAREN, &quot;Expect '(' after 'for'.&quot;);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>forStatement</em>()<br>
 replace 1 line</div>
@@ -784,7 +784,7 @@ emits an <code>OP_POP</code> instruction to discard the value. We don&rsquo;t wa
 initializer to leave anything on the stack.</p>
 <p>If a <code>for</code> statement declares a variable, that variable should be scoped to the
 loop body. We ensure that by wrapping the whole statement in a scope.</p>
-<div class="codehilite"><pre class="insert-before">static void forStatement() {
+<div class="codehilite" translate="no"><pre class="insert-before">static void forStatement() {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">  <span class="i">beginScope</span>();
@@ -793,7 +793,7 @@ in <em>forStatement</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>forStatement</em>()</div>
 
 <p>Then we close it at the end.</p>
-<div class="codehilite"><pre class="insert-before">  emitLoop(loopStart);
+<div class="codehilite" translate="no"><pre class="insert-before">  emitLoop(loopStart);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">  <span class="i">endScope</span>();
@@ -803,7 +803,7 @@ in <em>forStatement</em>()</div>
 
 <h3><a href="#condition-clause" id="condition-clause"><small>23&#8202;.&#8202;4&#8202;.&#8202;2</small>Condition clause</a></h3>
 <p>Next, is the condition expression that can be used to exit the loop.</p>
-<div class="codehilite"><pre class="insert-before">  int loopStart = currentChunk()-&gt;count;
+<div class="codehilite" translate="no"><pre class="insert-before">  int loopStart = currentChunk()-&gt;count;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>forStatement</em>()<br>
 replace 1 line</div>
@@ -829,7 +829,7 @@ jump that exits the loop if the condition is falsey. Since the jump leaves the
 value on the stack, we pop it before executing the body. That ensures we discard
 the value when the condition is true.</p>
 <p>After the loop body, we need to patch that jump.</p>
-<div class="codehilite"><pre class="insert-before">  emitLoop(loopStart);
+<div class="codehilite" translate="no"><pre class="insert-before">  emitLoop(loopStart);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">
@@ -857,7 +857,7 @@ increment, run the body, jump <em>back</em> up to the increment, run it, and the
 the next iteration.</p>
 <p>I know, a little weird, but hey, it beats manually managing ASTs in memory in C,
 right? Here&rsquo;s the code:</p>
-<div class="codehilite"><pre class="insert-before">  }
+<div class="codehilite" translate="no"><pre class="insert-before">  }
 
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>forStatement</em>()<br>
@@ -914,7 +914,7 @@ architecture of our VM.</p>
 <li>
 <p>In addition to <code>if</code> statements, most C-family languages have a multi-way
 <code>switch</code> statement. Add one to clox. The grammar is:</p>
-<div class="codehilite"><pre><span class="i">switchStmt</span>     → <span class="s">&quot;switch&quot;</span> <span class="s">&quot;(&quot;</span> <span class="i">expression</span> <span class="s">&quot;)&quot;</span>
+<div class="codehilite" translate="no"><pre><span class="i">switchStmt</span>     → <span class="s">&quot;switch&quot;</span> <span class="s">&quot;(&quot;</span> <span class="i">expression</span> <span class="s">&quot;)&quot;</span>
                  <span class="s">&quot;{&quot;</span> <span class="i">switchCase</span>* <span class="i">defaultCase</span>? <span class="s">&quot;}&quot;</span> ;
 <span class="i">switchCase</span>     → <span class="s">&quot;case&quot;</span> <span class="i">expression</span> <span class="s">&quot;:&quot;</span> <span class="i">statement</span>* ;
 <span class="i">defaultCase</span>    → <span class="s">&quot;default&quot;</span> <span class="s">&quot;:&quot;</span> <span class="i">statement</span>* ;
@@ -932,7 +932,7 @@ statements are done.</p>
 <li>
 <p>In jlox, we had a challenge to add support for <code>break</code> statements. This
 time, let&rsquo;s do <code>continue</code>:</p>
-<div class="codehilite"><pre><span class="i">continueStmt</span>   → <span class="s">&quot;continue&quot;</span> <span class="s">&quot;;&quot;</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">continueStmt</span>   → <span class="s">&quot;continue&quot;</span> <span class="s">&quot;;&quot;</span> ;
 </pre></div>
 <p>A <code>continue</code> statement jumps directly to the top of the nearest enclosing
 loop, skipping the rest of the loop body. Inside a <code>for</code> loop, a <code>continue</code>
@@ -1085,7 +1085,7 @@ absence of goto, we often resort to more complex structured patterns. The
 &ldquo;switch inside a loop&rdquo; is a classic one. Another is using a guard variable to
 exit out of a series of nested loops:</p><span name="break">
 </span>
-<div class="codehilite"><pre><span class="c">// See if the matrix contains a zero.</span>
+<div class="codehilite" translate="no"><pre><span class="c">// See if the matrix contains a zero.</span>
 <span class="t">bool</span> <span class="i">found</span> = <span class="k">false</span>;
 <span class="k">for</span> (<span class="t">int</span> <span class="i">x</span> = <span class="n">0</span>; <span class="i">x</span> &lt; <span class="i">xSize</span>; <span class="i">x</span>++) {
   <span class="k">for</span> (<span class="t">int</span> <span class="i">y</span> = <span class="n">0</span>; <span class="i">y</span> &lt; <span class="i">ySize</span>; <span class="i">y</span>++) {
@@ -1102,7 +1102,7 @@ exit out of a series of nested loops:</p><span name="break">
 }
 </pre></div>
 <p>Is that really better than:</p>
-<div class="codehilite"><pre><span class="k">for</span> (<span class="t">int</span> <span class="i">x</span> = <span class="n">0</span>; <span class="i">x</span> &lt; <span class="i">xSize</span>; <span class="i">x</span>++) {
+<div class="codehilite" translate="no"><pre><span class="k">for</span> (<span class="t">int</span> <span class="i">x</span> = <span class="n">0</span>; <span class="i">x</span> &lt; <span class="i">xSize</span>; <span class="i">x</span>++) {
   <span class="k">for</span> (<span class="t">int</span> <span class="i">y</span> = <span class="n">0</span>; <span class="i">y</span> &lt; <span class="i">ySize</span>; <span class="i">y</span>++) {
     <span class="k">for</span> (<span class="t">int</span> <span class="i">z</span> = <span class="n">0</span>; <span class="i">z</span> &lt; <span class="i">zSize</span>; <span class="i">z</span>++) {
       <span class="k">if</span> (<span class="i">matrix</span>[<span class="i">x</span>][<span class="i">y</span>][<span class="i">z</span>] == <span class="n">0</span>) {

--- a/site/local-variables.html
+++ b/site/local-variables.html
@@ -182,7 +182,7 @@ HashMaps to track which local variables were currently in scope. That&rsquo;s so
 the classic, schoolbook way of representing lexical scope. For clox, as usual,
 we&rsquo;re going a little closer to the metal. All of the state lives in a new
 struct.</p>
-<div class="codehilite"><pre class="insert-before">} ParseRule;
+<div class="codehilite" translate="no"><pre class="insert-before">} ParseRule;
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after struct <em>ParseRule</em></div>
 <pre class="insert">
@@ -208,7 +208,7 @@ the locals array a fixed size.</p>
 <p>We&rsquo;re writing a single-pass compiler, so it&rsquo;s not like we have <em>too</em> many other
 options for how to order them in the array.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">#define DEBUG_TRACE_EXECUTION
+<div class="codehilite" translate="no"><pre class="insert-before">#define DEBUG_TRACE_EXECUTION
 </pre><div class="source-file"><em>common.h</em></div>
 <pre class="insert">
 
@@ -230,7 +230,7 @@ top-level block, two is inside that, you get the idea. We use this to track
 which block each local belongs to so that we know which locals to discard when a
 block ends.</p>
 <p>Each local in the array is one of these:</p>
-<div class="codehilite"><pre class="insert-before">} ParseRule;
+<div class="codehilite" translate="no"><pre class="insert-before">} ParseRule;
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after struct <em>ParseRule</em></div>
 <pre class="insert">
@@ -263,7 +263,7 @@ the code we already wrote, so here&rsquo;s a global variable instead:</p>
 application, possibly with multiple compilers running in parallel, then using a
 global variable is a <em>bad</em> idea.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">Parser parser;
+<div class="codehilite" translate="no"><pre class="insert-before">Parser parser;
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after variable <em>parser</em></div>
 <pre class="insert"><span class="t">Compiler</span>* <span class="i">current</span> = <span class="a">NULL</span>;
@@ -272,7 +272,7 @@ add after variable <em>parser</em></div>
 <div class="source-file-narrow"><em>compiler.c</em>, add after variable <em>parser</em></div>
 
 <p>Here&rsquo;s a little function to initialize the compiler:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>emitConstant</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">initCompiler</span>(<span class="t">Compiler</span>* <span class="i">compiler</span>) {
   <span class="i">compiler</span>-&gt;<span class="i">localCount</span> = <span class="n">0</span>;
@@ -283,7 +283,7 @@ add after <em>emitConstant</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, add after <em>emitConstant</em>()</div>
 
 <p>When we first start up the VM, we call it to get everything into a clean state.</p>
-<div class="codehilite"><pre class="insert-before">  initScanner(source);
+<div class="codehilite" translate="no"><pre class="insert-before">  initScanner(source);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>compile</em>()</div>
 <pre class="insert">  <span class="t">Compiler</span> <span class="i">compiler</span>;
@@ -301,7 +301,7 @@ from two things: function bodies and <span name="block">blocks</span>. Functions
 are a big chunk of work that we&rsquo;ll tackle in <a href="calls-and-functions.html">a later chapter</a>, so
 for now we&rsquo;re only going to do blocks. As usual, we start with the syntax. The
 new grammar we&rsquo;ll introduce is:</p>
-<div class="codehilite"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
+<div class="codehilite" translate="no"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
                | <span class="i">printStmt</span>
                | <span class="i">block</span> ;
 
@@ -316,7 +316,7 @@ statements. It could be worse, I suppose. Algol 58 called <code>begin</code> and
 </aside>
 <p>Blocks are a kind of statement, so the rule for them goes in the <code>statement</code>
 production. The corresponding code to compile one looks like this:</p>
-<div class="codehilite"><pre class="insert-before">  if (match(TOKEN_PRINT)) {
+<div class="codehilite" translate="no"><pre class="insert-before">  if (match(TOKEN_PRINT)) {
     printStatement();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>statement</em>()</div>
@@ -333,7 +333,7 @@ helper function to compile the rest of the block:</p>
 <aside name="helper">
 <p>This function will come in handy later for compiling function bodies.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>expression</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">block</span>() {
   <span class="k">while</span> (!<span class="i">check</span>(<span class="a">TOKEN_RIGHT_BRACE</span>) &amp;&amp; !<span class="i">check</span>(<span class="a">TOKEN_EOF</span>)) {
@@ -353,7 +353,7 @@ the compiler doesn&rsquo;t get stuck in a loop.</p>
 the other, so there isn&rsquo;t much to compiling them. The semantically interesting
 thing blocks do is create scopes. Before we compile the body of a block, we call
 this function to enter a new local scope:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>endCompiler</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">beginScope</span>() {
   <span class="i">current</span>-&gt;<span class="i">scopeDepth</span>++;
@@ -364,7 +364,7 @@ add after <em>endCompiler</em>()</div>
 <p>In order to &ldquo;create&rdquo; a scope, all we do is increment the current depth. This is
 certainly much faster than jlox, which allocated an entire new HashMap for
 each one. Given <code>beginScope()</code>, you can probably guess what <code>endScope()</code> does.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>beginScope</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">endScope</span>() {
   <span class="i">current</span>-&gt;<span class="i">scopeDepth</span>--;
@@ -388,7 +388,7 @@ and then returns the constant table index where it was added. Then, after
 the bytecode for storing the variable&rsquo;s value in the global variable hash table.</p>
 <p>Both of those helpers need a few changes to support local variables. In
 <code>parseVariable()</code>, we add:</p>
-<div class="codehilite"><pre class="insert-before">  consume(TOKEN_IDENTIFIER, errorMessage);
+<div class="codehilite" translate="no"><pre class="insert-before">  consume(TOKEN_IDENTIFIER, errorMessage);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>parseVariable</em>()</div>
 <pre class="insert">
@@ -407,7 +407,7 @@ constant table, so if the declaration is inside a local scope, we return a dummy
 table index instead.</p>
 <p>Over in <code>defineVariable()</code>, we need to emit the code to store a local variable
 if we&rsquo;re in a local scope. It looks like this:</p>
-<div class="codehilite"><pre class="insert-before">static void defineVariable(uint8_t global) {
+<div class="codehilite" translate="no"><pre class="insert-before">static void defineVariable(uint8_t global) {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>defineVariable</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">current</span>-&gt;<span class="i">scopeDepth</span> &gt; <span class="n">0</span>) {
@@ -431,7 +431,7 @@ efficient than that.</p>
 <p>The code on the left compiles to the sequence of instructions on the right.</p>
 </aside>
 <p>OK, so what&rsquo;s &ldquo;declaring&rdquo; about? Here&rsquo;s what that does:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>identifierConstant</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">declareVariable</span>() {
   <span class="k">if</span> (<span class="i">current</span>-&gt;<span class="i">scopeDepth</span> == <span class="n">0</span>) <span class="k">return</span>;
@@ -449,7 +449,7 @@ which declarations for them it has seen.</p>
 <p>But for local variables, the compiler does need to remember that the variable
 exists. That&rsquo;s what declaring it does<span class="em">&mdash;</span>it adds it to the compiler&rsquo;s list of
 variables in the current scope. We implement that using another new function.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>identifierConstant</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">addLocal</span>(<span class="t">Token</span> <span class="i">name</span>) {
   <span class="t">Local</span>* <span class="i">local</span> = &amp;<span class="i">current</span>-&gt;<span class="i">locals</span>[<span class="i">current</span>-&gt;<span class="i">localCount</span>++];
@@ -479,7 +479,7 @@ operand, which means the VM only supports up to 256 local variables in scope at
 one time.</p>
 <p>If we try to go over that, not only could we not refer to them at runtime, but
 the compiler would overwrite its own locals array, too. Let&rsquo;s prevent that.</p>
-<div class="codehilite"><pre class="insert-before">static void addLocal(Token name) {
+<div class="codehilite" translate="no"><pre class="insert-before">static void addLocal(Token name) {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>addLocal</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">current</span>-&gt;<span class="i">localCount</span> == <span class="a">UINT8_COUNT</span>) {
@@ -492,7 +492,7 @@ in <em>addLocal</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>addLocal</em>()</div>
 
 <p>The next case is trickier. Consider:</p>
-<div class="codehilite"><pre>{
+<div class="codehilite" translate="no"><pre>{
   <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;first&quot;</span>;
   <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;second&quot;</span>;
 }
@@ -507,7 +507,7 @@ assumption by making this an error.</p>
 code relies on it.</p>
 </aside>
 <p>Note that the above program is different from this one:</p>
-<div class="codehilite"><pre>{
+<div class="codehilite" translate="no"><pre>{
   <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;outer&quot;</span>;
   {
     <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;inner&quot;</span>;
@@ -519,7 +519,7 @@ when the scopes overlap such that both are visible at the same time. That&rsquo;
 shadowing, and Lox does allow that. It&rsquo;s only an error to have two variables
 with the same name in the <em>same</em> local scope.</p>
 <p>We detect that error like so:</p>
-<div class="codehilite"><pre class="insert-before">  Token* name = &amp;parser.previous;
+<div class="codehilite" translate="no"><pre class="insert-before">  Token* name = &amp;parser.previous;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>declareVariable</em>()</div>
 <pre class="insert">  <span class="k">for</span> (<span class="t">int</span> <span class="i">i</span> = <span class="i">current</span>-&gt;<span class="i">localCount</span> - <span class="n">1</span>; <span class="i">i</span> &gt;= <span class="n">0</span>; <span class="i">i</span>--) {
@@ -549,7 +549,7 @@ same name. If we find one in the current scope, we report the error. Otherwise,
 if we reach the beginning of the array or a variable owned by another scope,
 then we know we&rsquo;ve checked all of the existing variables in the scope.</p>
 <p>To see if two identifiers are the same, we use this:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>identifierConstant</em>()</div>
 <pre><span class="k">static</span> <span class="t">bool</span> <span class="i">identifiersEqual</span>(<span class="t">Token</span>* <span class="i">a</span>, <span class="t">Token</span>* <span class="i">b</span>) {
   <span class="k">if</span> (<span class="i">a</span>-&gt;<span class="i">length</span> != <span class="i">b</span>-&gt;<span class="i">length</span>) <span class="k">return</span> <span class="k">false</span>;
@@ -566,7 +566,7 @@ need an include.</p>
 <p>It would be a nice little optimization if we could check their hashes, but
 tokens aren&rsquo;t full LoxStrings, so we haven&rsquo;t calculated their hashes yet.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">#include &lt;stdlib.h&gt;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &lt;stdlib.h&gt;
 </pre><div class="source-file"><em>compiler.c</em></div>
 <pre class="insert"><span class="a">#include &lt;string.h&gt;</span>
 </pre><pre class="insert-after">
@@ -578,7 +578,7 @@ tokens aren&rsquo;t full LoxStrings, so we haven&rsquo;t calculated their hashes
 <p>With this, we&rsquo;re able to bring variables into being. But, like ghosts, they
 linger on beyond the scope where they are declared. When a block ends, we need
 to put them to rest.</p>
-<div class="codehilite"><pre class="insert-before">  current-&gt;scopeDepth--;
+<div class="codehilite" translate="no"><pre class="insert-before">  current-&gt;scopeDepth--;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>endScope</em>()</div>
 <pre class="insert">
@@ -614,7 +614,7 @@ the same functions in the compiler.</p>
 <p>We already have code for getting and setting global variables, and<span class="em">&mdash;</span>like good
 little software engineers<span class="em">&mdash;</span>we want to reuse as much of that existing code as
 we can. Something like this:</p>
-<div class="codehilite"><pre class="insert-before">static void namedVariable(Token name, bool canAssign) {
+<div class="codehilite" translate="no"><pre class="insert-before">static void namedVariable(Token name, bool canAssign) {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>namedVariable</em>()<br>
 replace 1 line</div>
@@ -641,7 +641,7 @@ working with locals. Otherwise, we assume it&rsquo;s a global variable and use t
 existing bytecode instructions for globals.</p>
 <p>A little further down, we use those variables to emit the right instructions.
 For assignment:</p>
-<div class="codehilite"><pre class="insert-before">  if (canAssign &amp;&amp; match(TOKEN_EQUAL)) {
+<div class="codehilite" translate="no"><pre class="insert-before">  if (canAssign &amp;&amp; match(TOKEN_EQUAL)) {
     expression();
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>namedVariable</em>()<br>
@@ -652,7 +652,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>namedVariable</em>(), replace 1 line</div>
 
 <p>And for access:</p>
-<div class="codehilite"><pre class="insert-before">    emitBytes(setOp, (uint8_t)arg);
+<div class="codehilite" translate="no"><pre class="insert-before">    emitBytes(setOp, (uint8_t)arg);
   } else {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>namedVariable</em>()<br>
@@ -664,7 +664,7 @@ replace 1 line</div>
 
 <p>The real heart of this chapter, the part where we resolve a local variable, is
 here:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>identifiersEqual</em>()</div>
 <pre><span class="k">static</span> <span class="t">int</span> <span class="i">resolveLocal</span>(<span class="t">Compiler</span>* <span class="i">compiler</span>, <span class="t">Token</span>* <span class="i">name</span>) {
   <span class="k">for</span> (<span class="t">int</span> <span class="i">i</span> = <span class="i">compiler</span>-&gt;<span class="i">localCount</span> - <span class="n">1</span>; <span class="i">i</span> &gt;= <span class="n">0</span>; <span class="i">i</span>--) {
@@ -698,7 +698,7 @@ wasn&rsquo;t found and should be assumed to be a global variable instead.</p>
 <h3><a href="#interpreting-local-variables" id="interpreting-local-variables"><small>22&#8202;.&#8202;4&#8202;.&#8202;1</small>Interpreting local variables</a></h3>
 <p>Our compiler is emitting two new instructions, so let&rsquo;s get them working. First
 is loading a local variable:</p>
-<div class="codehilite"><pre class="insert-before">  OP_POP,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_POP,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_GET_LOCAL</span>,
@@ -707,7 +707,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>And its implementation:</p>
-<div class="codehilite"><pre class="insert-before">      case OP_POP: pop(); break;
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_POP: pop(); break;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_GET_LOCAL</span>: {
@@ -731,7 +731,7 @@ aspect that makes our bytecode instruction set <em>stack</em>-based.
 cost of having larger instructions with more operands.</p>
 </aside>
 <p>Next is assignment:</p>
-<div class="codehilite"><pre class="insert-before">  OP_GET_LOCAL,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_GET_LOCAL,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_SET_LOCAL</span>,
@@ -740,7 +740,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>You can probably predict the implementation.</p>
-<div class="codehilite"><pre class="insert-before">      }
+<div class="codehilite" translate="no"><pre class="insert-before">      }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_SET_LOCAL</span>: {
@@ -758,7 +758,7 @@ from the stack. Remember, assignment is an expression, and every expression
 produces a value. The value of an assignment expression is the assigned value
 itself, so the VM just leaves the value on the stack.</p>
 <p>Our disassembler is incomplete without support for these two new instructions.</p>
-<div class="codehilite"><pre class="insert-before">      return simpleInstruction(&quot;OP_POP&quot;, offset);
+<div class="codehilite" translate="no"><pre class="insert-before">      return simpleInstruction(&quot;OP_POP&quot;, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OP_GET_LOCAL</span>:
@@ -781,7 +781,7 @@ see the values of local variables organized by their names. To support that,
 we&rsquo;d need to output some additional information that tracks the name of each
 local variable at each stack slot.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>debug.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>debug.c</em><br>
 add after <em>simpleInstruction</em>()</div>
 <pre><span class="k">static</span> <span class="t">int</span> <span class="i">byteInstruction</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">name</span>, <span class="t">Chunk</span>* <span class="i">chunk</span>,
                            <span class="t">int</span> <span class="i">offset</span>) {
@@ -803,7 +803,7 @@ name="elegant">elegant</span>.</p>
 <p>No, not even Scheme.</p>
 </aside>
 <p>We&rsquo;ve got one more edge case to deal with before we end this chapter. Recall this strange beastie we first met in <a href="resolving-and-binding.html#resolving-variable-declarations">jlox&rsquo;s implementation of variable resolution</a>:</p>
-<div class="codehilite"><pre>{
+<div class="codehilite" translate="no"><pre>{
   <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;outer&quot;</span>;
   {
     <span class="k">var</span> <span class="i">a</span> = <span class="i">a</span>;
@@ -823,7 +823,7 @@ for use.</p>
 &ldquo;uninitialized&rdquo; state somehow. We could add a new field to Local, but let&rsquo;s be a
 little more parsimonious with memory. Instead, we&rsquo;ll set the variable&rsquo;s scope
 depth to a special sentinel value, <code>-1</code>.</p>
-<div class="codehilite"><pre class="insert-before">  local-&gt;name = name;
+<div class="codehilite" translate="no"><pre class="insert-before">  local-&gt;name = name;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>addLocal</em>()<br>
 replace 1 line</div>
@@ -834,7 +834,7 @@ replace 1 line</div>
 
 <p>Later, once the variable&rsquo;s initializer has been compiled, we mark it
 initialized.</p>
-<div class="codehilite"><pre class="insert-before">  if (current-&gt;scopeDepth &gt; 0) {
+<div class="codehilite" translate="no"><pre class="insert-before">  if (current-&gt;scopeDepth &gt; 0) {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>defineVariable</em>()</div>
 <pre class="insert">    <span class="i">markInitialized</span>();
@@ -844,7 +844,7 @@ in <em>defineVariable</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>defineVariable</em>()</div>
 
 <p>That is implemented like so:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>parseVariable</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">markInitialized</span>() {
   <span class="i">current</span>-&gt;<span class="i">locals</span>[<span class="i">current</span>-&gt;<span class="i">localCount</span> - <span class="n">1</span>].<span class="i">depth</span> =
@@ -858,7 +858,7 @@ compiler. &ldquo;Declaring&rdquo; is when the variable is added to the scope, an
 is when it becomes available for use.</p>
 <p>When we resolve a reference to a local variable, we check the scope depth to see
 if it&rsquo;s fully defined.</p>
-<div class="codehilite"><pre class="insert-before">    if (identifiersEqual(name, &amp;local-&gt;name)) {
+<div class="codehilite" translate="no"><pre class="insert-before">    if (identifiersEqual(name, &amp;local-&gt;name)) {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>resolveLocal</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">local</span>-&gt;<span class="i">depth</span> == -<span class="n">1</span>) {
@@ -902,7 +902,7 @@ complexity is worth it?</p>
 </li>
 <li>
 <p>How do other languages handle code like this:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="i">a</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="i">a</span>;
 </pre></div>
 <p>What would you do if it was your language? Why?</p>
 </li>

--- a/site/methods-and-initializers.html
+++ b/site/methods-and-initializers.html
@@ -113,7 +113,7 @@ methods without having methods to call, so we&rsquo;ll start with declarations.<
 this time. The runtime representation for methods in clox is similar to that of
 jlox. Each class stores a hash table of methods. Keys are method names, and each
 value is an ObjClosure for the body of the method.</p>
-<div class="codehilite"><pre class="insert-before">typedef struct {
+<div class="codehilite" translate="no"><pre class="insert-before">typedef struct {
   Obj obj;
   ObjString* name;
 </pre><div class="source-file"><em>object.h</em><br>
@@ -124,7 +124,7 @@ in struct <em>ObjClass</em></div>
 <div class="source-file-narrow"><em>object.h</em>, in struct <em>ObjClass</em></div>
 
 <p>A brand new class begins with an empty method table.</p>
-<div class="codehilite"><pre class="insert-before">  klass-&gt;name = name;<span name="klass"> </span>
+<div class="codehilite" translate="no"><pre class="insert-before">  klass-&gt;name = name;<span name="klass"> </span>
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>newClass</em>()</div>
 <pre class="insert">  <span class="i">initTable</span>(&amp;<span class="i">klass</span>-&gt;<span class="i">methods</span>);
@@ -134,7 +134,7 @@ in <em>newClass</em>()</div>
 
 <p>The ObjClass struct owns the memory for this table, so when the memory manager
 deallocates a class, the table should be freed too.</p>
-<div class="codehilite"><pre class="insert-before">    case OBJ_CLASS: {
+<div class="codehilite" translate="no"><pre class="insert-before">    case OBJ_CLASS: {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>freeObject</em>()</div>
 <pre class="insert">      <span class="t">ObjClass</span>* <span class="i">klass</span> = (<span class="t">ObjClass</span>*)<span class="i">object</span>;
@@ -146,7 +146,7 @@ in <em>freeObject</em>()</div>
 <p>Speaking of memory managers, the GC needs to trace through classes into the
 method table. If a class is still reachable (likely through some instance),
 then all of its methods certainly need to stick around too.</p>
-<div class="codehilite"><pre class="insert-before">      markObject((Obj*)klass-&gt;name);
+<div class="codehilite" translate="no"><pre class="insert-before">      markObject((Obj*)klass-&gt;name);
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>blackenObject</em>()</div>
 <pre class="insert">      <span class="i">markTable</span>(&amp;<span class="i">klass</span>-&gt;<span class="i">methods</span>);
@@ -169,7 +169,7 @@ find out.</p>
 <p>The last chapter left us with a compiler that parses classes but allows only an
 empty body. Now we insert a little code to compile a series of method
 declarations between the braces.</p>
-<div class="codehilite"><pre class="insert-before">  consume(TOKEN_LEFT_BRACE, &quot;Expect '{' before class body.&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">  consume(TOKEN_LEFT_BRACE, &quot;Expect '{' before class body.&quot;);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>classDeclaration</em>()</div>
 <pre class="insert">  <span class="k">while</span> (!<span class="i">check</span>(<span class="a">TOKEN_RIGHT_BRACE</span>) &amp;&amp; !<span class="i">check</span>(<span class="a">TOKEN_EOF</span>)) {
@@ -221,7 +221,7 @@ mutations.</p>
 </ol>
 <p>We&rsquo;ll incrementally write the compiler code to see how those all get through to
 the runtime, starting here:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>function</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">method</span>() {
   <span class="i">consume</span>(<span class="a">TOKEN_IDENTIFIER</span>, <span class="s">&quot;Expect method name.&quot;</span>);
@@ -235,7 +235,7 @@ add after <em>function</em>()</div>
 compiler adds the method name token&rsquo;s lexeme to the constant table, getting back
 a table index. Then we emit an <code>OP_METHOD</code> instruction with that index as the
 operand. That&rsquo;s the name. Next is the method body:</p>
-<div class="codehilite"><pre class="insert-before">  uint8_t constant = identifierConstant(&amp;parser.previous);
+<div class="codehilite" translate="no"><pre class="insert-before">  uint8_t constant = identifierConstant(&amp;parser.previous);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>method</em>()</div>
 <pre class="insert">
@@ -263,7 +263,7 @@ case too.</p>
 </aside>
 <p>Fear not. The compiler does know the <em>name</em> of the class. We can capture it
 right after we consume its token.</p>
-<div class="codehilite"><pre class="insert-before">  consume(TOKEN_IDENTIFIER, &quot;Expect class name.&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">  consume(TOKEN_IDENTIFIER, &quot;Expect class name.&quot;);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>classDeclaration</em>()</div>
 <pre class="insert">  <span class="t">Token</span> <span class="i">className</span> = <span class="i">parser</span>.<span class="i">previous</span>;
@@ -274,7 +274,7 @@ in <em>classDeclaration</em>()</div>
 <p>And we know that no other declaration with that name could possibly shadow the
 class. So we do the easy fix. Before we start binding methods, we emit whatever
 code is necessary to load the class back on top of the stack.</p>
-<div class="codehilite"><pre class="insert-before">  defineVariable(nameConstant);
+<div class="codehilite" translate="no"><pre class="insert-before">  defineVariable(nameConstant);
 
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>classDeclaration</em>()</div>
@@ -298,7 +298,7 @@ on the stack.</p>
 method&rsquo;s closure on top with the class right under it. Once we&rsquo;ve reached the
 end of the methods, we no longer need the class and tell the VM to pop it off
 the stack.</p>
-<div class="codehilite"><pre class="insert-before">  consume(TOKEN_RIGHT_BRACE, &quot;Expect '}' after class body.&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">  consume(TOKEN_RIGHT_BRACE, &quot;Expect '}' after class body.&quot;);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>classDeclaration</em>()</div>
 <pre class="insert">  <span class="i">emitByte</span>(<span class="a">OP_POP</span>);
@@ -308,7 +308,7 @@ in <em>classDeclaration</em>()</div>
 
 <p>Putting all of that together, here is an example class declaration to throw at
 the compiler:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Brunch</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Brunch</span> {
   <span class="i">bacon</span>() {}
   <span class="i">eggs</span>() {}
 }
@@ -319,7 +319,7 @@ affect the stack at runtime:</p><img src="image/methods-and-initializers/method-
 instruction.</p>
 <h3><a href="#executing-method-declarations" id="executing-method-declarations"><small>28&#8202;.&#8202;1&#8202;.&#8202;3</small>Executing method declarations</a></h3>
 <p>First we define the opcode.</p>
-<div class="codehilite"><pre class="insert-before">  OP_CLASS,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_CLASS,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_METHOD</span>
@@ -328,7 +328,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>We disassemble it like other instructions that have string constant operands.</p>
-<div class="codehilite"><pre class="insert-before">    case OP_CLASS:
+<div class="codehilite" translate="no"><pre class="insert-before">    case OP_CLASS:
       return constantInstruction(&quot;OP_CLASS&quot;, chunk, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
@@ -339,7 +339,7 @@ in <em>disassembleInstruction</em>()</div>
 <div class="source-file-narrow"><em>debug.c</em>, in <em>disassembleInstruction</em>()</div>
 
 <p>And over in the interpreter, we add a new case too.</p>
-<div class="codehilite"><pre class="insert-before">        break;
+<div class="codehilite" translate="no"><pre class="insert-before">        break;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_METHOD</span>:
@@ -350,7 +350,7 @@ in <em>run</em>()</div>
 <div class="source-file-narrow"><em>vm.c</em>, in <em>run</em>()</div>
 
 <p>There, we read the method name from the constant table and pass it here:</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>closeUpvalues</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">defineMethod</span>(<span class="t">ObjString</span>* <span class="i">name</span>) {
   <span class="t">Value</span> <span class="i">method</span> = <span class="i">peek</span>(<span class="n">0</span>);
@@ -385,11 +385,11 @@ them.</p>
 <h2><a href="#method-references" id="method-references"><small>28&#8202;.&#8202;2</small>Method References</a></h2>
 <p>Most of the time, methods are accessed and immediately called, leading to this
 familiar syntax:</p>
-<div class="codehilite"><pre><span class="i">instance</span>.<span class="i">method</span>(<span class="i">argument</span>);
+<div class="codehilite" translate="no"><pre><span class="i">instance</span>.<span class="i">method</span>(<span class="i">argument</span>);
 </pre></div>
 <p>But remember, in Lox and some other languages, those two steps are distinct and
 can be separated.</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">closure</span> = <span class="i">instance</span>.<span class="i">method</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">closure</span> = <span class="i">instance</span>.<span class="i">method</span>;
 <span class="i">closure</span>(<span class="i">argument</span>);
 </pre></div>
 <p>Since users <em>can</em> separate the operations, we have to implement them separately.
@@ -400,7 +400,7 @@ user can then call like a function.</p>
 return the ObjClosure associated with that name. But we also need to remember
 that when you access a method, <code>this</code> gets bound to the instance the method was
 accessed from. Here&rsquo;s the example from <a href="classes.html#methods-on-classes">when we added methods to jlox</a>:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Person</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Person</span> {
   <span class="i">sayName</span>() {
     <span class="k">print</span> <span class="k">this</span>.<span class="i">name</span>;
   }
@@ -432,7 +432,7 @@ later like a function. When invoked, the VM will do some shenanigans to wire up
 and I used its implementation for inspiration.</p>
 </aside>
 <p>Here&rsquo;s the new object type:</p>
-<div class="codehilite"><pre class="insert-before">} ObjInstance;
+<div class="codehilite" translate="no"><pre class="insert-before">} ObjInstance;
 
 </pre><div class="source-file"><em>object.h</em><br>
 add after struct <em>ObjInstance</em></div>
@@ -453,7 +453,7 @@ have to keep converting the pointer back to a Value when it gets passed to more
 general functions.</p>
 <p>The new struct implies the usual boilerplate you&rsquo;re used to by now. A new case
 in the object type enum:</p>
-<div class="codehilite"><pre class="insert-before">typedef enum {
+<div class="codehilite" translate="no"><pre class="insert-before">typedef enum {
 </pre><div class="source-file"><em>object.h</em><br>
 in enum <em>ObjType</em></div>
 <pre class="insert">  <span class="a">OBJ_BOUND_METHOD</span>,
@@ -462,7 +462,7 @@ in enum <em>ObjType</em></div>
 <div class="source-file-narrow"><em>object.h</em>, in enum <em>ObjType</em></div>
 
 <p>A macro to check a value&rsquo;s type:</p>
-<div class="codehilite"><pre class="insert-before">#define OBJ_TYPE(value)        (AS_OBJ(value)-&gt;type)
+<div class="codehilite" translate="no"><pre class="insert-before">#define OBJ_TYPE(value)        (AS_OBJ(value)-&gt;type)
 
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert"><span class="a">#define IS_BOUND_METHOD(value) isObjType(value, OBJ_BOUND_METHOD)</span>
@@ -471,7 +471,7 @@ in enum <em>ObjType</em></div>
 <div class="source-file-narrow"><em>object.h</em></div>
 
 <p>Another macro to cast the value to an ObjBoundMethod pointer:</p>
-<div class="codehilite"><pre class="insert-before">#define IS_STRING(value)       isObjType(value, OBJ_STRING)
+<div class="codehilite" translate="no"><pre class="insert-before">#define IS_STRING(value)       isObjType(value, OBJ_STRING)
 
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert"><span class="a">#define AS_BOUND_METHOD(value) ((ObjBoundMethod*)AS_OBJ(value))</span>
@@ -480,7 +480,7 @@ in enum <em>ObjType</em></div>
 <div class="source-file-narrow"><em>object.h</em></div>
 
 <p>A function to create a new ObjBoundMethod:</p>
-<div class="codehilite"><pre class="insert-before">} ObjBoundMethod;
+<div class="codehilite" translate="no"><pre class="insert-before">} ObjBoundMethod;
 
 </pre><div class="source-file"><em>object.h</em><br>
 add after struct <em>ObjBoundMethod</em></div>
@@ -491,7 +491,7 @@ add after struct <em>ObjBoundMethod</em></div>
 <div class="source-file-narrow"><em>object.h</em>, add after struct <em>ObjBoundMethod</em></div>
 
 <p>And an implementation of that function here:</p>
-<div class="codehilite"><div class="source-file"><em>object.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.c</em><br>
 add after <em>allocateObject</em>()</div>
 <pre><span class="t">ObjBoundMethod</span>* <span class="i">newBoundMethod</span>(<span class="t">Value</span> <span class="i">receiver</span>,
                                <span class="t">ObjClosure</span>* <span class="i">method</span>) {
@@ -506,7 +506,7 @@ add after <em>allocateObject</em>()</div>
 
 <p>The constructor-like function simply stores the given closure and receiver. When
 the bound method is no longer needed, we free it.</p>
-<div class="codehilite"><pre class="insert-before">  switch (object-&gt;type) {
+<div class="codehilite" translate="no"><pre class="insert-before">  switch (object-&gt;type) {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>freeObject</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OBJ_BOUND_METHOD</span>:
@@ -519,7 +519,7 @@ in <em>freeObject</em>()</div>
 <p>The bound method has a couple of references, but it doesn&rsquo;t <em>own</em> them, so it
 frees nothing but itself. However, those references do get traced by the garbage
 collector.</p>
-<div class="codehilite"><pre class="insert-before">  switch (object-&gt;type) {
+<div class="codehilite" translate="no"><pre class="insert-before">  switch (object-&gt;type) {
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>blackenObject</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OBJ_BOUND_METHOD</span>: {
@@ -542,7 +542,7 @@ the methods. But it feels dubious to me in some vague way to have ObjBoundMethod
 rely on that.</p>
 </aside>
 <p>The last operation all objects support is printing.</p>
-<div class="codehilite"><pre class="insert-before">  switch (OBJ_TYPE(value)) {
+<div class="codehilite" translate="no"><pre class="insert-before">  switch (OBJ_TYPE(value)) {
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>printObject</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OBJ_BOUND_METHOD</span>:
@@ -571,7 +571,7 @@ stack. The instruction&rsquo;s job is to find a field or method with the given n
 and replace the top of the stack with the accessed property.</p>
 <p>The interpreter already handles fields, so we simply extend the
 <code>OP_GET_PROPERTY</code> case with another section.</p>
-<div class="codehilite"><pre class="insert-before">          pop(); // Instance.
+<div class="codehilite" translate="no"><pre class="insert-before">          pop(); // Instance.
           push(value);
           break;
         }
@@ -597,7 +597,7 @@ Otherwise it returns <code>false</code> to indicate a method with that name coul
 found. Since the name also wasn&rsquo;t a field, that means we have a runtime error,
 which aborts the interpreter.</p>
 <p>Here is the good stuff:</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>callValue</em>()</div>
 <pre><span class="k">static</span> <span class="t">bool</span> <span class="i">bindMethod</span>(<span class="t">ObjClass</span>* <span class="i">klass</span>, <span class="t">ObjString</span>* <span class="i">name</span>) {
   <span class="t">Value</span> <span class="i">method</span>;
@@ -621,7 +621,7 @@ the method and wrap it in a new ObjBoundMethod. We grab the receiver from its
 home on top of the stack. Finally, we pop the instance and replace the top of
 the stack with the bound method.</p>
 <p>For example:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Brunch</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Brunch</span> {
   <span class="i">eggs</span>() {}
 }
 
@@ -642,7 +642,7 @@ object type.</p>
 <p>A bound method <em>is</em> a first-class value, so they can store it in variables, pass
 it to functions, and otherwise do &ldquo;value&rdquo;-y stuff with it.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">    switch (OBJ_TYPE(callee)) {
+<div class="codehilite" translate="no"><pre class="insert-before">    switch (OBJ_TYPE(callee)) {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>callValue</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OBJ_BOUND_METHOD</span>: {
@@ -657,7 +657,7 @@ in <em>callValue</em>()</div>
 <code>call()</code> helper to begin an invocation of that closure by pushing a CallFrame
 for it onto the call stack. That&rsquo;s all it takes to be able to run this Lox
 program:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Scone</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Scone</span> {
   <span class="i">topping</span>(<span class="i">first</span>, <span class="i">second</span>) {
     <span class="k">print</span> <span class="s">&quot;scone with &quot;</span> + <span class="i">first</span> + <span class="s">&quot; and &quot;</span> + <span class="i">second</span>;
   }
@@ -676,7 +676,7 @@ accessed inside the body of the method. Lox exposes a method&rsquo;s receiver th
 <code>this</code> expressions. It&rsquo;s time for some new syntax. The lexer already treats
 <code>this</code> as a special token type, so the first step is wiring that token up in the
 parse table.</p>
-<div class="codehilite"><pre class="insert-before">  [TOKEN_SUPER]         = {NULL,     NULL,   PREC_NONE},
+<div class="codehilite" translate="no"><pre class="insert-before">  [TOKEN_SUPER]         = {NULL,     NULL,   PREC_NONE},
 </pre><div class="source-file"><em>compiler.c</em><br>
 replace 1 line</div>
 <pre class="insert">  [<span class="a">TOKEN_THIS</span>]          = {<span class="i">this_</span>,    <span class="a">NULL</span>,   <span class="a">PREC_NONE</span>},
@@ -690,7 +690,7 @@ is a reserved word in C++ and we support compiling clox as C++.</p>
 </aside>
 <p>When the parser encounters a <code>this</code> in prefix position, it dispatches to a new
 parser function.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>variable</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">this_</span>(<span class="t">bool</span> <span class="i">canAssign</span>) {
   <span class="i">variable</span>(<span class="k">false</span>);
@@ -725,7 +725,7 @@ this is going. For <em>method</em> calls, we can repurpose that slot to store th
 receiver. Slot zero will store the instance that <code>this</code> is bound to. In order to
 compile <code>this</code> expressions, the compiler simply needs to give the correct name
 to that local variable.</p>
-<div class="codehilite"><pre class="insert-before">  local-&gt;isCaptured = false;
+<div class="codehilite" translate="no"><pre class="insert-before">  local-&gt;isCaptured = false;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>initCompiler</em>()<br>
 replace 2 lines</div>
@@ -744,7 +744,7 @@ replace 2 lines</div>
 And, in fact, they <em>must not</em> declare a variable named &ldquo;this&rdquo;, so that if you
 write a <code>this</code> expression inside a function declaration which is itself inside a
 method, the <code>this</code> correctly resolves to the outer method&rsquo;s receiver.</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Nested</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Nested</span> {
   <span class="i">method</span>() {
     <span class="k">fun</span> <span class="i">function</span>() {
       <span class="k">print</span> <span class="k">this</span>;
@@ -760,7 +760,7 @@ method, the <code>this</code> correctly resolves to the outer method&rsquo;s rec
 local slot zero, the compiler needs to know whether it&rsquo;s compiling a function or
 method declaration, so we add a new case to our FunctionType enum to distinguish
 methods.</p>
-<div class="codehilite"><pre class="insert-before">  TYPE_FUNCTION,
+<div class="codehilite" translate="no"><pre class="insert-before">  TYPE_FUNCTION,
 </pre><div class="source-file"><em>compiler.c</em><br>
 in enum <em>FunctionType</em></div>
 <pre class="insert">  <span class="a">TYPE_METHOD</span>,
@@ -769,7 +769,7 @@ in enum <em>FunctionType</em></div>
 <div class="source-file-narrow"><em>compiler.c</em>, in enum <em>FunctionType</em></div>
 
 <p>When we compile a method, we use that type.</p>
-<div class="codehilite"><pre class="insert-before">  uint8_t constant = identifierConstant(&amp;parser.previous);
+<div class="codehilite" translate="no"><pre class="insert-before">  uint8_t constant = identifierConstant(&amp;parser.previous);
 
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>method</em>()<br>
@@ -784,7 +784,7 @@ compiler will emit the right <code>OP_GET_LOCAL</code> instructions to access it
 can even capture <code>this</code> and store the receiver in upvalues. Pretty cool.</p>
 <p>Except that at runtime, the receiver isn&rsquo;t actually <em>in</em> slot zero. The
 interpreter isn&rsquo;t holding up its end of the bargain yet. Here is the fix:</p>
-<div class="codehilite"><pre class="insert-before">      case OBJ_BOUND_METHOD: {
+<div class="codehilite" translate="no"><pre class="insert-before">      case OBJ_BOUND_METHOD: {
         ObjBoundMethod* bound = AS_BOUND_METHOD(callee);
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>callValue</em>()</div>
@@ -798,7 +798,7 @@ in <em>callValue</em>()</div>
 then just under those is the closure of the called method. That&rsquo;s where slot
 zero in the new CallFrame will be. This line of code inserts the receiver into
 that slot. For example, given a method call like this:</p>
-<div class="codehilite"><pre><span class="i">scone</span>.<span class="i">topping</span>(<span class="s">&quot;berries&quot;</span>, <span class="s">&quot;cream&quot;</span>);
+<div class="codehilite" translate="no"><pre><span class="i">scone</span>.<span class="i">topping</span>(<span class="s">&quot;berries&quot;</span>, <span class="s">&quot;cream&quot;</span>);
 </pre></div>
 <p>We calculate the slot to store the receiver like so:</p><img src="image/methods-and-initializers/closure-slot.png" alt="Skipping over the argument stack slots to find the slot containing the closure." />
 <p>The <code>-argCount</code> skips past the arguments and the <code>- 1</code> adjusts for the fact that
@@ -808,7 +808,7 @@ that slot. For example, given a method call like this:</p>
 sure it properly handles users <em>mis</em>using <code>this</code>. Lox says it is a compile
 error for a <code>this</code> expression to appear outside of the body of a method. These
 two wrong uses should be caught by the compiler:</p>
-<div class="codehilite"><pre><span class="k">print</span> <span class="k">this</span>; <span class="c">// At top level.</span>
+<div class="codehilite" translate="no"><pre><span class="k">print</span> <span class="k">this</span>; <span class="c">// At top level.</span>
 
 <span class="k">fun</span> <span class="i">notMethod</span>() {
   <span class="k">print</span> <span class="k">this</span>; <span class="c">// In a function.</span>
@@ -827,7 +827,7 @@ variable implicitly considers it a global access if no declaration is found.</p>
 If we had that, we could use it here to determine if we are inside a method. So
 we may as well make our future selves&rsquo; lives a little easier and put that
 machinery in place now.</p>
-<div class="codehilite"><pre class="insert-before">Compiler* current = NULL;
+<div class="codehilite" translate="no"><pre class="insert-before">Compiler* current = NULL;
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after variable <em>current</em></div>
 <pre class="insert"><span class="t">ClassCompiler</span>* <span class="i">currentClass</span> = <span class="a">NULL</span>;
@@ -839,7 +839,7 @@ static Chunk* currentChunk() {
 
 <p>This module variable points to a struct representing the current, innermost
 class being compiled. The new type looks like this:</p>
-<div class="codehilite"><pre class="insert-before">} Compiler;
+<div class="codehilite" translate="no"><pre class="insert-before">} Compiler;
 </pre><div class="source-file"><em>compiler.c</em><br>
 add after struct <em>Compiler</em></div>
 <pre class="insert">
@@ -861,7 +861,7 @@ compiled out through all of the enclosing classes.</p>
 <p>If we aren&rsquo;t inside any class declaration at all, the module variable
 <code>currentClass</code> is <code>NULL</code>. When the compiler begins compiling a class, it pushes
 a new ClassCompiler onto that implicit linked stack.</p>
-<div class="codehilite"><pre class="insert-before">  defineVariable(nameConstant);
+<div class="codehilite" translate="no"><pre class="insert-before">  defineVariable(nameConstant);
 
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>classDeclaration</em>()</div>
@@ -877,7 +877,7 @@ in <em>classDeclaration</em>()</div>
 capability we get by writing our compiler using recursive descent. At the end of
 the class body, we pop that compiler off the stack and restore the enclosing
 one.</p>
-<div class="codehilite"><pre class="insert-before">  emitByte(OP_POP);
+<div class="codehilite" translate="no"><pre class="insert-before">  emitByte(OP_POP);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>classDeclaration</em>()</div>
 <pre class="insert">
@@ -890,7 +890,7 @@ in <em>classDeclaration</em>()</div>
 <p>When an outermost class body ends, <code>enclosing</code> will be <code>NULL</code>, so this resets
 <code>currentClass</code> to <code>NULL</code>. Thus, to see if we are inside a class<span class="em">&mdash;</span>and therefore
 inside a method<span class="em">&mdash;</span>we simply check that module variable.</p>
-<div class="codehilite"><pre class="insert-before">static void this_(bool canAssign) {
+<div class="codehilite" translate="no"><pre class="insert-before">static void this_(bool canAssign) {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>this_</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">currentClass</span> == <span class="a">NULL</span>) {
@@ -941,7 +941,7 @@ since the value would never be seen anyway.</p>
 </ol>
 <aside name="return">
 <p>It&rsquo;s as if the initializer is implicitly wrapped in a bundle of code like this:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">create</span>(<span class="i">klass</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">create</span>(<span class="i">klass</span>) {
   <span class="k">var</span> <span class="i">obj</span> = <span class="i">newInstance</span>(<span class="i">klass</span>);
   <span class="i">obj</span>.<span class="i">init</span>();
   <span class="k">return</span> <span class="i">obj</span>;
@@ -953,7 +953,7 @@ since the value would never be seen anyway.</p>
 those three special rules. We&rsquo;ll go in order.</p>
 <h3><a href="#invoking-initializers" id="invoking-initializers"><small>28&#8202;.&#8202;4&#8202;.&#8202;1</small>Invoking initializers</a></h3>
 <p>First, automatically calling <code>init()</code> on new instances:</p>
-<div class="codehilite"><pre class="insert-before">        vm.stackTop[-argCount - 1] = OBJ_VAL(newInstance(klass));
+<div class="codehilite" translate="no"><pre class="insert-before">        vm.stackTop[-argCount - 1] = OBJ_VAL(newInstance(klass));
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>callValue</em>()</div>
 <pre class="insert">        <span class="t">Value</span> <span class="i">initializer</span>;
@@ -968,7 +968,7 @@ in <em>callValue</em>()</div>
 <p>After the runtime allocates the new instance, we look for an <code>init()</code> method on
 the class. If we find one, we initiate a call to it. This pushes a new CallFrame
 for the initializer&rsquo;s closure. Say we run this program:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Brunch</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Brunch</span> {
   <span class="i">init</span>(<span class="i">food</span>, <span class="i">drink</span>) {}
 }
 
@@ -982,7 +982,7 @@ stack window, so those arguments implicitly get forwarded to the initializer.</p
 simply returns the new uninitialized instance. However, if there is no <code>init()</code>
 method, then it doesn&rsquo;t make any sense to pass arguments to the class when
 creating the instance. We make that an error.</p>
-<div class="codehilite"><pre class="insert-before">          return call(AS_CLOSURE(initializer), argCount);
+<div class="codehilite" translate="no"><pre class="insert-before">          return call(AS_CLOSURE(initializer), argCount);
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>callValue</em>()</div>
 <pre class="insert">        } <span class="k">else</span> <span class="k">if</span> (<span class="i">argCount</span> != <span class="n">0</span>) {
@@ -1001,7 +1001,7 @@ want that to be fast since it happens every time an instance is constructed.
 That means it would be good to take advantage of the string interning we&rsquo;ve
 already implemented. To do that, the VM creates an ObjString for &ldquo;init&rdquo; and
 reuses it. The string lives right in the VM struct.</p>
-<div class="codehilite"><pre class="insert-before">  Table strings;
+<div class="codehilite" translate="no"><pre class="insert-before">  Table strings;
 </pre><div class="source-file"><em>vm.h</em><br>
 in struct <em>VM</em></div>
 <pre class="insert">  <span class="t">ObjString</span>* <span class="i">initString</span>;
@@ -1010,7 +1010,7 @@ in struct <em>VM</em></div>
 <div class="source-file-narrow"><em>vm.h</em>, in struct <em>VM</em></div>
 
 <p>We create and intern the string when the VM boots up.</p>
-<div class="codehilite"><pre class="insert-before">  initTable(&amp;vm.strings);
+<div class="codehilite" translate="no"><pre class="insert-before">  initTable(&amp;vm.strings);
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>initVM</em>()</div>
 <pre class="insert">
@@ -1023,7 +1023,7 @@ in <em>initVM</em>()</div>
 <div class="source-file-narrow"><em>vm.c</em>, in <em>initVM</em>()</div>
 
 <p>We want it to stick around, so the GC considers it a root.</p>
-<div class="codehilite"><pre class="insert-before">  markCompilerRoots();
+<div class="codehilite" translate="no"><pre class="insert-before">  markCompilerRoots();
 </pre><div class="source-file"><em>memory.c</em><br>
 in <em>markRoots</em>()</div>
 <pre class="insert">  <span class="i">markObject</span>((<span class="t">Obj</span>*)<span class="i">vm</span>.<span class="i">initString</span>);
@@ -1036,7 +1036,7 @@ garbage collector now reads <code>vm.initString</code>. That field is initialize
 result of calling <code>copyString()</code>. But copying a string allocates memory, which
 can trigger a GC. If the collector ran at just the wrong time, it would read
 <code>vm.initString</code> before it had been initialized. So, first we zero the field out.</p>
-<div class="codehilite"><pre class="insert-before">  initTable(&amp;vm.strings);
+<div class="codehilite" translate="no"><pre class="insert-before">  initTable(&amp;vm.strings);
 
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>initVM</em>()</div>
@@ -1047,7 +1047,7 @@ in <em>initVM</em>()</div>
 <div class="source-file-narrow"><em>vm.c</em>, in <em>initVM</em>()</div>
 
 <p>We clear the pointer when the VM shuts down since the next line will free it.</p>
-<div class="codehilite"><pre class="insert-before">  freeTable(&amp;vm.strings);
+<div class="codehilite" translate="no"><pre class="insert-before">  freeTable(&amp;vm.strings);
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>freeVM</em>()</div>
 <pre class="insert">  <span class="i">vm</span>.<span class="i">initString</span> = <span class="a">NULL</span>;
@@ -1073,7 +1073,7 @@ instead of the usual implicit <code>nil</code> most functions return. In order t
 <em>that</em>, the compiler needs to actually know when it is compiling an initializer.
 We detect that by checking to see if the name of the method we&rsquo;re compiling is
 &ldquo;init&rdquo;.</p>
-<div class="codehilite"><pre class="insert-before">  FunctionType type = TYPE_METHOD;
+<div class="codehilite" translate="no"><pre class="insert-before">  FunctionType type = TYPE_METHOD;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>method</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">parser</span>.<span class="i">previous</span>.<span class="i">length</span> == <span class="n">4</span> &amp;&amp;
@@ -1086,7 +1086,7 @@ in <em>method</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>method</em>()</div>
 
 <p>We define a new function type to distinguish initializers from other methods.</p>
-<div class="codehilite"><pre class="insert-before">  TYPE_FUNCTION,
+<div class="codehilite" translate="no"><pre class="insert-before">  TYPE_FUNCTION,
 </pre><div class="source-file"><em>compiler.c</em><br>
 in enum <em>FunctionType</em></div>
 <pre class="insert">  <span class="a">TYPE_INITIALIZER</span>,
@@ -1096,7 +1096,7 @@ in enum <em>FunctionType</em></div>
 
 <p>Whenever the compiler emits the implicit return at the end of a body, we check
 the type to decide whether to insert the initializer-specific behavior.</p>
-<div class="codehilite"><pre class="insert-before">static void emitReturn() {
+<div class="codehilite" translate="no"><pre class="insert-before">static void emitReturn() {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>emitReturn</em>()<br>
 replace 1 line</div>
@@ -1119,7 +1119,7 @@ initializer.</p>
 <p>The last step, the last item in our list of special features of initializers, is
 making it an error to try to return anything <em>else</em> from an initializer. Now
 that the compiler tracks the method type, this is straightforward.</p>
-<div class="codehilite"><pre class="insert-before">  if (match(TOKEN_SEMICOLON)) {
+<div class="codehilite" translate="no"><pre class="insert-before">  if (match(TOKEN_SEMICOLON)) {
     emitReturn();
   } else {
 </pre><div class="source-file"><em>compiler.c</em><br>
@@ -1137,7 +1137,7 @@ still go ahead and compile the value afterwards so that the compiler doesn&rsquo
 confused by the trailing expression and report a bunch of cascaded errors.</p>
 <p>Aside from inheritance, which we&rsquo;ll get to <a href="superclasses.html">soon</a>, we now have a
 fairly full-featured class system working in clox.</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">CoffeeMaker</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">CoffeeMaker</span> {
   <span class="i">init</span>(<span class="i">coffee</span>) {
     <span class="k">this</span>.<span class="i">coffee</span> = <span class="i">coffee</span>;
   }
@@ -1199,7 +1199,7 @@ its own use and there are only so many of those to go around. Add too many, and
 you&rsquo;ll need a larger encoding for opcodes, which then increases code size and
 makes decoding <em>all</em> instructions slower.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">  if (canAssign &amp;&amp; match(TOKEN_EQUAL)) {
+<div class="codehilite" translate="no"><pre class="insert-before">  if (canAssign &amp;&amp; match(TOKEN_EQUAL)) {
     expression();
     emitBytes(OP_SET_PROPERTY, name);
 </pre><div class="source-file"><em>compiler.c</em><br>
@@ -1227,7 +1227,7 @@ new <code>OP_INVOKE</code> instruction. It takes two operands:</p>
 <p>In other words, this single instruction combines the operands of the
 <code>OP_GET_PROPERTY</code> and <code>OP_CALL</code> instructions it replaces, in that order. It
 really is a fusion of those two instructions. Let&rsquo;s define it.</p>
-<div class="codehilite"><pre class="insert-before">  OP_CALL,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_CALL,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_INVOKE</span>,
@@ -1236,7 +1236,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>And add it to the disassembler:</p>
-<div class="codehilite"><pre class="insert-before">    case OP_CALL:
+<div class="codehilite" translate="no"><pre class="insert-before">    case OP_CALL:
       return byteInstruction(&quot;OP_CALL&quot;, chunk, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
@@ -1248,7 +1248,7 @@ in <em>disassembleInstruction</em>()</div>
 
 <p>This is a new, special instruction format, so it needs a little custom
 disassembly logic.</p>
-<div class="codehilite"><div class="source-file"><em>debug.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>debug.c</em><br>
 add after <em>constantInstruction</em>()</div>
 <pre><span class="k">static</span> <span class="t">int</span> <span class="i">invokeInstruction</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">name</span>, <span class="t">Chunk</span>* <span class="i">chunk</span>,
                                 <span class="t">int</span> <span class="i">offset</span>) {
@@ -1265,7 +1265,7 @@ add after <em>constantInstruction</em>()</div>
 <p>We read the two operands and then print out both the method name and the
 argument count. Over in the interpreter&rsquo;s bytecode dispatch loop is where the
 real action begins.</p>
-<div class="codehilite"><pre class="insert-before">      }
+<div class="codehilite" translate="no"><pre class="insert-before">      }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_INVOKE</span>: {
@@ -1290,7 +1290,7 @@ struck.</p>
 <p>Finally, assuming the invocation succeeded, then there is a new CallFrame on the
 stack, so we refresh our cached copy of the current frame in <code>frame</code>.</p>
 <p>The interesting work happens here:</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>callValue</em>()</div>
 <pre><span class="k">static</span> <span class="t">bool</span> <span class="i">invoke</span>(<span class="t">ObjString</span>* <span class="i">name</span>, <span class="t">int</span> <span class="i">argCount</span>) {
   <span class="t">Value</span> <span class="i">receiver</span> = <span class="i">peek</span>(<span class="i">argCount</span>);
@@ -1306,7 +1306,7 @@ matter to cast the object to an instance and invoke the method on it.</p>
 <p>That does assume the object <em>is</em> an instance. As with <code>OP_GET_PROPERTY</code>
 instructions, we also need to handle the case where a user incorrectly tries to
 call a method on a value of the wrong type.</p>
-<div class="codehilite"><pre class="insert-before">  Value receiver = peek(argCount);
+<div class="codehilite" translate="no"><pre class="insert-before">  Value receiver = peek(argCount);
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>invoke</em>()</div>
 <pre class="insert">
@@ -1327,7 +1327,7 @@ utility function:</p>
 <p>As you can guess by now, we split this code into a separate function because
 we&rsquo;re going to reuse it later<span class="em">&mdash;</span>in this case for <code>super</code> calls.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>callValue</em>()</div>
 <pre><span class="k">static</span> <span class="t">bool</span> <span class="i">invokeFromClass</span>(<span class="t">ObjClass</span>* <span class="i">klass</span>, <span class="t">ObjString</span>* <span class="i">name</span>,
                             <span class="t">int</span> <span class="i">argCount</span>) {
@@ -1374,7 +1374,7 @@ to win any races.</p>
 <span name="monte">Users</span> like it when a language implementation gives
 them an answer faster, but only if it&rsquo;s the <em>right</em> answer. Alas, our
 implementation of faster method invocations fails to uphold that principle:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Oops</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Oops</span> {
   <span class="i">init</span>() {
     <span class="k">fun</span> <span class="i">f</span>() {
       <span class="k">print</span> <span class="s">&quot;not a method&quot;</span>;
@@ -1403,7 +1403,7 @@ their program&rsquo;s correctness.</p>
 </aside>
 <p>Earlier, when we implemented <code>OP_GET_PROPERTY</code>, we handled both field and method
 accesses. To squash this new bug, we need to do the same thing for <code>OP_INVOKE</code>.</p>
-<div class="codehilite"><pre class="insert-before">  ObjInstance* instance = AS_INSTANCE(receiver);
+<div class="codehilite" translate="no"><pre class="insert-before">  ObjInstance* instance = AS_INSTANCE(receiver);
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>invoke</em>()</div>
 <pre class="insert">

--- a/site/optimization.html
+++ b/site/optimization.html
@@ -115,7 +115,7 @@ understand a program&rsquo;s performance just by thinking real hard. Those days 
 long gone, separated from the present by microcode, cache lines, branch
 prediction, deep compiler pipelines, and mammoth instruction sets. We like to
 pretend C is a &ldquo;low-level&rdquo; language, but the stack of technology between</p>
-<div class="codehilite"><pre><span class="i">printf</span>(<span class="s">&quot;Hello, world!&quot;</span>);
+<div class="codehilite" translate="no"><pre><span class="i">printf</span>(<span class="s">&quot;Hello, world!&quot;</span>);
 </pre></div>
 <p>and a greeting appearing on screen is now perilously tall.</p>
 <p>Optimization today is an empirical science. Our program is a border collie
@@ -228,7 +228,7 @@ couple of benchmarks, fired up a profiler, and ran those scripts through my
 interpreter. In a dynamically typed language like Lox, a large fraction of user
 code is field accesses and method calls, so one of my benchmarks looked
 something like this:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Zoo</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Zoo</span> {
   <span class="i">init</span>() {
     <span class="k">this</span>.<span class="i">aardvark</span> = <span class="n">1</span>;
     <span class="k">this</span>.<span class="i">baboon</span>   = <span class="n">1</span>;
@@ -309,7 +309,7 @@ dynamism. But, still, <em>wow.</em></p>
 <p>If you take a look at <code>tableGet()</code>, you&rsquo;ll see it&rsquo;s mostly a wrapper around a
 call to <code>findEntry()</code> where the actual hash table lookup happens. To refresh
 your memory, here it is in full:</p>
-<div class="codehilite"><pre><span class="k">static</span> <span class="t">Entry</span>* <span class="i">findEntry</span>(<span class="t">Entry</span>* <span class="i">entries</span>, <span class="t">int</span> <span class="i">capacity</span>,
+<div class="codehilite" translate="no"><pre><span class="k">static</span> <span class="t">Entry</span>* <span class="i">findEntry</span>(<span class="t">Entry</span>* <span class="i">entries</span>, <span class="t">int</span> <span class="i">capacity</span>,
                         <span class="t">ObjString</span>* <span class="i">key</span>) {
   <span class="t">uint32_t</span> <span class="i">index</span> = <span class="i">key</span>-&gt;<span class="i">hash</span> % <span class="i">capacity</span>;
   <span class="t">Entry</span>* <span class="i">tombstone</span> = <span class="a">NULL</span>;
@@ -336,7 +336,7 @@ your memory, here it is in full:</p>
 <p>When running that previous benchmark<span class="em">&mdash;</span>on my machine, at least<span class="em">&mdash;</span>the VM spends
 70% of the total execution time on <em>one line</em> in this function. Any guesses as
 to which one? No? It&rsquo;s this:</p>
-<div class="codehilite"><pre>  <span class="t">uint32_t</span> <span class="i">index</span> = <span class="i">key</span>-&gt;<span class="i">hash</span> % <span class="i">capacity</span>;
+<div class="codehilite" translate="no"><pre>  <span class="t">uint32_t</span> <span class="i">index</span> = <span class="i">key</span>-&gt;<span class="i">hash</span> % <span class="i">capacity</span>;
 </pre></div>
 <p>That pointer dereference isn&rsquo;t the problem. It&rsquo;s the little <code>%</code>. It turns out
 the modulo operator is <em>really</em> slow. Much slower than other <span
@@ -374,7 +374,7 @@ not enough of a mathematician to <em>prove</em> to you that this works, but if y
 think it through, it should make sense. We can replace that slow modulo operator
 with a very fast decrement and bitwise <span class="small-caps">AND</span>. We
 simply change the offending line of code to this:</p>
-<div class="codehilite"><pre class="insert-before">static Entry* findEntry(Entry* entries, int capacity,
+<div class="codehilite" translate="no"><pre class="insert-before">static Entry* findEntry(Entry* entries, int capacity,
                         ObjString* key) {
 </pre><div class="source-file"><em>table.c</em><br>
 in <em>findEntry</em>()<br>
@@ -393,7 +393,7 @@ CPU is bottlenecked elsewhere.</p>
 </aside>
 <p>Our linear probing search may need to wrap around the end of the array, so there
 is another modulo in <code>findEntry()</code> to update.</p>
-<div class="codehilite"><pre class="insert-before">      // We found the key.
+<div class="codehilite" translate="no"><pre class="insert-before">      // We found the key.
       return entry;
     }
 
@@ -411,7 +411,7 @@ a hash table lookup for interning strings. We may as well apply the same
 optimizations there too. This function is called only when interning strings,
 which wasn&rsquo;t heavily stressed by our benchmark. But a Lox program that created
 lots of strings might noticeably benefit from this change.</p>
-<div class="codehilite"><pre class="insert-before">  if (table-&gt;count == 0) return NULL;
+<div class="codehilite" translate="no"><pre class="insert-before">  if (table-&gt;count == 0) return NULL;
 
 </pre><div class="source-file"><em>table.c</em><br>
 in <em>tableFindString</em>()<br>
@@ -423,7 +423,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>table.c</em>, in <em>tableFindString</em>(), replace 1 line</div>
 
 <p>And also when the linear probing wraps around.</p>
-<div class="codehilite"><pre class="insert-before">      return entry-&gt;key;
+<div class="codehilite" translate="no"><pre class="insert-before">      return entry-&gt;key;
     }
 
 </pre><div class="source-file"><em>table.c</em><br>
@@ -621,7 +621,7 @@ totally sure.</p>
 of its value representation. To avoid that, we&rsquo;ll maintain support for <em>both</em>
 the old tagged union implementation of Value and the new NaN-boxed form. We
 select which representation we want at compile time using this flag:</p>
-<div class="codehilite"><pre class="insert-before">#include &lt;stdint.h&gt;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &lt;stdint.h&gt;
 
 </pre><div class="source-file"><em>common.h</em></div>
 <pre class="insert"><span class="a">#define NAN_BOXING</span>
@@ -636,7 +636,7 @@ Values<span class="em">&mdash;</span>vary based on whether this flag is set. The
 continue along its merry way.</p>
 <p>Most of the work happens in the &ldquo;value&rdquo; module where we add a section for the
 new type.</p>
-<div class="codehilite"><pre class="insert-before">typedef struct ObjString ObjString;
+<div class="codehilite" translate="no"><pre class="insert-before">typedef struct ObjString ObjString;
 
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="a">#ifdef NAN_BOXING</span>
@@ -656,7 +656,7 @@ do bitwise operations and uint64_t is a much friendlier type for that. Outside
 of this module, the rest of the VM doesn&rsquo;t really care one way or the other.</p>
 <p>Before we start re-implementing those macros, we close the <code>#else</code> branch of the
 <code>#ifdef</code> at the end of the definitions for the old representation.</p>
-<div class="codehilite"><pre class="insert-before">#define OBJ_VAL(object)   ((Value){VAL_OBJ, {.obj = (Obj*)object}})
+<div class="codehilite" translate="no"><pre class="insert-before">#define OBJ_VAL(object)   ((Value){VAL_OBJ, {.obj = (Obj*)object}})
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert">
 
@@ -700,7 +700,7 @@ breaks that assumption.</p>
 supported by both the C and C++ specs. Unfortunately, it doesn&rsquo;t fit in a single
 expression, so the conversion macros have to call out to helper functions.
 Here&rsquo;s the first macro:</p>
-<div class="codehilite"><pre class="insert-before">typedef uint64_t Value;
+<div class="codehilite" translate="no"><pre class="insert-before">typedef uint64_t Value;
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert">
 
@@ -712,7 +712,7 @@ Here&rsquo;s the first macro:</p>
 <div class="source-file-narrow"><em>value.h</em></div>
 
 <p>That macro passes the double here:</p>
-<div class="codehilite"><pre class="insert-before">#define NUMBER_VAL(num) numToValue(num)
+<div class="codehilite" translate="no"><pre class="insert-before">#define NUMBER_VAL(num) numToValue(num)
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert">
 
@@ -735,7 +735,7 @@ bytes as the input. Thankfully, because this <em>is</em> the supported idiom for
 punning, most compilers recognize the pattern and optimize away the <code>memcpy()</code>
 entirely.</p>
 <p>&ldquo;Unwrapping&rdquo; a Lox number is the mirror image.</p>
-<div class="codehilite"><pre class="insert-before">typedef uint64_t Value;
+<div class="codehilite" translate="no"><pre class="insert-before">typedef uint64_t Value;
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert">
 
@@ -747,7 +747,7 @@ entirely.</p>
 <div class="source-file-narrow"><em>value.h</em></div>
 
 <p>That macro calls this function:</p>
-<div class="codehilite"><pre class="insert-before">#define NUMBER_VAL(num) numToValue(num)
+<div class="codehilite" translate="no"><pre class="insert-before">#define NUMBER_VAL(num) numToValue(num)
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert">
 
@@ -769,7 +769,7 @@ we&rsquo;re calling so we also need an <span name="union">include</span>.</p>
 <aside name="union" class="bottom">
 <p>If you find yourself with a compiler that does not optimize the <code>memcpy()</code> away,
 try this instead:</p>
-<div class="codehilite"><pre><span class="t">double</span> <span class="i">valueToNum</span>(<span class="t">Value</span> <span class="i">value</span>) {
+<div class="codehilite" translate="no"><pre><span class="t">double</span> <span class="i">valueToNum</span>(<span class="t">Value</span> <span class="i">value</span>) {
   <span class="k">union</span> {
     <span class="t">uint64_t</span> <span class="i">bits</span>;
     <span class="t">double</span> <span class="i">num</span>;
@@ -779,7 +779,7 @@ try this instead:</p>
 }
 </pre></div>
 </aside>
-<div class="codehilite"><pre class="insert-before">#define clox_value_h
+<div class="codehilite" translate="no"><pre class="insert-before">#define clox_value_h
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert">
 
@@ -794,7 +794,7 @@ try this instead:</p>
 Doing a runtime type <em>test</em> on a Lox number is a little more interesting. If all
 we have are exactly the bits for a double, how do we tell that it <em>is</em> a double?
 It&rsquo;s time to get bit twiddling.</p>
-<div class="codehilite"><pre class="insert-before">typedef uint64_t Value;
+<div class="codehilite" translate="no"><pre class="insert-before">typedef uint64_t Value;
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert">
 
@@ -822,7 +822,7 @@ whose bit representation collides with ones we have claimed. But in my tests
 across a number of architectures, I haven&rsquo;t seen it happen.</p>
 </aside>
 <p>The set of quiet NaN bits are declared like this:</p>
-<div class="codehilite"><pre class="insert-before">#ifdef NAN_BOXING
+<div class="codehilite" translate="no"><pre class="insert-before">#ifdef NAN_BOXING
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert">
 
@@ -846,7 +846,7 @@ for three total unique bit patterns.</p>
 lowest bits of our unused mantissa space as a &ldquo;type tag&rdquo; to determine which of
 these three singleton values we&rsquo;re looking at. The three type tags are defined
 like so:</p>
-<div class="codehilite"><pre class="insert-before">#define QNAN     ((uint64_t)0x7ffc000000000000)
+<div class="codehilite" translate="no"><pre class="insert-before">#define QNAN     ((uint64_t)0x7ffc000000000000)
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert">
 
@@ -862,7 +862,7 @@ typedef uint64_t Value;
 <p>Our representation of <code>nil</code> is thus all of the bits required to define our
 quiet NaN representation along with the <code>nil</code> type tag bits:</p><img src="image/optimization/nil.png" alt="The bit representation of the nil value." />
 <p>In code, we check the bits like so:</p>
-<div class="codehilite"><pre class="insert-before">#define AS_NUMBER(value)    valueToNum(value)
+<div class="codehilite" translate="no"><pre class="insert-before">#define AS_NUMBER(value)    valueToNum(value)
 
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="a">#define NIL_VAL         ((Value)(uint64_t)(QNAN | TAG_NIL))</span>
@@ -876,7 +876,7 @@ those bits to mean.</p>
 <p>Since <code>nil</code> has only a single bit representation, we can use equality on
 uint64_t to see if a Value is <code>nil</code>.</p>
 <p><span name="equal"></span></p>
-<div class="codehilite"><pre class="insert-before">typedef uint64_t Value;
+<div class="codehilite" translate="no"><pre class="insert-before">typedef uint64_t Value;
 
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="a">#define IS_NIL(value)       ((value) == NIL_VAL)</span>
@@ -885,7 +885,7 @@ uint64_t to see if a Value is <code>nil</code>.</p>
 <div class="source-file-narrow"><em>value.h</em></div>
 
 <p>You can guess how we define the <code>true</code> and <code>false</code> values.</p>
-<div class="codehilite"><pre class="insert-before">#define AS_NUMBER(value)    valueToNum(value)
+<div class="codehilite" translate="no"><pre class="insert-before">#define AS_NUMBER(value)    valueToNum(value)
 
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="a">#define FALSE_VAL       ((Value)(uint64_t)(QNAN | TAG_FALSE))</span>
@@ -897,7 +897,7 @@ uint64_t to see if a Value is <code>nil</code>.</p>
 <p>The bits look like this:</p><img src="image/optimization/bools.png" alt="The bit representation of the true and false values." />
 <p>To convert a C bool into a Lox Boolean, we rely on these two singleton values
 and the good old conditional operator.</p>
-<div class="codehilite"><pre class="insert-before">#define AS_NUMBER(value)    valueToNum(value)
+<div class="codehilite" translate="no"><pre class="insert-before">#define AS_NUMBER(value)    valueToNum(value)
 
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="a">#define BOOL_VAL(b)     ((b) ? TRUE_VAL : FALSE_VAL)</span>
@@ -908,7 +908,7 @@ and the good old conditional operator.</p>
 <p>There&rsquo;s probably a cleverer bitwise way to do this, but my hunch is that the
 compiler can figure one out faster than I can. Going the other direction is
 simpler.</p>
-<div class="codehilite"><pre class="insert-before">#define IS_NUMBER(value)    (((value) &amp; QNAN) != QNAN)
+<div class="codehilite" translate="no"><pre class="insert-before">#define IS_NUMBER(value)    (((value) &amp; QNAN) != QNAN)
 
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="a">#define AS_BOOL(value)      ((value) == TRUE_VAL)</span>
@@ -920,7 +920,7 @@ simpler.</p>
 in C where any non-zero value can be considered &ldquo;true&rdquo;<span class="em">&mdash;</span>if it ain&rsquo;t <code>true</code>, it
 must be <code>false</code>. This macro does assume you call it only on a Value that you
 know <em>is</em> a Lox Boolean. To check that, there&rsquo;s one more macro.</p>
-<div class="codehilite"><pre class="insert-before">typedef uint64_t Value;
+<div class="codehilite" translate="no"><pre class="insert-before">typedef uint64_t Value;
 
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="a">#define IS_BOOL(value)      (((value) | 1) == TRUE_VAL)</span>
@@ -929,7 +929,7 @@ know <em>is</em> a Lox Boolean. To check that, there&rsquo;s one more macro.</p>
 <div class="source-file-narrow"><em>value.h</em></div>
 
 <p>That looks a little strange. A more obvious macro would look like this:</p>
-<div class="codehilite"><pre><span class="a">#define IS_BOOL(v) ((v) == TRUE_VAL || (v) == FALSE_VAL)</span>
+<div class="codehilite" translate="no"><pre><span class="a">#define IS_BOOL(v) ((v) == TRUE_VAL || (v) == FALSE_VAL)</span>
 </pre></div>
 <p>Unfortunately, that&rsquo;s not safe. The expansion mentions <code>v</code> twice, which means if
 that expression has any side effects, they will be executed twice. We could have
@@ -976,7 +976,7 @@ pointer.</p>
 Obj:</p><img src="image/optimization/obj.png" alt="Bit representation of an Obj* stored in a Value." />
 <p>To convert a raw Obj pointer to a Value, we take the pointer and set all of the
 quiet NaN bits and the sign bit.</p>
-<div class="codehilite"><pre class="insert-before">#define NUMBER_VAL(num) numToValue(num)
+<div class="codehilite" translate="no"><pre class="insert-before">#define NUMBER_VAL(num) numToValue(num)
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="a">#define OBJ_VAL(obj) \</span>
 <span class="a">    (Value)(SIGN_BIT | QNAN | (uint64_t)(uintptr_t)(obj))</span>
@@ -1001,7 +1001,7 @@ compiler and chip let you get away with.</p>
 lawless territory too. It&rsquo;s up to you to decide if the gains are worth it.</p>
 </aside>
 <p>We define the sign bit like so:</p>
-<div class="codehilite"><pre class="insert-before">#ifdef NAN_BOXING
+<div class="codehilite" translate="no"><pre class="insert-before">#ifdef NAN_BOXING
 
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="a">#define SIGN_BIT ((uint64_t)0x8000000000000000)</span>
@@ -1011,7 +1011,7 @@ lawless territory too. It&rsquo;s up to you to decide if the gains are worth it.
 <div class="source-file-narrow"><em>value.h</em></div>
 
 <p>To get the Obj pointer back out, we simply mask off all of those extra bits.</p>
-<div class="codehilite"><pre class="insert-before">#define AS_NUMBER(value)    valueToNum(value)
+<div class="codehilite" translate="no"><pre class="insert-before">#define AS_NUMBER(value)    valueToNum(value)
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="a">#define AS_OBJ(value) \</span>
 <span class="a">    ((Obj*)(uintptr_t)((value) &amp; ~(SIGN_BIT | QNAN)))</span>
@@ -1026,7 +1026,7 @@ before, is bitwise <span class="small-caps">NOT</span>. It toggles all ones and
 zeroes in its operand. By masking the value with the bitwise negation of the
 quiet NaN and sign bits, we <em>clear</em> those bits and let the pointer bits remain.</p>
 <p>One last macro:</p>
-<div class="codehilite"><pre class="insert-before">#define IS_NUMBER(value)    (((value) &amp; QNAN) != QNAN)
+<div class="codehilite" translate="no"><pre class="insert-before">#define IS_NUMBER(value)    (((value) &amp; QNAN) != QNAN)
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="a">#define IS_OBJ(value) \</span>
 <span class="a">    (((value) &amp; (QNAN | SIGN_BIT)) == (QNAN | SIGN_BIT))</span>
@@ -1049,7 +1049,7 @@ encoding directly. We need to fix those too.</p>
 <p>The first is <code>printValue()</code>. It has separate code for each value type. We no
 longer have an explicit type enum we can switch on, so instead we use a series
 of type tests to handle each kind of value.</p>
-<div class="codehilite"><pre class="insert-before">void printValue(Value value) {
+<div class="codehilite" translate="no"><pre class="insert-before">void printValue(Value value) {
 </pre><div class="source-file"><em>value.c</em><br>
 in <em>printValue</em>()</div>
 <pre class="insert"><span class="a">#ifdef NAN_BOXING</span>
@@ -1071,7 +1071,7 @@ in <em>printValue</em>()</div>
 overhead of actually writing to a stream, it&rsquo;s negligible.</p>
 <p>We still support the original tagged union representation, so we keep the old
 code and enclose it in the <code>#else</code> conditional section.</p>
-<div class="codehilite"><pre class="insert-before">  }
+<div class="codehilite" translate="no"><pre class="insert-before">  }
 </pre><div class="source-file"><em>value.c</em><br>
 in <em>printValue</em>()</div>
 <pre class="insert"><span class="a">#endif</span>
@@ -1080,7 +1080,7 @@ in <em>printValue</em>()</div>
 <div class="source-file-narrow"><em>value.c</em>, in <em>printValue</em>()</div>
 
 <p>The other operation is testing two values for equality.</p>
-<div class="codehilite"><pre class="insert-before">bool valuesEqual(Value a, Value b) {
+<div class="codehilite" translate="no"><pre class="insert-before">bool valuesEqual(Value a, Value b) {
 </pre><div class="source-file"><em>value.c</em><br>
 in <em>valuesEqual</em>()</div>
 <pre class="insert"><span class="a">#ifdef NAN_BOXING</span>
@@ -1104,7 +1104,7 @@ problem for the special quiet NaNs that we are using for our own purposes. But
 it&rsquo;s possible to produce a &ldquo;real&rdquo; arithmetic NaN in Lox, and if we want to
 correctly implement IEEE 754 numbers, then the resulting value is not supposed
 to be equal to itself. More concretely:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">nan</span> = <span class="n">0</span>/<span class="n">0</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">nan</span> = <span class="n">0</span>/<span class="n">0</span>;
 <span class="k">print</span> <span class="i">nan</span> == <span class="i">nan</span>;
 </pre></div>
 <p>IEEE 754 says this program is supposed to print &ldquo;false&rdquo;. It does the right thing
@@ -1113,7 +1113,7 @@ with our old tagged union representation because the <code>VAL_NUMBER</code> cas
 generates the right CPU instruction to perform an IEEE floating-point equality.</p>
 <p>Our new representation breaks that by defining Value to be a uint64_t. If we
 want to be <em>fully</em> compliant with IEEE 754, we need to handle this case.</p>
-<div class="codehilite"><pre class="insert-before">#ifdef NAN_BOXING
+<div class="codehilite" translate="no"><pre class="insert-before">#ifdef NAN_BOXING
 </pre><div class="source-file"><em>value.c</em><br>
 in <em>valuesEqual</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="a">IS_NUMBER</span>(<span class="i">a</span>) &amp;&amp; <span class="a">IS_NUMBER</span>(<span class="i">b</span>)) {
@@ -1135,7 +1135,7 @@ Object and compare them using <code>equals()</code>, which is how jlox implement
 </aside>
 <p>Finally, we close the conditional compilation section around the old
 implementation.</p>
-<div class="codehilite"><pre class="insert-before">  }
+<div class="codehilite" translate="no"><pre class="insert-before">  }
 </pre><div class="source-file"><em>value.c</em><br>
 in <em>valuesEqual</em>()</div>
 <pre class="insert"><span class="a">#endif</span>

--- a/site/parsing-expressions.html
+++ b/site/parsing-expressions.html
@@ -152,7 +152,7 @@ we parse, we aren&rsquo;t just determining if the string is valid Lox code, we&r
 also tracking which rules match which parts of it so that we know what part of
 the language each token belongs to. Here&rsquo;s the Lox expression grammar we put
 together in the last chapter:</p>
-<div class="codehilite"><pre><span class="i">expression</span>     → <span class="i">literal</span>
+<div class="codehilite" translate="no"><pre><span class="i">expression</span>     → <span class="i">literal</span>
                | <span class="i">unary</span>
                | <span class="i">binary</span>
                | <span class="i">grouping</span> ;
@@ -200,16 +200,16 @@ operators are said to &ldquo;bind tighter&rdquo;.</p>
 of the <em>same</em> operator. When an operator is <strong>left-associative</strong> (think
 &ldquo;left-to-right&rdquo;), operators on the left evaluate before those on the right.
 Since <code>-</code> is left-associative, this expression:</p>
-<div class="codehilite"><pre><span class="n">5</span> - <span class="n">3</span> - <span class="n">1</span>
+<div class="codehilite" translate="no"><pre><span class="n">5</span> - <span class="n">3</span> - <span class="n">1</span>
 </pre></div>
 <p>is equivalent to:</p>
-<div class="codehilite"><pre>(<span class="n">5</span> - <span class="n">3</span>) - <span class="n">1</span>
+<div class="codehilite" translate="no"><pre>(<span class="n">5</span> - <span class="n">3</span>) - <span class="n">1</span>
 </pre></div>
 <p>Assignment, on the other hand, is <strong>right-associative</strong>. This:</p>
-<div class="codehilite"><pre><span class="i">a</span> = <span class="i">b</span> = <span class="i">c</span>
+<div class="codehilite" translate="no"><pre><span class="i">a</span> = <span class="i">b</span> = <span class="i">c</span>
 </pre></div>
 <p>is equivalent to:</p>
-<div class="codehilite"><pre><span class="i">a</span> = (<span class="i">b</span> = <span class="i">c</span>)
+<div class="codehilite" translate="no"><pre><span class="i">a</span> = (<span class="i">b</span> = <span class="i">c</span>)
 </pre></div>
 </li>
 </ul>
@@ -267,7 +267,7 @@ grammar accept any kind of expression as a subexpression, regardless of whether
 the precedence rules allow it.</p>
 <p>We fix that by <span name="massage">stratifying</span> the grammar. We define a
 separate rule for each precedence level.</p>
-<div class="codehilite"><pre><span class="i">expression</span>     → ...
+<div class="codehilite" translate="no"><pre><span class="i">expression</span>     → ...
 <span class="i">equality</span>       → ...
 <span class="i">comparison</span>     → ...
 <span class="i">term</span>           → ...
@@ -298,28 +298,28 @@ little better.</p>
 logical operators, we&rsquo;ll only need to change the production for <code>expression</code>
 instead of touching every rule that contains an expression.</p>
 </aside>
-<div class="codehilite"><pre><span class="i">expression</span>     → <span class="i">equality</span>
+<div class="codehilite" translate="no"><pre><span class="i">expression</span>     → <span class="i">equality</span>
 </pre></div>
 <p>Over at the other end of the precedence table, a primary expression contains
 all the literals and grouping expressions.</p>
-<div class="codehilite"><pre><span class="i">primary</span>        → <span class="t">NUMBER</span> | <span class="t">STRING</span> | <span class="s">&quot;true&quot;</span> | <span class="s">&quot;false&quot;</span> | <span class="s">&quot;nil&quot;</span>
+<div class="codehilite" translate="no"><pre><span class="i">primary</span>        → <span class="t">NUMBER</span> | <span class="t">STRING</span> | <span class="s">&quot;true&quot;</span> | <span class="s">&quot;false&quot;</span> | <span class="s">&quot;nil&quot;</span>
                | <span class="s">&quot;(&quot;</span> <span class="i">expression</span> <span class="s">&quot;)&quot;</span> ;
 </pre></div>
 <p>A unary expression starts with a unary operator followed by the operand. Since
 unary operators can nest<span class="em">&mdash;</span><code>!!true</code> is a valid if weird expression<span class="em">&mdash;</span>the
 operand can itself be a unary operator. A recursive rule handles that nicely.</p>
-<div class="codehilite"><pre><span class="i">unary</span>          → ( <span class="s">&quot;!&quot;</span> | <span class="s">&quot;-&quot;</span> ) <span class="i">unary</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">unary</span>          → ( <span class="s">&quot;!&quot;</span> | <span class="s">&quot;-&quot;</span> ) <span class="i">unary</span> ;
 </pre></div>
 <p>But this rule has a problem. It never terminates.</p>
 <p>Remember, each rule needs to match expressions at that precedence level <em>or
 higher</em>, so we also need to let this match a primary expression.</p>
-<div class="codehilite"><pre><span class="i">unary</span>          → ( <span class="s">&quot;!&quot;</span> | <span class="s">&quot;-&quot;</span> ) <span class="i">unary</span>
+<div class="codehilite" translate="no"><pre><span class="i">unary</span>          → ( <span class="s">&quot;!&quot;</span> | <span class="s">&quot;-&quot;</span> ) <span class="i">unary</span>
                | <span class="i">primary</span> ;
 </pre></div>
 <p>That works.</p>
 <p>The remaining rules are all binary operators. We&rsquo;ll start with the rule for
 multiplication and division. Here&rsquo;s a first try:</p>
-<div class="codehilite"><pre><span class="i">factor</span>         → <span class="i">factor</span> ( <span class="s">&quot;/&quot;</span> | <span class="s">&quot;*&quot;</span> ) <span class="i">unary</span>
+<div class="codehilite" translate="no"><pre><span class="i">factor</span>         → <span class="i">factor</span> ( <span class="s">&quot;/&quot;</span> | <span class="s">&quot;*&quot;</span> ) <span class="i">unary</span>
                | <span class="i">unary</span> ;
 </pre></div>
 <p>The rule recurses to match the left operand. That enables the rule to match a
@@ -331,7 +331,7 @@ recursive production on the left side and <code>unary</code> on the right makes 
 right-associative<span class="em">&mdash;</span>you get the same result either way. Alas, in the real world
 with limited precision, roundoff and overflow mean that associativity can affect
 the result of a sequence of multiplications. Consider:</p>
-<div class="codehilite"><pre><span class="k">print</span> <span class="n">0.1</span> * (<span class="n">0.2</span> * <span class="n">0.3</span>);
+<div class="codehilite" translate="no"><pre><span class="k">print</span> <span class="n">0.1</span> * (<span class="n">0.2</span> * <span class="n">0.3</span>);
 <span class="k">print</span> (<span class="n">0.1</span> * <span class="n">0.2</span>) * <span class="n">0.3</span>;
 </pre></div>
 <p>In languages like Lox that use <a href="https://en.wikipedia.org/wiki/Double-precision_floating-point_format">IEEE 754</a> double-precision floating-point
@@ -348,14 +348,14 @@ use, have trouble with left recursion. (Recursion elsewhere, like we have in
 for how to model a particular language is partially a matter of taste and
 partially a pragmatic one. This rule is correct, but not optimal for how we
 intend to parse it. Instead of a left recursive rule, we&rsquo;ll use a different one.</p>
-<div class="codehilite"><pre><span class="i">factor</span>         → <span class="i">unary</span> ( ( <span class="s">&quot;/&quot;</span> | <span class="s">&quot;*&quot;</span> ) <span class="i">unary</span> )* ;
+<div class="codehilite" translate="no"><pre><span class="i">factor</span>         → <span class="i">unary</span> ( ( <span class="s">&quot;/&quot;</span> | <span class="s">&quot;*&quot;</span> ) <span class="i">unary</span> )* ;
 </pre></div>
 <p>We define a factor expression as a flat <em>sequence</em> of multiplications
 and divisions. This matches the same syntax as the previous rule, but better
 mirrors the code we&rsquo;ll write to parse Lox. We use the same structure for all of
 the other binary operator precedence levels, giving us this complete expression
 grammar:</p>
-<div class="codehilite"><pre><span class="i">expression</span>     → <span class="i">equality</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">expression</span>     → <span class="i">equality</span> ;
 <span class="i">equality</span>       → <span class="i">comparison</span> ( ( <span class="s">&quot;!=&quot;</span> | <span class="s">&quot;==&quot;</span> ) <span class="i">comparison</span> )* ;
 <span class="i">comparison</span>     → <span class="i">term</span> ( ( <span class="s">&quot;&gt;&quot;</span> | <span class="s">&quot;&gt;=&quot;</span> | <span class="s">&quot;&lt;&quot;</span> | <span class="s">&quot;&lt;=&quot;</span> ) <span class="i">term</span> )* ;
 <span class="i">term</span>           → <span class="i">factor</span> ( ( <span class="s">&quot;-&quot;</span> | <span class="s">&quot;+&quot;</span> ) <span class="i">factor</span> )* ;
@@ -419,7 +419,7 @@ itself<span class="em">&mdash;</span>directly or indirectly<span class="em">&mda
 call.</p>
 <h3><a href="#the-parser-class" id="the-parser-class"><small>6&#8202;.&#8202;2&#8202;.&#8202;1</small>The parser class</a></h3>
 <p>Each grammar rule becomes a method inside this new class:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -444,7 +444,7 @@ reading tokens instead of characters. We store the list of tokens and use
 <p>We&rsquo;re going to run straight through the expression grammar now and translate
 each rule to Java code. The first rule, <code>expression</code>, simply expands to the
 <code>equality</code> rule, so that&rsquo;s straightforward.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>Parser</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">expression</span>() {
     <span class="k">return</span> <span class="i">equality</span>();
@@ -462,10 +462,10 @@ for a left-recursive rule immediately calls itself, which calls itself again,
 and so on, until the parser hits a stack overflow and dies.</p>
 </aside>
 <p>The rule for equality is a little more complex.</p>
-<div class="codehilite"><pre><span class="i">equality</span>       → <span class="i">comparison</span> ( ( <span class="s">&quot;!=&quot;</span> | <span class="s">&quot;==&quot;</span> ) <span class="i">comparison</span> )* ;
+<div class="codehilite" translate="no"><pre><span class="i">equality</span>       → <span class="i">comparison</span> ( ( <span class="s">&quot;!=&quot;</span> | <span class="s">&quot;==&quot;</span> ) <span class="i">comparison</span> )* ;
 </pre></div>
 <p>In Java, that becomes:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>expression</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">equality</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">comparison</span>();
@@ -489,7 +489,7 @@ when to exit that loop. We can see that inside the rule, we must first find
 either a <code>!=</code> or <code>==</code> token. So, if we <em>don&rsquo;t</em> see one of those, we must be done
 with the sequence of equality operators. We express that check using a handy
 <code>match()</code> method.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>equality</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">match</span>(<span class="t">TokenType</span>... <span class="i">types</span>) {
     <span class="k">for</span> (<span class="t">TokenType</span> <span class="i">type</span> : <span class="i">types</span>) {
@@ -510,7 +510,7 @@ the current token alone. The <code>match()</code> method is defined in terms of 
 fundamental operations.</p>
 <p>The <code>check()</code> method returns <code>true</code> if the current token is of the given type.
 Unlike <code>match()</code>, it never consumes the token, it only looks at it.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>match</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">check</span>(<span class="t">TokenType</span> <span class="i">type</span>) {
     <span class="k">if</span> (<span class="i">isAtEnd</span>()) <span class="k">return</span> <span class="k">false</span>;
@@ -521,7 +521,7 @@ add after <em>match</em>()</div>
 
 <p>The <code>advance()</code> method consumes the current token and returns it, similar to how
 our scanner&rsquo;s corresponding method crawled through characters.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>check</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Token</span> <span class="i">advance</span>() {
     <span class="k">if</span> (!<span class="i">isAtEnd</span>()) <span class="i">current</span>++;
@@ -531,7 +531,7 @@ add after <em>check</em>()</div>
 <div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>check</em>()</div>
 
 <p>These methods bottom out on the last handful of primitive operations.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>advance</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isAtEnd</span>() {
     <span class="k">return</span> <span class="i">peek</span>().<span class="i">type</span> == <span class="i">EOF</span>;
@@ -573,10 +573,10 @@ the <code>equality()</code> method effectively calls and returns <code>compariso
 way, this method matches an equality operator <em>or anything of higher
 precedence</em>.</p>
 <p>Moving on to the next rule<span class="ellipse">&thinsp;.&thinsp;.&thinsp;.&nbsp;</span></p>
-<div class="codehilite"><pre><span class="i">comparison</span>     → <span class="i">term</span> ( ( <span class="s">&quot;&gt;&quot;</span> | <span class="s">&quot;&gt;=&quot;</span> | <span class="s">&quot;&lt;&quot;</span> | <span class="s">&quot;&lt;=&quot;</span> ) <span class="i">term</span> )* ;
+<div class="codehilite" translate="no"><pre><span class="i">comparison</span>     → <span class="i">term</span> ( ( <span class="s">&quot;&gt;&quot;</span> | <span class="s">&quot;&gt;=&quot;</span> | <span class="s">&quot;&lt;&quot;</span> | <span class="s">&quot;&lt;=&quot;</span> ) <span class="i">term</span> )* ;
 </pre></div>
 <p>Translated to Java:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>equality</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">comparison</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">term</span>();
@@ -603,7 +603,7 @@ follow the same pattern.</p>
 parsing a left-associative series of binary operators given a list of token
 types, and an operand method handle to simplify this redundant code.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>comparison</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">term</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">factor</span>();
@@ -620,7 +620,7 @@ add after <em>comparison</em>()</div>
 <div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>comparison</em>()</div>
 
 <p>And finally, multiplication and division:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>term</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">factor</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">unary</span>();
@@ -639,11 +639,11 @@ add after <em>term</em>()</div>
 <p>That&rsquo;s all of the binary operators, parsed with the correct precedence and
 associativity. We&rsquo;re crawling up the precedence hierarchy and now we&rsquo;ve reached
 the unary operators.</p>
-<div class="codehilite"><pre><span class="i">unary</span>          → ( <span class="s">&quot;!&quot;</span> | <span class="s">&quot;-&quot;</span> ) <span class="i">unary</span>
+<div class="codehilite" translate="no"><pre><span class="i">unary</span>          → ( <span class="s">&quot;!&quot;</span> | <span class="s">&quot;-&quot;</span> ) <span class="i">unary</span>
                | <span class="i">primary</span> ;
 </pre></div>
 <p>The code for this is a little different.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>factor</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">unary</span>() {
     <span class="k">if</span> (<span class="i">match</span>(<span class="i">BANG</span>, <span class="i">MINUS</span>)) {
@@ -667,12 +667,12 @@ puts recursive descent into the category of <strong>predictive parsers</strong>.
 </aside>
 <p>Otherwise, we must have reached the highest level of precedence, primary
 expressions.</p>
-<div class="codehilite"><pre><span class="i">primary</span>        → <span class="t">NUMBER</span> | <span class="t">STRING</span> | <span class="s">&quot;true&quot;</span> | <span class="s">&quot;false&quot;</span> | <span class="s">&quot;nil&quot;</span>
+<div class="codehilite" translate="no"><pre><span class="i">primary</span>        → <span class="t">NUMBER</span> | <span class="t">STRING</span> | <span class="s">&quot;true&quot;</span> | <span class="s">&quot;false&quot;</span> | <span class="s">&quot;nil&quot;</span>
                | <span class="s">&quot;(&quot;</span> <span class="i">expression</span> <span class="s">&quot;)&quot;</span> ;
 </pre></div>
 <p>Most of the cases for the rule are single terminals, so parsing is
 straightforward.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>unary</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">primary</span>() {
     <span class="k">if</span> (<span class="i">match</span>(<span class="i">FALSE</span>)) <span class="k">return</span> <span class="k">new</span> <span class="t">Expr</span>.<span class="t">Literal</span>(<span class="k">false</span>);
@@ -805,7 +805,7 @@ we&rsquo;ll get the machinery in place for later.</p>
 code to parse a parenthesized expression. After parsing the expression, the
 parser looks for the closing <code>)</code> by calling <code>consume()</code>. Here, finally, is that
 method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>match</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Token</span> <span class="i">consume</span>(<span class="t">TokenType</span> <span class="i">type</span>, <span class="t">String</span> <span class="i">message</span>) {
     <span class="k">if</span> (<span class="i">check</span>(<span class="i">type</span>)) <span class="k">return</span> <span class="i">advance</span>();
@@ -818,7 +818,7 @@ add after <em>match</em>()</div>
 <p>It&rsquo;s similar to <code>match()</code> in that it checks to see if the next token is of the
 expected type. If so, it consumes the token and everything is groovy. If some
 other token is there, then we&rsquo;ve hit an error. We report it by calling this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>previous</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">ParseError</span> <span class="i">error</span>(<span class="t">Token</span> <span class="i">token</span>, <span class="t">String</span> <span class="i">message</span>) {
     <span class="t">Lox</span>.<span class="i">error</span>(<span class="i">token</span>, <span class="i">message</span>);
@@ -828,7 +828,7 @@ add after <em>previous</em>()</div>
 <div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>previous</em>()</div>
 
 <p>First, that shows the error to the user by calling:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Lox.java</em><br>
 add after <em>report</em>()</div>
 <pre>  <span class="k">static</span> <span class="t">void</span> <span class="i">error</span>(<span class="t">Token</span> <span class="i">token</span>, <span class="t">String</span> <span class="i">message</span>) {
     <span class="k">if</span> (<span class="i">token</span>.<span class="i">type</span> == <span class="t">TokenType</span>.<span class="i">EOF</span>) {
@@ -846,7 +846,7 @@ interpreter to track locations in code.</p>
 <p>After we report the error, the user knows about their mistake, but what does the
 <em>parser</em> do next? Back in <code>error()</code>, we create and return a ParseError, an
 instance of this new class:</p>
-<div class="codehilite"><pre class="insert-before">class Parser {
+<div class="codehilite" translate="no"><pre class="insert-before">class Parser {
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 nest inside class <em>Parser</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">static</span> <span class="k">class</span> <span class="t">ParseError</span> <span class="k">extends</span> <span class="t">RuntimeException</span> {}
@@ -873,7 +873,7 @@ producing a syntax tree.</p>
 <p>For example, some languages have a unary <code>+</code> operator, like <code>+123</code>, but Lox does
 not. Instead of getting confused when the parser stumbles onto a <code>+</code> at the
 beginning of an expression, we could extend the unary rule to allow it.</p>
-<div class="codehilite"><pre><span class="i">unary</span> → ( <span class="s">&quot;!&quot;</span> | <span class="s">&quot;-&quot;</span> | <span class="s">&quot;+&quot;</span> ) <span class="i">unary</span>
+<div class="codehilite" translate="no"><pre><span class="i">unary</span> → ( <span class="s">&quot;!&quot;</span> | <span class="s">&quot;-&quot;</span> | <span class="s">&quot;+&quot;</span> ) <span class="i">unary</span>
       | <span class="i">primary</span> ;
 </pre></div>
 <p>This lets the parser consume <code>+</code> without going into panic mode or leaving the
@@ -910,7 +910,7 @@ loop. Our synchronization isn&rsquo;t perfect, but that&rsquo;s OK. We&rsquo;ve 
 the first error precisely, so everything after that is kind of &ldquo;best effort&rdquo;.</p>
 </aside>
 <p>This method encapsulates that logic:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>error</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">synchronize</span>() {
     <span class="i">advance</span>();
@@ -951,7 +951,7 @@ need to add a little error handling. As the parser descends through the parsing
 methods for each grammar rule, it eventually hits <code>primary()</code>. If none of the
 cases in there match, it means we are sitting on a token that can&rsquo;t start an
 expression. We need to handle that error too.</p>
-<div class="codehilite"><pre class="insert-before">    if (match(LEFT_PAREN)) {
+<div class="codehilite" translate="no"><pre class="insert-before">    if (match(LEFT_PAREN)) {
       Expr expr = expression();
       consume(RIGHT_PAREN, &quot;Expect ')' after expression.&quot;);
       return new Expr.Grouping(expr);
@@ -967,7 +967,7 @@ in <em>primary</em>()</div>
 
 <p>With that, all that remains in the parser is to define an initial method to kick
 it off. That method is called, naturally enough, <code>parse()</code>.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>Parser</em>()</div>
 <pre>  <span class="t">Expr</span> <span class="i">parse</span>() {
     <span class="k">try</span> {
@@ -992,7 +992,7 @@ out. We still don&rsquo;t have an interpreter, so for now, we&rsquo;ll parse to 
 tree and then use the AstPrinter class from the <a href="representing-code.html#a-not-very-pretty-printer">last chapter</a> to
 display it.</p>
 <p>Delete the old code to print the scanned tokens and replace it with this:</p>
-<div class="codehilite"><pre class="insert-before">    List&lt;Token&gt; tokens = scanner.scanTokens();
+<div class="codehilite" translate="no"><pre class="insert-before">    List&lt;Token&gt; tokens = scanner.scanTokens();
 </pre><div class="source-file"><em>lox/Lox.java</em><br>
 in <em>run</em>()<br>
 replace 5 lines</div>
@@ -1056,7 +1056,7 @@ discard a right-hand operand with the appropriate precedence.</p>
 put them in the precedence hierarchy? C<span class="em">&mdash;</span>and most languages that follow in C&rsquo;s
 footsteps<span class="em">&mdash;</span>place them below <code>==</code>. This is widely considered a mistake because
 it means common operations like testing a flag require parentheses.</p>
-<div class="codehilite"><pre><span class="k">if</span> (<span class="i">flags</span> &amp; <span class="a">FLAG_MASK</span> == <span class="a">SOME_FLAG</span>) { ... } <span class="c">// Wrong.</span>
+<div class="codehilite" translate="no"><pre><span class="k">if</span> (<span class="i">flags</span> &amp; <span class="a">FLAG_MASK</span> == <span class="a">SOME_FLAG</span>) { ... } <span class="c">// Wrong.</span>
 <span class="k">if</span> ((<span class="i">flags</span> &amp; <span class="a">FLAG_MASK</span>) == <span class="a">SOME_FLAG</span>) { ... } <span class="c">// Right.</span>
 </pre></div>
 <p>Should we fix this for Lox and put bitwise operators higher up the precedence

--- a/site/representing-code.html
+++ b/site/representing-code.html
@@ -114,7 +114,7 @@ interpreter to consume. If you haven&rsquo;t written a parser or interpreter yet
 those requirements aren&rsquo;t exactly illuminating. Maybe your intuition can help.
 What is your brain doing when you play the part of a <em>human</em> interpreter? How do
 you mentally evaluate an arithmetic expression like this:</p>
-<div class="codehilite"><pre><span class="n">1</span> + <span class="n">2</span> * <span class="n">3</span> - <span class="n">4</span>
+<div class="codehilite" translate="no"><pre><span class="n">1</span> + <span class="n">2</span> * <span class="n">3</span> - <span class="n">4</span>
 </pre></div>
 <p>Because you understand the order of operations<span class="em">&mdash;</span>the old &ldquo;<a href="https://en.wikipedia.org/wiki/Order_of_operations#Mnemonics">Please Excuse My
 Dear Aunt Sally</a>&rdquo; stuff<span class="em">&mdash;</span>you know that the multiplication is evaluated
@@ -255,7 +255,7 @@ languages all the way down!</p>
 <p>Yes, I really am going to be using breakfast examples throughout this entire
 book. Sorry.</p>
 </aside>
-<div class="codehilite"><pre><span class="i">breakfast</span>  → <span class="i">protein</span> <span class="s">&quot;with&quot;</span> <span class="i">breakfast</span> <span class="s">&quot;on the side&quot;</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">breakfast</span>  → <span class="i">protein</span> <span class="s">&quot;with&quot;</span> <span class="i">breakfast</span> <span class="s">&quot;on the side&quot;</span> ;
 <span class="i">breakfast</span>  → <span class="i">protein</span> ;
 <span class="i">breakfast</span>  → <span class="i">bread</span> ;
 
@@ -278,15 +278,15 @@ book. Sorry.</p>
 see how it works. By age-old convention, the game starts with the first rule in
 the grammar, here <code>breakfast</code>. There are three productions for that, and we
 randomly pick the first one. Our resulting string looks like:</p>
-<div class="codehilite"><pre>protein &quot;with&quot; breakfast &quot;on the side&quot;
+<div class="codehilite" translate="no"><pre>protein &quot;with&quot; breakfast &quot;on the side&quot;
 </pre></div>
 <p>We need to expand that first nonterminal, <code>protein</code>, so we pick a production for
 that. Let&rsquo;s pick:</p>
-<div class="codehilite"><pre><span class="i">protein</span> → <span class="i">cooked</span> <span class="s">&quot;eggs&quot;</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">protein</span> → <span class="i">cooked</span> <span class="s">&quot;eggs&quot;</span> ;
 </pre></div>
 <p>Next, we need a production for <code>cooked</code>, and so we pick <code>"poached"</code>. That&rsquo;s a
 terminal, so we add that. Now our string looks like:</p>
-<div class="codehilite"><pre>&quot;poached&quot; &quot;eggs&quot; &quot;with&quot; breakfast &quot;on the side&quot;
+<div class="codehilite" translate="no"><pre>&quot;poached&quot; &quot;eggs&quot; &quot;with&quot; breakfast &quot;on the side&quot;
 </pre></div>
 <p>The next non-terminal is <code>breakfast</code> again. The first <code>breakfast</code> production we
 chose recursively refers back to the <code>breakfast</code> rule. Recursion in the grammar
@@ -327,13 +327,13 @@ allow a few other kinds of expressions in the body of a rule:</p>
 <p>Instead of repeating the rule name each time we want to add another
 production for it, we&rsquo;ll allow a series of productions separated by a pipe
 (<code>|</code>).</p>
-<div class="codehilite"><pre><span class="i">bread</span> → <span class="s">&quot;toast&quot;</span> | <span class="s">&quot;biscuits&quot;</span> | <span class="s">&quot;English muffin&quot;</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">bread</span> → <span class="s">&quot;toast&quot;</span> | <span class="s">&quot;biscuits&quot;</span> | <span class="s">&quot;English muffin&quot;</span> ;
 </pre></div>
 </li>
 <li>
 <p>Further, we&rsquo;ll allow parentheses for grouping and then allow <code>|</code> within that
 to select one from a series of options within the middle of a production.</p>
-<div class="codehilite"><pre><span class="i">protein</span> → ( <span class="s">&quot;scrambled&quot;</span> | <span class="s">&quot;poached&quot;</span> | <span class="s">&quot;fried&quot;</span> ) <span class="s">&quot;eggs&quot;</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">protein</span> → ( <span class="s">&quot;scrambled&quot;</span> | <span class="s">&quot;poached&quot;</span> | <span class="s">&quot;fried&quot;</span> ) <span class="s">&quot;eggs&quot;</span> ;
 </pre></div>
 </li>
 <li>
@@ -342,7 +342,7 @@ appealing <span name="purity">purity</span>, but it&rsquo;s kind of a chore to
 make a separate named sub-rule each time we want to loop. So, we also use a
 postfix <code>*</code> to allow the previous symbol or group to be repeated zero or
 more times.</p>
-<div class="codehilite"><pre><span class="i">crispiness</span> → <span class="s">&quot;really&quot;</span> <span class="s">&quot;really&quot;</span>* ;
+<div class="codehilite" translate="no"><pre><span class="i">crispiness</span> → <span class="s">&quot;really&quot;</span> <span class="s">&quot;really&quot;</span>* ;
 </pre></div>
 </li>
 </ul>
@@ -355,18 +355,18 @@ recursion.</p>
 <li>
 <p>A postfix <code>+</code> is similar, but requires the preceding production to appear
 at least once.</p>
-<div class="codehilite"><pre><span class="i">crispiness</span> → <span class="s">&quot;really&quot;</span>+ ;
+<div class="codehilite" translate="no"><pre><span class="i">crispiness</span> → <span class="s">&quot;really&quot;</span>+ ;
 </pre></div>
 </li>
 <li>
 <p>A postfix <code>?</code> is for an optional production. The thing before it can appear
 zero or one time, but not more.</p>
-<div class="codehilite"><pre><span class="i">breakfast</span> → <span class="i">protein</span> ( <span class="s">&quot;with&quot;</span> <span class="i">breakfast</span> <span class="s">&quot;on the side&quot;</span> )? ;
+<div class="codehilite" translate="no"><pre><span class="i">breakfast</span> → <span class="i">protein</span> ( <span class="s">&quot;with&quot;</span> <span class="i">breakfast</span> <span class="s">&quot;on the side&quot;</span> )? ;
 </pre></div>
 </li>
 </ul>
 <p>With all of those syntactic niceties, our breakfast grammar condenses down to:</p>
-<div class="codehilite"><pre><span class="i">breakfast</span> → <span class="i">protein</span> ( <span class="s">&quot;with&quot;</span> <span class="i">breakfast</span> <span class="s">&quot;on the side&quot;</span> )?
+<div class="codehilite" translate="no"><pre><span class="i">breakfast</span> → <span class="i">protein</span> ( <span class="s">&quot;with&quot;</span> <span class="i">breakfast</span> <span class="s">&quot;on the side&quot;</span> )?
           | <span class="i">bread</span> ;
 
 <span class="i">protein</span>   → <span class="s">&quot;really&quot;</span>+ <span class="s">&quot;crispy&quot;</span> <span class="s">&quot;bacon&quot;</span>
@@ -414,10 +414,10 @@ operators (<code>==</code>, <code>!=</code>, <code>&lt;</code>, <code>&lt;=</cod
 </li>
 </ul>
 <p>That gives us enough syntax for expressions like:</p>
-<div class="codehilite"><pre><span class="n">1</span> - (<span class="n">2</span> * <span class="n">3</span>) &lt; <span class="n">4</span> == <span class="k">false</span>
+<div class="codehilite" translate="no"><pre><span class="n">1</span> - (<span class="n">2</span> * <span class="n">3</span>) &lt; <span class="n">4</span> == <span class="k">false</span>
 </pre></div>
 <p>Using our handy dandy new notation, here&rsquo;s a grammar for those:</p>
-<div class="codehilite"><pre><span class="i">expression</span>     → <span class="i">literal</span>
+<div class="codehilite" translate="no"><pre><span class="i">expression</span>     → <span class="i">literal</span>
                | <span class="i">unary</span>
                | <span class="i">binary</span>
                | <span class="i">grouping</span> ;
@@ -471,7 +471,7 @@ different classes for literals and other kinds of lexemes, but I figured I&rsquo
 keep things simpler.</p>
 </aside>
 <p>Something like this:</p>
-<div class="codehilite"><pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
+<div class="codehilite" translate="no"><pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
 <span class="k">abstract</span> <span class="k">class</span> <span class="t">Expr</span> {<span name="expr"> </span>
   <span class="k">static</span> <span class="k">class</span> <span class="t">Binary</span> <span class="k">extends</span> <span class="t">Expr</span> {
@@ -544,7 +544,7 @@ Jython and IronPython.</p>
 <p>An actual scripting language would be a better fit for this than Java, but I&rsquo;m
 trying not to throw too many languages at you.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>tool/GenerateAst.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>tool/GenerateAst.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.tool</span>;
 
@@ -572,7 +572,7 @@ When it&rsquo;s done, we treat &ldquo;Expr.java&rdquo; like any other file in th
 We are merely automating how that file gets authored.</p>
 <p>To generate the classes, it needs to have some description of each type and its
 fields.</p>
-<div class="codehilite"><pre class="insert-before">    String outputDir = args[0];
+<div class="codehilite" translate="no"><pre class="insert-before">    String outputDir = args[0];
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">    <span class="i">defineAst</span>(<span class="i">outputDir</span>, <span class="s">&quot;Expr&quot;</span>, <span class="t">Arrays</span>.<span class="i">asList</span>(
@@ -589,7 +589,7 @@ in <em>main</em>()</div>
 strings. Each is the name of the class followed by <code>:</code> and the list of fields,
 separated by commas. Each field has a type and a name.</p>
 <p>The first thing <code>defineAst()</code> needs to do is output the base Expr class.</p>
-<div class="codehilite"><div class="source-file"><em>tool/GenerateAst.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>tool/GenerateAst.java</em><br>
 add after <em>main</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">defineAst</span>(
       <span class="t">String</span> <span class="i">outputDir</span>, <span class="t">String</span> <span class="i">baseName</span>, <span class="t">List</span>&lt;<span class="t">String</span>&gt; <span class="i">types</span>)
@@ -614,7 +614,7 @@ the name of the file it outputs. We pass this as an argument instead of
 hardcoding the name because we&rsquo;ll add a separate family of classes later for
 statements.</p>
 <p>Inside the base class, we define each subclass.</p>
-<div class="codehilite"><pre class="insert-before">    writer.println(&quot;abstract class &quot; + baseName + &quot; {&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">    writer.println(&quot;abstract class &quot; + baseName + &quot; {&quot;);
 
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>defineAst</em>()</div>
@@ -634,7 +634,7 @@ It only runs on the exact set of class definitions we give it. Robustness ain&rs
 a priority.</p>
 </aside>
 <p>That code, in turn, calls:</p>
-<div class="codehilite"><div class="source-file"><em>tool/GenerateAst.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>tool/GenerateAst.java</em><br>
 add after <em>defineAst</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">defineType</span>(
       <span class="t">PrintWriter</span> <span class="i">writer</span>, <span class="t">String</span> <span class="i">baseName</span>,
@@ -683,7 +683,7 @@ needs to select a different chunk of code to handle each expression type. With
 tokens, we can simply switch on the TokenType. But we don&rsquo;t have a &ldquo;type&rdquo; enum
 for the syntax trees, just a separate Java class for each one.</p>
 <p>We could write a long chain of type tests:</p>
-<div class="codehilite"><pre><span class="k">if</span> (<span class="i">expr</span> <span class="k">instanceof</span> <span class="t">Expr</span>.<span class="t">Binary</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">if</span> (<span class="i">expr</span> <span class="k">instanceof</span> <span class="t">Expr</span>.<span class="t">Binary</span>) {
   <span class="c">// ...</span>
 } <span class="k">else</span> <span class="k">if</span> (<span class="i">expr</span> <span class="k">instanceof</span> <span class="t">Expr</span>.<span class="t">Grouping</span>) {
   <span class="c">// ...</span>
@@ -792,7 +792,7 @@ piled high in powdered sugar, and washed down with a cup of café au lait while 
 watch tourists staggering around trying to shake off their hangover from the
 previous night&rsquo;s revelry.</p>
 </aside>
-<div class="codehilite"><pre>  <span class="k">abstract</span> <span class="k">class</span> <span class="t">Pastry</span> {
+<div class="codehilite" translate="no"><pre>  <span class="k">abstract</span> <span class="k">class</span> <span class="t">Pastry</span> {
   }
 
   <span class="k">class</span> <span class="t">Beignet</span> <span class="k">extends</span> <span class="t">Pastry</span> {
@@ -805,7 +805,7 @@ previous night&rsquo;s revelry.</p>
 <p>We want to be able to define new pastry operations<span class="em">&mdash;</span>cooking them, eating them,
 decorating them, etc.<span class="em">&mdash;</span>without having to add a new method to each class every
 time. Here&rsquo;s how we do it. First, we define a separate interface.</p>
-<div class="codehilite"><pre>  <span class="k">interface</span> <span class="t">PastryVisitor</span> {
+<div class="codehilite" translate="no"><pre>  <span class="k">interface</span> <span class="t">PastryVisitor</span> {
     <span class="t">void</span> <span class="i">visitBeignet</span>(<span class="t">Beignet</span> <span class="i">beignet</span>);<span name="overload"> </span>
     <span class="t">void</span> <span class="i">visitCruller</span>(<span class="t">Cruller</span> <span class="i">cruller</span>);
   }
@@ -825,13 +825,13 @@ that interface. It has a concrete method for each type of pastry. That keeps the
 code for the operation on both types all nestled snugly together in one class.</p>
 <p>Given some pastry, how do we route it to the correct method on the visitor based
 on its type? Polymorphism to the rescue! We add this method to Pastry:</p>
-<div class="codehilite"><pre class="insert-before">  abstract class Pastry {
+<div class="codehilite" translate="no"><pre class="insert-before">  abstract class Pastry {
 </pre><pre class="insert">    <span class="k">abstract</span> <span class="t">void</span> <span class="i">accept</span>(<span class="t">PastryVisitor</span> <span class="i">visitor</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
 
 <p>Each subclass implements it.</p>
-<div class="codehilite"><pre class="insert-before">  class Beignet extends Pastry {
+<div class="codehilite" translate="no"><pre class="insert-before">  class Beignet extends Pastry {
 </pre><pre class="insert">    <span class="a">@Override</span>
     <span class="t">void</span> <span class="i">accept</span>(<span class="t">PastryVisitor</span> <span class="i">visitor</span>) {
       <span class="i">visitor</span>.<span class="i">visitBeignet</span>(<span class="k">this</span>);
@@ -840,7 +840,7 @@ on its type? Polymorphism to the rescue! We add this method to Pastry:</p>
 </pre></div>
 
 <p>And:</p>
-<div class="codehilite"><pre class="insert-before">  class Cruller extends Pastry {
+<div class="codehilite" translate="no"><pre class="insert-before">  class Cruller extends Pastry {
 </pre><pre class="insert">    <span class="a">@Override</span>
     <span class="t">void</span> <span class="i">accept</span>(<span class="t">PastryVisitor</span> <span class="i">visitor</span>) {
       <span class="i">visitor</span>.<span class="i">visitCruller</span>(<span class="k">this</span>);
@@ -874,7 +874,7 @@ book don&rsquo;t need that, so I omitted it.</p>
 </aside>
 <p>First, we define the visitor interface. Again, we nest it inside the base class
 so that we can keep everything in one file.</p>
-<div class="codehilite"><pre class="insert-before">    writer.println(&quot;abstract class &quot; + baseName + &quot; {&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">    writer.println(&quot;abstract class &quot; + baseName + &quot; {&quot;);
 
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>defineAst</em>()</div>
@@ -885,7 +885,7 @@ in <em>defineAst</em>()</div>
 <div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>defineAst</em>()</div>
 
 <p>That function generates the visitor interface.</p>
-<div class="codehilite"><div class="source-file"><em>tool/GenerateAst.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>tool/GenerateAst.java</em><br>
 add after <em>defineAst</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">defineVisitor</span>(
       <span class="t">PrintWriter</span> <span class="i">writer</span>, <span class="t">String</span> <span class="i">baseName</span>, <span class="t">List</span>&lt;<span class="t">String</span>&gt; <span class="i">types</span>) {
@@ -906,7 +906,7 @@ add after <em>defineAst</em>()</div>
 each one. When we define new expression types later, this will automatically
 include them.</p>
 <p>Inside the base class, we define the abstract <code>accept()</code> method.</p>
-<div class="codehilite"><pre class="insert-before">      defineType(writer, baseName, className, fields);
+<div class="codehilite" translate="no"><pre class="insert-before">      defineType(writer, baseName, className, fields);
     }
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>defineAst</em>()</div>
@@ -922,7 +922,7 @@ in <em>defineAst</em>()</div>
 
 <p>Finally, each subclass implements that and calls the right visit method for its
 own type.</p>
-<div class="codehilite"><pre class="insert-before">    writer.println(&quot;    }&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">    writer.println(&quot;    }&quot;);
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>defineType</em>()</div>
 <pre class="insert">
@@ -964,11 +964,11 @@ Instead, it will look a lot like, well, Lisp. Each expression is explicitly
 parenthesized, and all of its subexpressions and tokens are contained in that.</p>
 <p>Given a syntax tree like:</p><img src="image/representing-code/expression.png" alt="An example syntax tree." />
 <p>It produces:</p>
-<div class="codehilite"><pre>(* (- 123) (group 45.67))
+<div class="codehilite" translate="no"><pre>(* (- 123) (group 45.67))
 </pre></div>
 <p>Not exactly &ldquo;pretty&rdquo;, but it does show the nesting and grouping explicitly. To
 implement this, we define a new class.</p>
-<div class="codehilite"><div class="source-file"><em>lox/AstPrinter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/AstPrinter.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -982,7 +982,7 @@ create new file</div>
 
 <p>As you can see, it implements the visitor interface. That means we need visit
 methods for each of the expression types we have so far.</p>
-<div class="codehilite"><pre class="insert-before">    return expr.accept(this);
+<div class="codehilite" translate="no"><pre class="insert-before">    return expr.accept(this);
   }
 </pre><div class="source-file"><em>lox/AstPrinter.java</em><br>
 add after <em>print</em>()</div>
@@ -1016,7 +1016,7 @@ add after <em>print</em>()</div>
 <p>Literal expressions are easy<span class="em">&mdash;</span>they convert the value to a string with a little
 check to handle Java&rsquo;s <code>null</code> standing in for Lox&rsquo;s <code>nil</code>. The other expressions
 have subexpressions, so they use this <code>parenthesize()</code> helper method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/AstPrinter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/AstPrinter.java</em><br>
 add after <em>visitUnaryExpr</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">String</span> <span class="i">parenthesize</span>(<span class="t">String</span> <span class="i">name</span>, <span class="t">Expr</span>... <span class="i">exprs</span>) {
     <span class="t">StringBuilder</span> <span class="i">builder</span> = <span class="k">new</span> <span class="t">StringBuilder</span>();
@@ -1035,7 +1035,7 @@ add after <em>visitUnaryExpr</em>()</div>
 
 <p>It takes a name and a list of subexpressions and wraps them all up in
 parentheses, yielding a string like:</p>
-<div class="codehilite"><pre>(+ 1 2)
+<div class="codehilite" translate="no"><pre>(+ 1 2)
 </pre></div>
 <p>Note that it calls <code>accept()</code> on each subexpression and passes in itself. This
 is the <span name="tree">recursive</span> step that lets us print an entire
@@ -1047,7 +1047,7 @@ with trees.</p>
 <p>We don&rsquo;t have a parser yet, so it&rsquo;s hard to see this in action. For now, we&rsquo;ll
 hack together a little <code>main()</code> method that manually instantiates a tree and
 prints it.</p>
-<div class="codehilite"><div class="source-file"><em>lox/AstPrinter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/AstPrinter.java</em><br>
 add after <em>parenthesize</em>()</div>
 <pre>  <span class="k">public</span> <span class="k">static</span> <span class="t">void</span> <span class="i">main</span>(<span class="t">String</span>[] <span class="i">args</span>) {
     <span class="t">Expr</span> <span class="i">expression</span> = <span class="k">new</span> <span class="t">Expr</span>.<span class="t">Binary</span>(
@@ -1064,7 +1064,7 @@ add after <em>parenthesize</em>()</div>
 <div class="source-file-narrow"><em>lox/AstPrinter.java</em>, add after <em>parenthesize</em>()</div>
 
 <p>If we did everything right, it prints:</p>
-<div class="codehilite"><pre>(* (- 123) (group 45.67))
+<div class="codehilite" translate="no"><pre>(* (- 123) (group 45.67))
 </pre></div>
 <p>You can go ahead and delete this method. We won&rsquo;t need it. Also, as we add new
 syntax tree types, I won&rsquo;t bother showing the necessary visit methods for them
@@ -1078,7 +1078,7 @@ maintain AstPrinter, feel free to delete it. We won&rsquo;t need it again.</p>
 <li>
 <p>Earlier, I said that the <code>|</code>, <code>*</code>, and <code>+</code> forms we added to our grammar
 metasyntax were just syntactic sugar. Take this grammar:</p>
-<div class="codehilite"><pre><span class="i">expr</span> → <span class="i">expr</span> ( <span class="s">&quot;(&quot;</span> ( <span class="i">expr</span> ( <span class="s">&quot;,&quot;</span> <span class="i">expr</span> )* )? <span class="s">&quot;)&quot;</span> | <span class="s">&quot;.&quot;</span> <span class="t">IDENTIFIER</span> )+
+<div class="codehilite" translate="no"><pre><span class="i">expr</span> → <span class="i">expr</span> ( <span class="s">&quot;(&quot;</span> ( <span class="i">expr</span> ( <span class="s">&quot;,&quot;</span> <span class="i">expr</span> )* )? <span class="s">&quot;)&quot;</span> | <span class="s">&quot;.&quot;</span> <span class="t">IDENTIFIER</span> )+
      | <span class="t">IDENTIFIER</span>
      | <span class="t">NUMBER</span>
 </pre></div>
@@ -1100,10 +1100,10 @@ operator are both placed before the operator, so <code>1 + 2</code> becomes <cod
 Evaluation proceeds from left to right. Numbers are pushed onto an implicit
 stack. An arithmetic operator pops the top two numbers, performs the
 operation, and pushes the result. Thus, this:</p>
-<div class="codehilite"><pre>(<span class="n">1</span> + <span class="n">2</span>) * (<span class="n">4</span> - <span class="n">3</span>)
+<div class="codehilite" translate="no"><pre>(<span class="n">1</span> + <span class="n">2</span>) * (<span class="n">4</span> - <span class="n">3</span>)
 </pre></div>
 <p>in RPN becomes:</p>
-<div class="codehilite"><pre><span class="n">1</span> <span class="n">2</span> + <span class="n">4</span> <span class="n">3</span> - *
+<div class="codehilite" translate="no"><pre><span class="n">1</span> <span class="n">2</span> + <span class="n">4</span> <span class="n">3</span> - *
 </pre></div>
 <p>Define a visitor class for our syntax tree classes that takes an expression,
 converts it to RPN, and returns the resulting string.</p>

--- a/site/resolving-and-binding.html
+++ b/site/resolving-and-binding.html
@@ -114,7 +114,7 @@ extracting meaning from the user&rsquo;s source code without having to run it.</
 <p>A quick refresher: Lox, like most modern languages, uses <em>lexical</em> scoping. This
 means that you can figure out which declaration a variable name refers to just
 by reading the text of the program. For example:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;outer&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;outer&quot;</span>;
 {
   <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;inner&quot;</span>;
   <span class="k">print</span> <span class="i">a</span>;
@@ -146,7 +146,7 @@ variable is used&rdquo;.</p>
 </li>
 <li>
 <p>&ldquo;Preceding&rdquo; means appearing before <em>in the program text</em>.</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;outer&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;outer&quot;</span>;
 {
   <span class="k">print</span> <span class="i">a</span>;
   <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;inner&quot;</span>;
@@ -163,13 +163,13 @@ execution no longer mirrors the <em>static textual</em> ordering.</p>
 the beginning of the block. Any use of that name in the block will refer to
 that variable, even if the use appears before the declaration. When you
 write this in JavaScript:</p>
-<div class="codehilite"><pre>{
+<div class="codehilite" translate="no"><pre>{
   <span class="i">console</span>.<span class="i">log</span>(<span class="i">a</span>);
   <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;value&quot;</span>;
 }
 </pre></div>
 <p>It behaves like:</p>
-<div class="codehilite"><pre>{
+<div class="codehilite" translate="no"><pre>{
   <span class="k">var</span> <span class="i">a</span>; <span class="c">// Hoist.</span>
   <span class="i">console</span>.<span class="i">log</span>(<span class="i">a</span>);
   <span class="i">a</span> = <span class="s">&quot;value&quot;</span>;
@@ -182,7 +182,7 @@ declaring variables was added later to address this problem.</p>
 <li>
 <p>&ldquo;Innermost&rdquo; is there because of our good friend shadowing. There may be more
 than one variable with the given name in enclosing scopes, as in:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;outer&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;outer&quot;</span>;
 {
   <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;inner&quot;</span>;
   <span class="k">print</span> <span class="i">a</span>;
@@ -195,7 +195,7 @@ than one variable with the given name in enclosing scopes, as in:</p>
 variable expression always refers to the same declaration through the entire
 execution of the program. Our interpreter so far <em>mostly</em> implements the rule
 correctly. But when we added closures, an error snuck in.</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;global&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;global&quot;</span>;
 {
   <span class="k">fun</span> <span class="i">showA</span>() {
     <span class="k">print</span> <span class="i">a</span>;
@@ -220,7 +220,7 @@ it to print &ldquo;global&rdquo; twice. The first call to <code>showA()</code> s
 by our rule that a variable expression always resolves to the same variable,
 that implies the second call to <code>showA()</code> should print the same thing.</p>
 <p>Alas, it prints:</p>
-<div class="codehilite"><pre>global
+<div class="codehilite" translate="no"><pre>global
 block
 </pre></div>
 <p>Let me stress that this program never reassigns any variable and contains only a
@@ -267,7 +267,7 @@ new local variable is declared, it gets added to the existing environment for
 that scope.</p>
 <p>That intuition, like many in life, isn&rsquo;t quite right. A block is not necessarily
 all the same scope. Consider:</p>
-<div class="codehilite"><pre>{
+<div class="codehilite" translate="no"><pre>{
   <span class="k">var</span> <span class="i">a</span>;
   <span class="c">// 1.</span>
   <span class="k">var</span> <span class="i">b</span>;
@@ -394,7 +394,7 @@ the user&rsquo;s program grows.</p>
 </aside>
 <h2><a href="#a-resolver-class" id="a-resolver-class"><small>11&#8202;.&#8202;3</small>A Resolver Class</a></h2>
 <p>Like everything in Java, our variable resolution pass is embodied in a class.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -438,7 +438,7 @@ operands might.</p>
 <h3><a href="#resolving-blocks" id="resolving-blocks"><small>11&#8202;.&#8202;3&#8202;.&#8202;1</small>Resolving blocks</a></h3>
 <p>We start with blocks since they create the local scopes where all the magic
 happens.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>Resolver</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitBlockStmt</span>(<span class="t">Stmt</span>.<span class="t">Block</span> <span class="i">stmt</span>) {
@@ -453,7 +453,7 @@ add after <em>Resolver</em>()</div>
 <p>This begins a new scope, traverses into the statements inside the block, and
 then discards the scope. The fun stuff lives in those helper methods. We start
 with the simple one.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>Resolver</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">resolve</span>(<span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span>) {
     <span class="k">for</span> (<span class="t">Stmt</span> <span class="i">statement</span> : <span class="i">statements</span>) {
@@ -464,7 +464,7 @@ add after <em>Resolver</em>()</div>
 <div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>Resolver</em>()</div>
 
 <p>This walks a list of statements and resolves each one. It in turn calls:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">resolve</span>(<span class="t">Stmt</span> <span class="i">stmt</span>) {
     <span class="i">stmt</span>.<span class="i">accept</span>(<span class="k">this</span>);
@@ -474,7 +474,7 @@ add after <em>visitBlockStmt</em>()</div>
 
 <p>While we&rsquo;re at it, let&rsquo;s add another overload that we&rsquo;ll need later for
 resolving an expression.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>resolve</em>(Stmt stmt)</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">resolve</span>(<span class="t">Expr</span> <span class="i">expr</span>) {
     <span class="i">expr</span>.<span class="i">accept</span>(<span class="k">this</span>);
@@ -487,7 +487,7 @@ Interpreter<span class="em">&mdash;</span>they turn around and apply the Visitor
 syntax tree node.</p>
 <p>The real interesting behavior is around scopes. A new block scope is created
 like so:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>resolve</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">beginScope</span>() {
     <span class="i">scopes</span>.<span class="i">push</span>(<span class="k">new</span> <span class="t">HashMap</span>&lt;<span class="t">String</span>, <span class="t">Boolean</span>&gt;());
@@ -498,7 +498,7 @@ add after <em>resolve</em>()</div>
 <p>Lexical scopes nest in both the interpreter and the resolver. They behave like a
 stack. The interpreter implements that stack using a linked list<span class="em">&mdash;</span>the chain of
 Environment objects. In the resolver, we use an actual Java Stack.</p>
-<div class="codehilite"><pre class="insert-before">  private final Interpreter interpreter;
+<div class="codehilite" translate="no"><pre class="insert-before">  private final Interpreter interpreter;
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in class <em>Resolver</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">Stack</span>&lt;<span class="t">Map</span>&lt;<span class="t">String</span>, <span class="t">Boolean</span>&gt;&gt; <span class="i">scopes</span> = <span class="k">new</span> <span class="t">Stack</span>&lt;&gt;();
@@ -517,7 +517,7 @@ top level in the global scope are not tracked by the resolver since they are
 more dynamic in Lox. When resolving a variable, if we can&rsquo;t find it in the stack
 of local scopes, we assume it must be global.</p>
 <p>Since scopes are stored in an explicit stack, exiting one is straightforward.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>beginScope</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">endScope</span>() {
     <span class="i">scopes</span>.<span class="i">pop</span>();
@@ -529,7 +529,7 @@ add after <em>beginScope</em>()</div>
 <h3><a href="#resolving-variable-declarations" id="resolving-variable-declarations"><small>11&#8202;.&#8202;3&#8202;.&#8202;2</small>Resolving variable declarations</a></h3>
 <p>Resolving a variable declaration adds a new entry to the current innermost
 scope&rsquo;s map. That seems simple, but there&rsquo;s a little dance we need to do.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitVarStmt</span>(<span class="t">Stmt</span>.<span class="t">Var</span> <span class="i">stmt</span>) {
@@ -545,7 +545,7 @@ add after <em>visitBlockStmt</em>()</div>
 
 <p>We split binding into two steps, declaring then defining, in order to handle
 funny edge cases like this:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;outer&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;outer&quot;</span>;
 {
   <span class="k">var</span> <span class="i">a</span> = <span class="i">a</span>;
 }
@@ -557,7 +557,7 @@ the same name as the variable being declared? We have a few options:</p>
 <p><strong>Run the initializer, then put the new variable in scope.</strong> Here, the new
 local <code>a</code> would be initialized with &ldquo;outer&rdquo;, the value of the <em>global</em> one.
 In other words, the previous declaration would desugar to:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">temp</span> = <span class="i">a</span>; <span class="c">// Run the initializer.</span>
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">temp</span> = <span class="i">a</span>; <span class="c">// Run the initializer.</span>
 <span class="k">var</span> <span class="i">a</span>;        <span class="c">// Declare the variable.</span>
 <span class="i">a</span> = <span class="i">temp</span>;     <span class="c">// Initialize it.</span>
 </pre></div>
@@ -568,7 +568,7 @@ could observe a variable before it&rsquo;s initialized, so we would need to figu
 out what value it would have then. Probably <code>nil</code>. That means the new local
 <code>a</code> would be re-initialized to its own implicitly initialized value, <code>nil</code>.
 Now the desugaring would look like:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span>; <span class="c">// Define the variable.</span>
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span>; <span class="c">// Define the variable.</span>
 <span class="i">a</span> = <span class="i">a</span>; <span class="c">// Run the initializer.</span>
 </pre></div>
 </li>
@@ -590,7 +590,7 @@ way, the user is alerted to the problem before any code is run.</p>
 <p>In order to do that, as we visit expressions, we need to know if we&rsquo;re inside
 the initializer for some variable. We do that by splitting binding into two
 steps. The first is <strong>declaring</strong> it.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>endScope</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">declare</span>(<span class="t">Token</span> <span class="i">name</span>) {
     <span class="k">if</span> (<span class="i">scopes</span>.<span class="i">isEmpty</span>()) <span class="k">return</span>;
@@ -610,7 +610,7 @@ variable&rsquo;s initializer.</p>
 scope where the new variable now exists but is unavailable. Once the initializer
 expression is done, the variable is ready for prime time. We do that by
 <strong>defining</strong> it.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>declare</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">define</span>(<span class="t">Token</span> <span class="i">name</span>) {
     <span class="k">if</span> (<span class="i">scopes</span>.<span class="i">isEmpty</span>()) <span class="k">return</span>;
@@ -624,7 +624,7 @@ initialized and available for use. It&rsquo;s alive! </p>
 <h3><a href="#resolving-variable-expressions" id="resolving-variable-expressions"><small>11&#8202;.&#8202;3&#8202;.&#8202;3</small>Resolving variable expressions</a></h3>
 <p>Variable declarations<span class="em">&mdash;</span>and function declarations, which we&rsquo;ll get to<span class="em">&mdash;</span>write
 to the scope maps. Those maps are read when we resolve variable expressions.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitVarStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitVariableExpr</span>(<span class="t">Expr</span>.<span class="t">Variable</span> <span class="i">expr</span>) {
@@ -645,7 +645,7 @@ initializer. This is where the values in the scope map come into play. If the
 variable exists in the current scope but its value is <code>false</code>, that means we
 have declared it but not yet defined it. We report that error.</p>
 <p>After that check, we actually resolve the variable itself using this helper:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>define</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">resolveLocal</span>(<span class="t">Expr</span> <span class="i">expr</span>, <span class="t">Token</span> <span class="i">name</span>) {
     <span class="k">for</span> (<span class="t">int</span> <span class="i">i</span> = <span class="i">scopes</span>.<span class="i">size</span>() - <span class="n">1</span>; <span class="i">i</span> &gt;= <span class="n">0</span>; <span class="i">i</span>--) {
@@ -671,7 +671,7 @@ other syntax nodes.</p>
 <h3><a href="#resolving-assignment-expressions" id="resolving-assignment-expressions"><small>11&#8202;.&#8202;3&#8202;.&#8202;4</small>Resolving assignment expressions</a></h3>
 <p>The other expression that references a variable is assignment. Resolving one
 looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitVarStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitAssignExpr</span>(<span class="t">Expr</span>.<span class="t">Assign</span> <span class="i">expr</span>) {
@@ -690,7 +690,7 @@ to resolve the variable that&rsquo;s being assigned to.</p>
 the function itself is bound in the surrounding scope where the function is
 declared. When we step into the function&rsquo;s body, we also bind its parameters
 into that inner function scope.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitFunctionStmt</span>(<span class="t">Stmt</span>.<span class="t">Function</span> <span class="i">stmt</span>) {
@@ -708,7 +708,7 @@ in the current scope. Unlike variables, though, we define the name eagerly,
 before resolving the function&rsquo;s body. This lets a function recursively refer to
 itself inside its own body.</p>
 <p>Then we resolve the function&rsquo;s body using this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>resolve</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">resolveFunction</span>(<span class="t">Stmt</span>.<span class="t">Function</span> <span class="i">function</span>) {
     <span class="i">beginScope</span>();
@@ -742,7 +742,7 @@ boring, but bear with me. We&rsquo;ll go kind of &ldquo;top down&rdquo; and star
 I didn&rsquo;t say they&rsquo;d all be exciting.</p>
 </aside>
 <p>An expression statement contains a single expression to traverse.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitExpressionStmt</span>(<span class="t">Stmt</span>.<span class="t">Expression</span> <span class="i">stmt</span>) {
@@ -754,7 +754,7 @@ add after <em>visitBlockStmt</em>()</div>
 
 <p>An if statement has an expression for its condition and one or two statements
 for the branches.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitFunctionStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitIfStmt</span>(<span class="t">Stmt</span>.<span class="t">If</span> <span class="i">stmt</span>) {
@@ -772,7 +772,7 @@ branches. Where a dynamic execution steps only into the branch that <em>is</em> 
 static analysis is conservative<span class="em">&mdash;</span>it analyzes any branch that <em>could</em> be run.
 Since either one could be reached at runtime, we resolve both.</p>
 <p>Like expression statements, a <code>print</code> statement contains a single subexpression.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitIfStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitPrintStmt</span>(<span class="t">Stmt</span>.<span class="t">Print</span> <span class="i">stmt</span>) {
@@ -783,7 +783,7 @@ add after <em>visitIfStmt</em>()</div>
 <div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitIfStmt</em>()</div>
 
 <p>Same deal for return.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitPrintStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitReturnStmt</span>(<span class="t">Stmt</span>.<span class="t">Return</span> <span class="i">stmt</span>) {
@@ -798,7 +798,7 @@ add after <em>visitPrintStmt</em>()</div>
 
 <p>As in <code>if</code> statements, with a <code>while</code> statement, we resolve its condition and
 resolve the body exactly once.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitVarStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitWhileStmt</span>(<span class="t">Stmt</span>.<span class="t">While</span> <span class="i">stmt</span>) {
@@ -812,7 +812,7 @@ add after <em>visitVarStmt</em>()</div>
 <p>That covers all the statements. On to expressions<span class="ellipse">&thinsp;.&thinsp;.&thinsp;.&nbsp;</span></p>
 <p>Our old friend the binary expression. We traverse into and resolve both
 operands.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitAssignExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitBinaryExpr</span>(<span class="t">Expr</span>.<span class="t">Binary</span> <span class="i">expr</span>) {
@@ -826,7 +826,7 @@ add after <em>visitAssignExpr</em>()</div>
 <p>Calls are similar<span class="em">&mdash;</span>we walk the argument list and resolve them all. The thing
 being called is also an expression (usually a variable expression), so that gets
 resolved too.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitBinaryExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitCallExpr</span>(<span class="t">Expr</span>.<span class="t">Call</span> <span class="i">expr</span>) {
@@ -842,7 +842,7 @@ add after <em>visitBinaryExpr</em>()</div>
 <div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitBinaryExpr</em>()</div>
 
 <p>Parentheses are easy.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitCallExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitGroupingExpr</span>(<span class="t">Expr</span>.<span class="t">Grouping</span> <span class="i">expr</span>) {
@@ -853,7 +853,7 @@ add after <em>visitCallExpr</em>()</div>
 <div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitCallExpr</em>()</div>
 
 <p>Literals are easiest of all.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitGroupingExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitLiteralExpr</span>(<span class="t">Expr</span>.<span class="t">Literal</span> <span class="i">expr</span>) {
@@ -866,7 +866,7 @@ add after <em>visitGroupingExpr</em>()</div>
 subexpressions so there is no work to do.</p>
 <p>Since a static analysis does no control flow or short-circuiting, logical
 expressions are exactly the same as other binary operators.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitLiteralExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitLogicalExpr</span>(<span class="t">Expr</span>.<span class="t">Logical</span> <span class="i">expr</span>) {
@@ -878,7 +878,7 @@ add after <em>visitLiteralExpr</em>()</div>
 <div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitLiteralExpr</em>()</div>
 
 <p>And, finally, the last node. We resolve its one operand.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitLogicalExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitUnaryExpr</span>(<span class="t">Expr</span>.<span class="t">Unary</span> <span class="i">expr</span>) {
@@ -898,7 +898,7 @@ the scope where the variable is defined. At runtime, this corresponds exactly to
 the number of <em>environments</em> between the current one and the enclosing one where
 the interpreter can find the variable&rsquo;s value. The resolver hands that number to
 the interpreter by calling this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>execute</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">resolve</span>(<span class="t">Expr</span> <span class="i">expr</span>, <span class="t">int</span> <span class="i">depth</span>) {
     <span class="i">locals</span>.<span class="i">put</span>(<span class="i">expr</span>, <span class="i">depth</span>);
@@ -924,7 +924,7 @@ the user&rsquo;s program. It may be hard to find all of the bits of state that n
 recalculating when they&rsquo;re hiding in the foliage of the syntax tree. A benefit
 of storing this data outside of the nodes is that it makes it easy to <em>discard</em>
 it<span class="em">&mdash;</span>simply clear the map.</p>
-<div class="codehilite"><pre class="insert-before">  private Environment environment = globals;
+<div class="codehilite" translate="no"><pre class="insert-before">  private Environment environment = globals;
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">Map</span>&lt;<span class="t">Expr</span>, <span class="t">Integer</span>&gt; <span class="i">locals</span> = <span class="k">new</span> <span class="t">HashMap</span>&lt;&gt;();
@@ -939,7 +939,7 @@ confused when there are multiple expressions that reference the same variable,
 but each expression node is its own Java object with its own unique identity. A
 single monolithic map doesn&rsquo;t have any trouble keeping them separated.</p>
 <p>As usual, using a collection requires us to import a couple of names.</p>
-<div class="codehilite"><pre class="insert-before">import java.util.ArrayList;
+<div class="codehilite" translate="no"><pre class="insert-before">import java.util.ArrayList;
 </pre><div class="source-file"><em>lox/Interpreter.java</em></div>
 <pre class="insert"><span class="k">import</span> <span class="i">java.util.HashMap</span>;
 </pre><pre class="insert-after">import java.util.List;
@@ -947,7 +947,7 @@ single monolithic map doesn&rsquo;t have any trouble keeping them separated.</p>
 <div class="source-file-narrow"><em>lox/Interpreter.java</em></div>
 
 <p>And:</p>
-<div class="codehilite"><pre class="insert-before">import java.util.List;
+<div class="codehilite" translate="no"><pre class="insert-before">import java.util.List;
 </pre><div class="source-file"><em>lox/Interpreter.java</em></div>
 <pre class="insert"><span class="k">import</span> <span class="i">java.util.Map</span>;
 </pre><pre class="insert-after">
@@ -960,7 +960,7 @@ class Interpreter implements Expr.Visitor&lt;Object&gt;,
 <p>Our interpreter now has access to each variable&rsquo;s resolved location. Finally, we
 get to make use of that. We replace the visit method for variable expressions
 with this:</p>
-<div class="codehilite"><pre class="insert-before">  public Object visitVariableExpr(Expr.Variable expr) {
+<div class="codehilite" translate="no"><pre class="insert-before">  public Object visitVariableExpr(Expr.Variable expr) {
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitVariableExpr</em>()<br>
 replace 1 line</div>
@@ -970,7 +970,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitVariableExpr</em>(), replace 1 line</div>
 
 <p>That delegates to:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitVariableExpr</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Object</span> <span class="i">lookUpVariable</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">Expr</span> <span class="i">expr</span>) {
     <span class="t">Integer</span> <span class="i">distance</span> = <span class="i">locals</span>.<span class="i">get</span>(<span class="i">expr</span>);
@@ -992,7 +992,7 @@ runtime error if the variable isn&rsquo;t defined.</p>
 <p>If we <em>do</em> get a distance, we have a local variable, and we get to take
 advantage of the results of our static analysis. Instead of calling <code>get()</code>, we
 call this new method on Environment:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Environment.java</em><br>
 add after <em>define</em>()</div>
 <pre>  <span class="t">Object</span> <span class="i">getAt</span>(<span class="t">int</span> <span class="i">distance</span>, <span class="t">String</span> <span class="i">name</span>) {
     <span class="k">return</span> <span class="i">ancestor</span>(<span class="i">distance</span>).<span class="i">values</span>.<span class="i">get</span>(<span class="i">name</span>);
@@ -1004,7 +1004,7 @@ add after <em>define</em>()</div>
 scouring each one to see if the variable might be hiding in there somewhere. But
 now we know exactly which environment in the chain will have the variable. We
 reach it using this helper method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Environment.java</em><br>
 add after <em>define</em>()</div>
 <pre>  <span class="t">Environment</span> <span class="i">ancestor</span>(<span class="t">int</span> <span class="i">distance</span>) {
     <span class="t">Environment</span> <span class="i">environment</span> = <span class="k">this</span>;
@@ -1038,7 +1038,7 @@ to have already upheld.</p>
 <h3><a href="#assigning-to-a-resolved-variable" id="assigning-to-a-resolved-variable"><small>11&#8202;.&#8202;4&#8202;.&#8202;2</small>Assigning to a resolved variable</a></h3>
 <p>We can also use a variable by assigning to it. The changes to visiting an
 assignment expression are similar.</p>
-<div class="codehilite"><pre class="insert-before">  public Object visitAssignExpr(Expr.Assign expr) {
+<div class="codehilite" translate="no"><pre class="insert-before">  public Object visitAssignExpr(Expr.Assign expr) {
     Object value = evaluate(expr.value);
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitAssignExpr</em>()<br>
@@ -1058,7 +1058,7 @@ replace 1 line</div>
 
 <p>Again, we look up the variable&rsquo;s scope distance. If not found, we assume it&rsquo;s
 global and handle it the same way as before. Otherwise, we call this new method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Environment.java</em><br>
 add after <em>getAt</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">assignAt</span>(<span class="t">int</span> <span class="i">distance</span>, <span class="t">Token</span> <span class="i">name</span>, <span class="t">Object</span> <span class="i">value</span>) {
     <span class="i">ancestor</span>(<span class="i">distance</span>).<span class="i">values</span>.<span class="i">put</span>(<span class="i">name</span>.<span class="i">lexeme</span>, <span class="i">value</span>);
@@ -1075,7 +1075,7 @@ unchanged.</p>
 <h3><a href="#running-the-resolver" id="running-the-resolver"><small>11&#8202;.&#8202;4&#8202;.&#8202;3</small>Running the resolver</a></h3>
 <p>We do need to actually <em>run</em> the resolver, though. We insert the new pass after
 the parser does its magic.</p>
-<div class="codehilite"><pre class="insert-before">    // Stop if there was a syntax error.
+<div class="codehilite" translate="no"><pre class="insert-before">    // Stop if there was a syntax error.
     if (hadError) return;
 
 </pre><div class="source-file"><em>lox/Lox.java</em><br>
@@ -1099,7 +1099,7 @@ resolution?</p>
 <p>Since we are doing a semantic analysis pass, we have an opportunity to make
 Lox&rsquo;s semantics more precise, and to help users catch bugs early before running
 their code. Take a look at this bad boy:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">bad</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">bad</span>() {
   <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;first&quot;</span>;
   <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;second&quot;</span>;
 }
@@ -1110,7 +1110,7 @@ variable already existed, they would have assigned to it instead of using <code>
 And if they <em>didn&rsquo;t</em> know it existed, they probably didn&rsquo;t intend to overwrite
 the previous one.</p>
 <p>We can detect this mistake statically while resolving.</p>
-<div class="codehilite"><pre class="insert-before">    Map&lt;String, Boolean&gt; scope = scopes.peek();
+<div class="codehilite" translate="no"><pre class="insert-before">    Map&lt;String, Boolean&gt; scope = scopes.peek();
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>declare</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">scope</span>.<span class="i">containsKey</span>(<span class="i">name</span>.<span class="i">lexeme</span>)) {
@@ -1127,7 +1127,7 @@ variable previously declared in that same scope. If we see a collision, we
 report an error.</p>
 <h3><a href="#invalid-return-errors" id="invalid-return-errors"><small>11&#8202;.&#8202;5&#8202;.&#8202;1</small>Invalid return errors</a></h3>
 <p>Here&rsquo;s another nasty little script:</p>
-<div class="codehilite"><pre><span class="k">return</span> <span class="s">&quot;at top level&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">return</span> <span class="s">&quot;at top level&quot;</span>;
 </pre></div>
 <p>This executes a <code>return</code> statement, but it&rsquo;s not even inside a function at all.
 It&rsquo;s top-level code. I don&rsquo;t know what the user <em>thinks</em> is going to happen, but
@@ -1135,7 +1135,7 @@ I don&rsquo;t think we want Lox to allow this.</p>
 <p>We can extend the resolver to detect this statically. Much like we track scopes
 as we walk the tree, we can track whether or not the code we are currently
 visiting is inside a function declaration.</p>
-<div class="codehilite"><pre class="insert-before">  private final Stack&lt;Map&lt;String, Boolean&gt;&gt; scopes = new Stack&lt;&gt;();
+<div class="codehilite" translate="no"><pre class="insert-before">  private final Stack&lt;Map&lt;String, Boolean&gt;&gt; scopes = new Stack&lt;&gt;();
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in class <em>Resolver</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="t">FunctionType</span> <span class="i">currentFunction</span> = <span class="t">FunctionType</span>.<span class="i">NONE</span>;
@@ -1146,7 +1146,7 @@ in class <em>Resolver</em></div>
 <div class="source-file-narrow"><em>lox/Resolver.java</em>, in class <em>Resolver</em></div>
 
 <p>Instead of a bare Boolean, we use this funny enum:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>Resolver</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">enum</span> <span class="t">FunctionType</span> {
     <span class="i">NONE</span>,
@@ -1158,7 +1158,7 @@ add after <em>Resolver</em>()</div>
 <p>It seems kind of dumb now, but we&rsquo;ll add a couple more cases to it later and
 then it will make more sense. When we resolve a function declaration, we pass
 that in.</p>
-<div class="codehilite"><pre class="insert-before">    define(stmt.name);
+<div class="codehilite" translate="no"><pre class="insert-before">    define(stmt.name);
 
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitFunctionStmt</em>()<br>
@@ -1170,7 +1170,7 @@ replace 1 line</div>
 
 <p>Over in <code>resolveFunction()</code>, we take that parameter and store it in the field
 before resolving the body.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Resolver.java</em><br>
 method <em>resolveFunction</em>()<br>
 replace 1 line</div>
 <pre class="insert">  <span class="k">private</span> <span class="t">void</span> <span class="i">resolveFunction</span>(
@@ -1190,7 +1190,7 @@ in.</p>
 we&rsquo;ll piggyback on the JVM. We store the previous value in a local on the Java
 stack. When we&rsquo;re done resolving the function body, we restore the field to that
 value.</p>
-<div class="codehilite"><pre class="insert-before">    endScope();
+<div class="codehilite" translate="no"><pre class="insert-before">    endScope();
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>resolveFunction</em>()</div>
 <pre class="insert">    <span class="i">currentFunction</span> = <span class="i">enclosingFunction</span>;
@@ -1200,7 +1200,7 @@ in <em>resolveFunction</em>()</div>
 
 <p>Now that we can always tell whether or not we&rsquo;re inside a function declaration,
 we check that when resolving a <code>return</code> statement.</p>
-<div class="codehilite"><pre class="insert-before">  public Void visitReturnStmt(Stmt.Return stmt) {
+<div class="codehilite" translate="no"><pre class="insert-before">  public Void visitReturnStmt(Stmt.Return stmt) {
 </pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitReturnStmt</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">currentFunction</span> == <span class="t">FunctionType</span>.<span class="i">NONE</span>) {
@@ -1218,7 +1218,7 @@ encountered. That check runs <em>before</em> the resolver so that we don&rsquo;t
 resolve syntactically invalid code.</p>
 <p>But we also need to skip the interpreter if there are resolution errors, so we
 add <em>another</em> check.</p>
-<div class="codehilite"><pre class="insert-before">    resolver.resolve(statements);
+<div class="codehilite" translate="no"><pre class="insert-before">    resolver.resolve(statements);
 </pre><div class="source-file"><em>lox/Lox.java</em><br>
 in <em>run</em>()</div>
 <pre class="insert">
@@ -1260,7 +1260,7 @@ can be used?</p>
 <li>
 <p>How do other languages you know handle local variables that refer to the
 same name in their initializer, like:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;outer&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;outer&quot;</span>;
 {
   <span class="k">var</span> <span class="i">a</span> = <span class="i">a</span>;
 }

--- a/site/scanning-on-demand.html
+++ b/site/scanning-on-demand.html
@@ -110,7 +110,7 @@ see what they are.</p>
 <p>Now that we&rsquo;re building the front end, we can get clox running like a real
 interpreter. No more hand-authored chunks of bytecode. It&rsquo;s time for a REPL and
 script loading. Tear out most of the code in <code>main()</code> and replace it with:</p>
-<div class="codehilite"><pre class="insert-before">int main(int argc, const char* argv[]) {
+<div class="codehilite" translate="no"><pre class="insert-before">int main(int argc, const char* argv[]) {
   initVM();
 
 </pre><div class="source-file"><em>main.c</em><br>
@@ -139,7 +139,7 @@ path to a script to run.</p>
 argument in <code>argv</code> is always the name of the executable being run.</p>
 </aside>
 <p>We&rsquo;ll need a few system headers, so let&rsquo;s get them all out of the way.</p>
-<div class="codehilite"><div class="source-file"><em>main.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>main.c</em><br>
 add to top of file</div>
 <pre class="insert"><span class="a">#include &lt;stdio.h&gt;</span>
 <span class="a">#include &lt;stdlib.h&gt;</span>
@@ -150,7 +150,7 @@ add to top of file</div>
 <div class="source-file-narrow"><em>main.c</em>, add to top of file</div>
 
 <p>Next, we get the REPL up and REPL-ing.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;vm.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;vm.h&quot;
 </pre><div class="source-file"><em>main.c</em></div>
 <pre class="insert">
 
@@ -175,7 +175,7 @@ have a hardcoded line length limit. This REPL here is a little more, ahem,
 austere, but it&rsquo;s fine for our purposes.</p>
 <p>The real work happens in <code>interpret()</code>. We&rsquo;ll get to that soon, but first let&rsquo;s
 take care of loading scripts.</p>
-<div class="codehilite"><div class="source-file"><em>main.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>main.c</em><br>
 add after <em>repl</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">runFile</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">path</span>) {
   <span class="t">char</span>* <span class="i">source</span> = <span class="i">readFile</span>(<span class="i">path</span>);
@@ -201,7 +201,7 @@ directly so that the compiler validates it for us.</p>
 <p>I like C&rsquo;s simplicity, but we pay a real price for it<span class="em">&mdash;</span>the language requires
 us to be more conscientious.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>main.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>main.c</em><br>
 add after <em>repl</em>()</div>
 <pre><span class="k">static</span> <span class="t">char</span>* <span class="i">readFile</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">path</span>) {
   <span class="a">FILE</span>* <span class="i">file</span> = <span class="i">fopen</span>(<span class="i">path</span>, <span class="s">&quot;rb&quot;</span>);
@@ -245,7 +245,7 @@ eating our vegetables or flossing.</p>
 occurs. If we can&rsquo;t correctly read the user&rsquo;s script, all we can really do is
 tell the user and exit the interpreter gracefully. First of all, we might fail
 to open the file.</p>
-<div class="codehilite"><pre class="insert-before">  FILE* file = fopen(path, &quot;rb&quot;);
+<div class="codehilite" translate="no"><pre class="insert-before">  FILE* file = fopen(path, &quot;rb&quot;);
 </pre><div class="source-file"><em>main.c</em><br>
 in <em>readFile</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">file</span> == <span class="a">NULL</span>) {
@@ -261,7 +261,7 @@ in <em>readFile</em>()</div>
 <p>This can happen if the file doesn&rsquo;t exist or the user doesn&rsquo;t have access to it.
 It&rsquo;s pretty common<span class="em">&mdash;</span>people mistype paths all the time.</p>
 <p>This failure is much rarer:</p>
-<div class="codehilite"><pre class="insert-before">  char* buffer = (char*)malloc(fileSize + 1);
+<div class="codehilite" translate="no"><pre class="insert-before">  char* buffer = (char*)malloc(fileSize + 1);
 </pre><div class="source-file"><em>main.c</em><br>
 in <em>readFile</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">buffer</span> == <span class="a">NULL</span>) {
@@ -277,7 +277,7 @@ in <em>readFile</em>()</div>
 probably got bigger problems to worry about, but we should do our best to at
 least let them know.</p>
 <p>Finally, the read itself may fail.</p>
-<div class="codehilite"><pre class="insert-before">  size_t bytesRead = fread(buffer, sizeof(char), fileSize, file);
+<div class="codehilite" translate="no"><pre class="insert-before">  size_t bytesRead = fread(buffer, sizeof(char), fileSize, file);
 </pre><div class="source-file"><em>main.c</em><br>
 in <em>readFile</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">bytesRead</span> &lt; <span class="i">fileSize</span>) {
@@ -301,7 +301,7 @@ error?</p>
 pipeline to scan, compile, and execute it. It&rsquo;s driven by <code>interpret()</code>. Right
 now, that function runs our old hardcoded test chunk. Let&rsquo;s change it to
 something closer to its final incarnation.</p>
-<div class="codehilite"><pre class="insert-before">void freeVM();
+<div class="codehilite" translate="no"><pre class="insert-before">void freeVM();
 </pre><div class="source-file"><em>vm.h</em><br>
 function <em>interpret</em>()<br>
 replace 1 line</div>
@@ -312,7 +312,7 @@ replace 1 line</div>
 
 <p>Where before we passed in a Chunk, now we pass in the string of source code.
 Here&rsquo;s the new implementation:</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 function <em>interpret</em>()<br>
 replace 4 lines</div>
 <pre class="insert"><span class="t">InterpretResult</span> <span class="i">interpret</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">source</span>) {
@@ -324,7 +324,7 @@ replace 4 lines</div>
 
 <p>We won&rsquo;t build the actual <em>compiler</em> yet in this chapter, but we can start
 laying out its structure. It lives in a new module.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;common.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;common.h&quot;
 </pre><div class="source-file"><em>vm.c</em></div>
 <pre class="insert"><span class="a">#include &quot;compiler.h&quot;</span>
 </pre><pre class="insert-after">#include &quot;debug.h&quot;
@@ -332,7 +332,7 @@ laying out its structure. It lives in a new module.</p>
 <div class="source-file-narrow"><em>vm.c</em></div>
 
 <p>For now, the one function in it is declared like so:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.h</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.h</em><br>
 create new file</div>
 <pre><span class="a">#ifndef clox_compiler_h</span>
 <span class="a">#define clox_compiler_h</span>
@@ -346,7 +346,7 @@ create new file</div>
 <p>That signature will change, but it gets us going.</p>
 <p>The first phase of compilation is scanning<span class="em">&mdash;</span>the thing we&rsquo;re doing in this
 chapter<span class="em">&mdash;</span>so right now all the compiler does is set that up.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 create new file</div>
 <pre><span class="a">#include &lt;stdio.h&gt;</span>
 
@@ -364,7 +364,7 @@ create new file</div>
 <h3><a href="#the-scanner-scans" id="the-scanner-scans"><small>16&#8202;.&#8202;1&#8202;.&#8202;2</small>The scanner scans</a></h3>
 <p>There are still a few more feet of scaffolding to stand up before we can start
 writing useful code. First, a new header:</p>
-<div class="codehilite"><div class="source-file"><em>scanner.h</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.h</em><br>
 create new file</div>
 <pre><span class="a">#ifndef clox_scanner_h</span>
 <span class="a">#define clox_scanner_h</span>
@@ -376,7 +376,7 @@ create new file</div>
 <div class="source-file-narrow"><em>scanner.h</em>, create new file</div>
 
 <p>And its corresponding implementation:</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 create new file</div>
 <pre><span class="a">#include &lt;stdio.h&gt;</span>
 <span class="a">#include &lt;string.h&gt;</span>
@@ -411,7 +411,7 @@ reporting. That&rsquo;s it! We don&rsquo;t even keep a pointer to the beginning 
 source code string. The scanner works its way through the code once and is done
 after that.</p>
 <p>Since we have some state, we should initialize it.</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after variable <em>scanner</em></div>
 <pre><span class="t">void</span> <span class="i">initScanner</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">source</span>) {
   <span class="i">scanner</span>.<span class="i">start</span> = <span class="i">source</span>;
@@ -437,7 +437,7 @@ returns the token by value. It doesn&rsquo;t need to dynamically allocate anythi
 <p>Unfortunately, we don&rsquo;t have a compiler yet that can ask the scanner for tokens,
 so the scanner will just sit there doing nothing. To kick it into action, we&rsquo;ll
 write some temporary code to drive it.</p>
-<div class="codehilite"><pre class="insert-before">  initScanner(source);
+<div class="codehilite" translate="no"><pre class="insert-before">  initScanner(source);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>compile</em>()</div>
 <pre class="insert">  <span class="t">int</span> <span class="i">line</span> = -<span class="n">1</span>;
@@ -468,10 +468,10 @@ into the original source string and doesn&rsquo;t have a terminator at the end.<
 <p>This loops indefinitely. Each turn through the loop, it scans one token and
 prints it. When it reaches a special &ldquo;end of file&rdquo; token or an error, it stops.
 For example, if we run the interpreter on this program:</p>
-<div class="codehilite"><pre><span class="k">print</span> <span class="n">1</span> + <span class="n">2</span>;
+<div class="codehilite" translate="no"><pre><span class="k">print</span> <span class="n">1</span> + <span class="n">2</span>;
 </pre></div>
 <p>It prints out:</p>
-<div class="codehilite"><pre>   1 31 'print'
+<div class="codehilite" translate="no"><pre>   1 31 'print'
    | 21 '1'
    |  7 '+'
    | 21 '2'
@@ -487,7 +487,7 @@ C gives us.</p>
 </aside>
 <p>The goal for the rest of the chapter is to make that blob of code work by
 implementing this key function:</p>
-<div class="codehilite"><pre class="insert-before">void initScanner(const char* source);
+<div class="codehilite" translate="no"><pre class="insert-before">void initScanner(const char* source);
 </pre><div class="source-file"><em>scanner.h</em><br>
 add after <em>initScanner</em>()</div>
 <pre class="insert"><span class="t">Token</span> <span class="i">scanToken</span>();
@@ -499,7 +499,7 @@ add after <em>initScanner</em>()</div>
 
 <p>Each call scans and returns the next token in the source code. A token looks
 like this:</p>
-<div class="codehilite"><pre class="insert-before">#define clox_scanner_h
+<div class="codehilite" translate="no"><pre class="insert-before">#define clox_scanner_h
 </pre><div class="source-file"><em>scanner.h</em></div>
 <pre class="insert">
 
@@ -518,7 +518,7 @@ void initScanner(const char* source);
 <p>It&rsquo;s pretty similar to jlox&rsquo;s Token class. We have an enum identifying what type
 of token it is<span class="em">&mdash;</span>number, identifier, <code>+</code> operator, etc. The enum is virtually
 identical to the one in jlox, so let&rsquo;s just hammer out the whole thing.</p>
-<div class="codehilite"><pre class="insert-before">#ifndef clox_scanner_h
+<div class="codehilite" translate="no"><pre class="insert-before">#ifndef clox_scanner_h
 #define clox_scanner_h
 </pre><div class="source-file"><em>scanner.h</em></div>
 <pre class="insert">
@@ -576,7 +576,7 @@ long enough lifetime. That&rsquo;s why <code>runFile()</code> doesn&rsquo;t free
 <h3><a href="#scanning-tokens" id="scanning-tokens"><small>16&#8202;.&#8202;2&#8202;.&#8202;1</small>Scanning tokens</a></h3>
 <p>We&rsquo;re ready to scan some tokens. We&rsquo;ll work our way up to the complete
 implementation, starting with this:</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>initScanner</em>()</div>
 <pre><span class="t">Token</span> <span class="i">scanToken</span>() {
   <span class="i">scanner</span>.<span class="i">start</span> = <span class="i">scanner</span>.<span class="i">current</span>;
@@ -602,7 +602,7 @@ That must mean we&rsquo;re at a character that the scanner can&rsquo;t recognize
 return an error token for that.</p>
 <p>This function relies on a couple of helpers, most of which are familiar from
 jlox. First up:</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>initScanner</em>()</div>
 <pre><span class="k">static</span> <span class="t">bool</span> <span class="i">isAtEnd</span>() {
   <span class="k">return</span> *<span class="i">scanner</span>.<span class="i">current</span> == <span class="s">&#39;\0&#39;</span>;
@@ -613,7 +613,7 @@ add after <em>initScanner</em>()</div>
 <p>We require the source string to be a good null-terminated C string. If the
 current character is the null byte, then we&rsquo;ve reached the end.</p>
 <p>To create a token, we have this constructor-like function:</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>isAtEnd</em>()</div>
 <pre><span class="k">static</span> <span class="t">Token</span> <span class="i">makeToken</span>(<span class="t">TokenType</span> <span class="i">type</span>) {
   <span class="t">Token</span> <span class="i">token</span>;
@@ -629,7 +629,7 @@ add after <em>isAtEnd</em>()</div>
 <p>It uses the scanner&rsquo;s <code>start</code> and <code>current</code> pointers to capture the token&rsquo;s
 lexeme. It sets a couple of other obvious fields then returns the token. It has
 a sister function for returning error tokens.</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>makeToken</em>()</div>
 <pre><span class="k">static</span> <span class="t">Token</span> <span class="i">errorToken</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">message</span>) {
   <span class="t">Token</span> <span class="i">token</span>;
@@ -657,7 +657,7 @@ error. That&rsquo;s not exactly a fun language to program in, so let&rsquo;s fil
 rules.</p>
 <h2><a href="#a-lexical-grammar-for-lox" id="a-lexical-grammar-for-lox"><small>16&#8202;.&#8202;3</small>A Lexical Grammar for Lox</a></h2>
 <p>The simplest tokens are only a single character. We recognize those like so:</p>
-<div class="codehilite"><pre class="insert-before">  if (isAtEnd()) return makeToken(TOKEN_EOF);
+<div class="codehilite" translate="no"><pre class="insert-before">  if (isAtEnd()) return makeToken(TOKEN_EOF);
 </pre><div class="source-file"><em>scanner.c</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">
@@ -687,7 +687,7 @@ in <em>scanToken</em>()</div>
 switch to see if it matches any of Lox&rsquo;s one-character lexemes. To read the next
 character, we use a new helper which consumes the current character and returns
 it.</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>isAtEnd</em>()</div>
 <pre><span class="k">static</span> <span class="t">char</span> <span class="i">advance</span>() {
   <span class="i">scanner</span>.<span class="i">current</span>++;
@@ -700,7 +700,7 @@ add after <em>isAtEnd</em>()</div>
 these also has a corresponding single-character token. That means that when we
 see a character like <code>!</code>, we don&rsquo;t know if we&rsquo;re in a <code>!</code> token or a <code>!=</code> until
 we look at the next character too. We handle those like so:</p>
-<div class="codehilite"><pre class="insert-before">    case '*': return makeToken(TOKEN_STAR);
+<div class="codehilite" translate="no"><pre class="insert-before">    case '*': return makeToken(TOKEN_STAR);
 </pre><div class="source-file"><em>scanner.c</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="s">&#39;!&#39;</span>:
@@ -724,7 +724,7 @@ and return the corresponding two-character token. Otherwise, we leave the
 current character alone (so it can be part of the <em>next</em> token) and return the
 appropriate one-character token.</p>
 <p>That logic for conditionally consuming the second character lives here:</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>advance</em>()</div>
 <pre><span class="k">static</span> <span class="t">bool</span> <span class="i">match</span>(<span class="t">char</span> <span class="i">expected</span>) {
   <span class="k">if</span> (<span class="i">isAtEnd</span>()) <span class="k">return</span> <span class="k">false</span>;
@@ -748,7 +748,7 @@ that the function still correctly finds the next token <em>after</em> the whites
 when you call it. We&rsquo;d have to wrap the whole body of the function in a loop or
 something.</p>
 <p>Instead, before starting the token, we shunt off to a separate function.</p>
-<div class="codehilite"><pre class="insert-before">Token scanToken() {
+<div class="codehilite" translate="no"><pre class="insert-before">Token scanToken() {
 </pre><div class="source-file"><em>scanner.c</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">  <span class="i">skipWhitespace</span>();
@@ -759,7 +759,7 @@ in <em>scanToken</em>()</div>
 <p>This advances the scanner past any leading whitespace. After this call returns,
 we know the very next character is a meaningful one (or we&rsquo;re at the end of the
 source code).</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>errorToken</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">skipWhitespace</span>() {
   <span class="k">for</span> (;;) {
@@ -781,7 +781,7 @@ add after <em>errorToken</em>()</div>
 <p>It&rsquo;s sort of a separate mini-scanner. It loops, consuming every whitespace
 character it encounters. We need to be careful that it does <em>not</em> consume any
 <em>non</em>-whitespace characters. To support that, we use this:</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>advance</em>()</div>
 <pre><span class="k">static</span> <span class="t">char</span> <span class="i">peek</span>() {
   <span class="k">return</span> *<span class="i">scanner</span>.<span class="i">current</span>;
@@ -791,7 +791,7 @@ add after <em>advance</em>()</div>
 
 <p>This simply returns the current character, but doesn&rsquo;t consume it. The previous
 code handles all the whitespace characters except for newlines.</p>
-<div class="codehilite"><pre class="insert-before">        break;
+<div class="codehilite" translate="no"><pre class="insert-before">        break;
 </pre><div class="source-file"><em>scanner.c</em><br>
 in <em>skipWhitespace</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="s">&#39;\n&#39;</span>:
@@ -808,7 +808,7 @@ in <em>skipWhitespace</em>()</div>
 <p>Comments aren&rsquo;t technically &ldquo;whitespace&rdquo;, if you want to get all precise with
 your terminology, but as far as Lox is concerned, they may as well be, so we
 skip those too.</p>
-<div class="codehilite"><pre class="insert-before">        break;
+<div class="codehilite" translate="no"><pre class="insert-before">        break;
 </pre><div class="source-file"><em>scanner.c</em><br>
 in <em>skipWhitespace</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="s">&#39;/&#39;</span>:
@@ -829,7 +829,7 @@ character of lookahead. However, with <code>!=</code>, we still wanted to consum
 even if the <code>=</code> wasn&rsquo;t found. Comments are different. If we don&rsquo;t find a second
 <code>/</code>, then <code>skipWhitespace()</code> needs to not consume the <em>first</em> slash either.</p>
 <p>To handle that, we add:</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>peek</em>()</div>
 <pre><span class="k">static</span> <span class="t">char</span> <span class="i">peekNext</span>() {
   <span class="k">if</span> (<span class="i">isAtEnd</span>()) <span class="k">return</span> <span class="s">&#39;\0&#39;</span>;
@@ -848,7 +848,7 @@ newline will be the current character on the next turn of the outer loop in
 <p>Number and string tokens are special because they have a runtime value
 associated with them. We&rsquo;ll start with strings because they are easy to
 recognize<span class="em">&mdash;</span>they always begin with a double quote.</p>
-<div class="codehilite"><pre class="insert-before">          match('=') ? TOKEN_GREATER_EQUAL : TOKEN_GREATER);
+<div class="codehilite" translate="no"><pre class="insert-before">          match('=') ? TOKEN_GREATER_EQUAL : TOKEN_GREATER);
 </pre><div class="source-file"><em>scanner.c</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="s">&#39;&quot;&#39;</span>: <span class="k">return</span> <span class="i">string</span>();
@@ -857,7 +857,7 @@ in <em>scanToken</em>()</div>
 <div class="source-file-narrow"><em>scanner.c</em>, in <em>scanToken</em>()</div>
 
 <p>That calls a new function.</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>skipWhitespace</em>()</div>
 <pre><span class="k">static</span> <span class="t">Token</span> <span class="i">string</span>() {
   <span class="k">while</span> (<span class="i">peek</span>() != <span class="s">&#39;&quot;&#39;</span> &amp;&amp; !<span class="i">isAtEnd</span>()) {
@@ -900,7 +900,7 @@ keeps our scanner simpler.</p>
 </aside>
 <p>Next up, numbers. Instead of adding a switch case for each of the ten digits
 that can start a number, we handle them here:</p>
-<div class="codehilite"><pre class="insert-before">  char c = advance();
+<div class="codehilite" translate="no"><pre class="insert-before">  char c = advance();
 </pre><div class="source-file"><em>scanner.c</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">isDigit</span>(<span class="i">c</span>)) <span class="k">return</span> <span class="i">number</span>();
@@ -911,7 +911,7 @@ in <em>scanToken</em>()</div>
 <div class="source-file-narrow"><em>scanner.c</em>, in <em>scanToken</em>()</div>
 
 <p>That uses this obvious utility function:</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>initScanner</em>()</div>
 <pre><span class="k">static</span> <span class="t">bool</span> <span class="i">isDigit</span>(<span class="t">char</span> <span class="i">c</span>) {
   <span class="k">return</span> <span class="i">c</span> &gt;= <span class="s">&#39;0&#39;</span> &amp;&amp; <span class="i">c</span> &lt;= <span class="s">&#39;9&#39;</span>;
@@ -920,7 +920,7 @@ add after <em>initScanner</em>()</div>
 <div class="source-file-narrow"><em>scanner.c</em>, add after <em>initScanner</em>()</div>
 
 <p>We finish scanning the number using this:</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>skipWhitespace</em>()</div>
 <pre><span class="k">static</span> <span class="t">Token</span> <span class="i">number</span>() {
   <span class="k">while</span> (<span class="i">isDigit</span>(<span class="i">peek</span>())) <span class="i">advance</span>();
@@ -947,7 +947,7 @@ different from how we did it in jlox, and touches on some important data
 structures.</p>
 <p>First, though, we have to scan the lexeme. Names start with a letter or
 underscore.</p>
-<div class="codehilite"><pre class="insert-before">  char c = advance();
+<div class="codehilite" translate="no"><pre class="insert-before">  char c = advance();
 </pre><div class="source-file"><em>scanner.c</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">isAlpha</span>(<span class="i">c</span>)) <span class="k">return</span> <span class="i">identifier</span>();
@@ -956,7 +956,7 @@ in <em>scanToken</em>()</div>
 <div class="source-file-narrow"><em>scanner.c</em>, in <em>scanToken</em>()</div>
 
 <p>We recognize those using this:</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>initScanner</em>()</div>
 <pre><span class="k">static</span> <span class="t">bool</span> <span class="i">isAlpha</span>(<span class="t">char</span> <span class="i">c</span>) {
   <span class="k">return</span> (<span class="i">c</span> &gt;= <span class="s">&#39;a&#39;</span> &amp;&amp; <span class="i">c</span> &lt;= <span class="s">&#39;z&#39;</span>) ||
@@ -967,7 +967,7 @@ add after <em>initScanner</em>()</div>
 <div class="source-file-narrow"><em>scanner.c</em>, add after <em>initScanner</em>()</div>
 
 <p>Once we&rsquo;ve found an identifier, we scan the rest of it here:</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>skipWhitespace</em>()</div>
 <pre><span class="k">static</span> <span class="t">Token</span> <span class="i">identifier</span>() {
   <span class="k">while</span> (<span class="i">isAlpha</span>(<span class="i">peek</span>()) || <span class="i">isDigit</span>(<span class="i">peek</span>())) <span class="i">advance</span>();
@@ -979,7 +979,7 @@ add after <em>skipWhitespace</em>()</div>
 <p>After the first letter, we allow digits too, and we keep consuming alphanumerics
 until we run out of them. Then we produce a token with the proper type.
 Determining that &ldquo;proper&rdquo; type is the unique part of this chapter.</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>skipWhitespace</em>()</div>
 <pre><span class="k">static</span> <span class="t">TokenType</span> <span class="i">identifierType</span>() {
   <span class="k">return</span> <span class="a">TOKEN_IDENTIFIER</span>;
@@ -1094,7 +1094,7 @@ node and handle the easy keywords.</p>
 and that&rsquo;s currently one of the world&rsquo;s most sophisticated, fastest language
 implementations.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">static TokenType identifierType() {
+<div class="codehilite" translate="no"><pre class="insert-before">static TokenType identifierType() {
 </pre><div class="source-file"><em>scanner.c</em><br>
 in <em>identifierType</em>()</div>
 <pre class="insert">  <span class="k">switch</span> (<span class="i">scanner</span>.<span class="i">start</span>[<span class="n">0</span>]) {
@@ -1121,7 +1121,7 @@ be, though, so we still need to check the rest of the letters too. In the tree
 diagram, this is basically that straight path hanging off the &ldquo;s&rdquo;.</p>
 <p>We won&rsquo;t roll a switch for each of those nodes. Instead, we have a utility
 function that tests the rest of a potential keyword&rsquo;s lexeme.</p>
-<div class="codehilite"><div class="source-file"><em>scanner.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>scanner.c</em><br>
 add after <em>skipWhitespace</em>()</div>
 <pre><span class="k">static</span> <span class="t">TokenType</span> <span class="i">checkKeyword</span>(<span class="t">int</span> <span class="i">start</span>, <span class="t">int</span> <span class="i">length</span>,
     <span class="k">const</span> <span class="t">char</span>* <span class="i">rest</span>, <span class="t">TokenType</span> <span class="i">type</span>) {
@@ -1146,7 +1146,7 @@ normal identifier.</p>
 <p>We have a couple of keywords where the tree branches again after the first
 letter. If the lexeme starts with &ldquo;f&rdquo;, it could be <code>false</code>, <code>for</code>, or <code>fun</code>. So
 we add another switch for the branches coming off the &ldquo;f&rdquo; node.</p>
-<div class="codehilite"><pre class="insert-before">    case 'e': return checkKeyword(1, 3, &quot;lse&quot;, TOKEN_ELSE);
+<div class="codehilite" translate="no"><pre class="insert-before">    case 'e': return checkKeyword(1, 3, &quot;lse&quot;, TOKEN_ELSE);
 </pre><div class="source-file"><em>scanner.c</em><br>
 in <em>identifierType</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="s">&#39;f&#39;</span>:
@@ -1165,7 +1165,7 @@ in <em>identifierType</em>()</div>
 <p>Before we switch, we need to check that there even <em>is</em> a second letter. &ldquo;f&rdquo; by
 itself is a valid identifier too, after all. The other letter that branches is
 &ldquo;t&rdquo;.</p>
-<div class="codehilite"><pre class="insert-before">    case 's': return checkKeyword(1, 4, &quot;uper&quot;, TOKEN_SUPER);
+<div class="codehilite" translate="no"><pre class="insert-before">    case 's': return checkKeyword(1, 4, &quot;uper&quot;, TOKEN_SUPER);
 </pre><div class="source-file"><em>scanner.c</em><br>
 in <em>identifierType</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="s">&#39;t&#39;</span>:
@@ -1202,19 +1202,19 @@ expression can appear. When the string literal is executed, the inner
 expression is evaluated, converted to a string, and then merged with the
 surrounding string literal.</p>
 <p>For example, if Lox supported string interpolation, then this<span class="ellipse">&thinsp;.&thinsp;.&thinsp;.&nbsp;</span></p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">drink</span> = <span class="s">&quot;Tea&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">drink</span> = <span class="s">&quot;Tea&quot;</span>;
 <span class="k">var</span> <span class="i">steep</span> = <span class="n">4</span>;
 <span class="k">var</span> <span class="i">cool</span> = <span class="n">2</span>;
 <span class="k">print</span> <span class="s">&quot;${drink} will be ready in ${steep + cool} minutes.&quot;</span>;
 </pre></div>
 <p><span class="ellipse">&thinsp;.&thinsp;.&thinsp;.&nbsp;</span>would print:</p>
-<div class="codehilite"><pre>Tea will be ready in 6 minutes.
+<div class="codehilite" translate="no"><pre>Tea will be ready in 6 minutes.
 </pre></div>
 <p>What token types would you define to implement a scanner for string
 interpolation? What sequence of tokens would you emit for the above string
 literal?</p>
 <p>What tokens would you emit for:</p>
-<div class="codehilite"><pre>&quot;Nested ${&quot;interpolation?! Are you ${&quot;mad?!&quot;}&quot;}&quot;
+<div class="codehilite" translate="no"><pre>&quot;Nested ${&quot;interpolation?! Are you ${&quot;mad?!&quot;}&quot;}&quot;
 </pre></div>
 <p>Consider looking at other language implementations that support
 interpolation to see how they handle it.</p>
@@ -1222,7 +1222,7 @@ interpolation to see how they handle it.</p>
 <li>
 <p>Several languages use angle brackets for generics and also have a <code>&gt;&gt;</code> right
 shift operator. This led to a classic problem in early versions of C++:</p>
-<div class="codehilite"><pre><span class="t">vector</span>&lt;<span class="t">vector</span>&lt;<span class="t">string</span>&gt;&gt; <span class="i">nestedVectors</span>;
+<div class="codehilite" translate="no"><pre><span class="t">vector</span>&lt;<span class="t">vector</span>&lt;<span class="t">string</span>&gt;&gt; <span class="i">nestedVectors</span>;
 </pre></div>
 <p>This would produce a compile error because the <code>&gt;&gt;</code> was lexed to a single
 right shift token, not two <code>&gt;</code> tokens. Users were forced to avoid this by

--- a/site/scanning.html
+++ b/site/scanning.html
@@ -127,7 +127,7 @@ in the next chapter.</p>
 <p>Since this is our first real chapter, before we get to actually scanning some
 code we need to sketch out the basic shape of our interpreter, jlox. Everything
 starts with a class in Java.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Lox.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -164,7 +164,7 @@ I&rsquo;ll be right here when you&rsquo;re ready. Good? OK!</p>
 <p>Lox is a scripting language, which means it executes directly from source. Our
 interpreter supports two ways of running code. If you start jlox from the
 command line and give it a path to a file, it reads the file and executes it.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Lox.java</em><br>
 add after <em>main</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">runFile</span>(<span class="t">String</span> <span class="i">path</span>) <span class="k">throws</span> <span class="t">IOException</span> {
     <span class="t">byte</span>[] <span class="i">bytes</span> = <span class="t">Files</span>.<span class="i">readAllBytes</span>(<span class="t">Paths</span>.<span class="i">get</span>(<span class="i">path</span>));
@@ -180,12 +180,12 @@ prompt where you can enter and execute code one line at a time.</p>
 <p>An interactive prompt is also called a &ldquo;REPL&rdquo; (pronounced like &ldquo;rebel&rdquo; but with
 a &ldquo;p&rdquo;). The name comes from Lisp where implementing one is as simple as
 wrapping a loop around a few built-in functions:</p>
-<div class="codehilite"><pre>(<span class="i">print</span> (<span class="i">eval</span> (<span class="i">read</span>)))
+<div class="codehilite" translate="no"><pre>(<span class="i">print</span> (<span class="i">eval</span> (<span class="i">read</span>)))
 </pre></div>
 <p>Working outwards from the most nested call, you <strong>R</strong>ead a line of input,
 <strong>E</strong>valuate it, <strong>P</strong>rint the result, then <strong>L</strong>oop and do it all over again.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Lox.java</em><br>
 add after <em>runFile</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">runPrompt</span>() <span class="k">throws</span> <span class="t">IOException</span> {
     <span class="t">InputStreamReader</span> <span class="i">input</span> = <span class="k">new</span> <span class="t">InputStreamReader</span>(<span class="t">System</span>.<span class="i">in</span>);
@@ -207,7 +207,7 @@ interactive command-line app, you usually type Control-D. Doing so signals an
 &ldquo;end-of-file&rdquo; condition to the program. When that happens <code>readLine()</code> returns
 <code>null</code>, so we check for that to exit the loop.</p>
 <p>Both the prompt and the file runner are thin wrappers around this core function:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Lox.java</em><br>
 add after <em>runPrompt</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">run</span>(<span class="t">String</span> <span class="i">source</span>) {
     <span class="t">Scanner</span> <span class="i">scanner</span> = <span class="k">new</span> <span class="t">Scanner</span>(<span class="i">source</span>);
@@ -242,7 +242,7 @@ handling all through the implementation of our interpreter, starting now.</p>
 bones. I&rsquo;d love to talk about interactive debuggers, static analyzers, and other
 fun stuff, but there&rsquo;s only so much ink in the pen.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Lox.java</em><br>
 add after <em>run</em>()</div>
 <pre>  <span class="k">static</span> <span class="t">void</span> <span class="i">error</span>(<span class="t">int</span> <span class="i">line</span>, <span class="t">String</span> <span class="i">message</span>) {
     <span class="i">report</span>(<span class="i">line</span>, <span class="s">&quot;&quot;</span>, <span class="i">message</span>);
@@ -261,12 +261,12 @@ add after <em>run</em>()</div>
 error occurred on a given line. That is really the bare minimum to be able to
 claim you even <em>have</em> error reporting. Imagine if you accidentally left a
 dangling comma in some function call and the interpreter printed out:</p>
-<div class="codehilite"><pre>Error: Unexpected &quot;,&quot; somewhere in your code. Good luck finding it!
+<div class="codehilite" translate="no"><pre>Error: Unexpected &quot;,&quot; somewhere in your code. Good luck finding it!
 </pre></div>
 <p>That&rsquo;s not very helpful. We need to at least point them to the right line. Even
 better would be the beginning and end column so they know <em>where</em> in the line.
 Even better than <em>that</em> is to <em>show</em> the user the offending line, like:</p>
-<div class="codehilite"><pre>Error: Unexpected &quot;,&quot; in argument list.
+<div class="codehilite" translate="no"><pre>Error: Unexpected &quot;,&quot; in argument list.
 
     15 | function(first, second,);
                                ^-- Here.
@@ -278,7 +278,7 @@ stick with just a line number. In your own interpreters, please do as I say and
 not as I do.</p>
 <p>The primary reason we&rsquo;re sticking this error reporting function in the main Lox
 class is because of that <code>hadError</code> field. It&rsquo;s defined here:</p>
-<div class="codehilite"><pre class="insert-before">public class Lox {
+<div class="codehilite" translate="no"><pre class="insert-before">public class Lox {
 </pre><div class="source-file"><em>lox/Lox.java</em><br>
 in class <em>Lox</em></div>
 <pre class="insert">  <span class="k">static</span> <span class="t">boolean</span> <span class="i">hadError</span> = <span class="k">false</span>;
@@ -288,7 +288,7 @@ in class <em>Lox</em></div>
 <p>We&rsquo;ll use this to ensure we don&rsquo;t try to execute code that has a known error.
 Also, it lets us exit with a non-zero exit code like a good command line citizen
 should.</p>
-<div class="codehilite"><pre class="insert-before">    run(new String(bytes, Charset.defaultCharset()));
+<div class="codehilite" translate="no"><pre class="insert-before">    run(new String(bytes, Charset.defaultCharset()));
 </pre><div class="source-file"><em>lox/Lox.java</em><br>
 in <em>runFile</em>()</div>
 <pre class="insert">
@@ -301,7 +301,7 @@ in <em>runFile</em>()</div>
 
 <p>We need to reset this flag in the interactive loop. If the user makes a mistake,
 it shouldn&rsquo;t kill their entire session.</p>
-<div class="codehilite"><pre class="insert-before">      run(line);
+<div class="codehilite" translate="no"><pre class="insert-before">      run(line);
 </pre><div class="source-file"><em>lox/Lox.java</em><br>
 in <em>runPrompt</em>()</div>
 <pre class="insert">      <span class="i">hadError</span> = <span class="k">false</span>;
@@ -332,7 +332,7 @@ Once we have a Scanner class with a <code>scanTokens()</code> method, we can sta
 it. Before we get to that, let&rsquo;s get more precise about what tokens are.</p>
 <h2><a href="#lexemes-and-tokens" id="lexemes-and-tokens"><small>4&#8202;.&#8202;2</small>Lexemes and Tokens</a></h2>
 <p>Here&rsquo;s a line of Lox code:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">language</span> = <span class="s">&quot;lox&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">language</span> = <span class="s">&quot;lox&quot;</span>;
 </pre></div>
 <p>Here, <code>var</code> is the keyword for declaring a variable. That three-character
 sequence &ldquo;v-a-r&rdquo; means something. But if we yank three letters out of the
@@ -359,7 +359,7 @@ punctuation, and literal type.</p>
 <p>After all, string comparison ends up looking at individual characters, and isn&rsquo;t
 that the scanner&rsquo;s job?</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/TokenType.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/TokenType.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -409,7 +409,7 @@ those, the less time you spend calculating position information ahead of time,
 the better.</p>
 </aside>
 <p>We take all of this data and wrap it in a class.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Token.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Token.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -453,7 +453,7 @@ which kind of lexeme it &ldquo;matches&rdquo; may sound familiar. If you know re
 expressions, you might consider defining a regex for each kind of lexeme and
 using those to match characters. For example, Lox has the same rules as C for
 identifiers (variable names and the like). This regex matches one:</p>
-<div class="codehilite"><pre>[a-zA-Z_][a-zA-Z_0-9]*
+<div class="codehilite" translate="no"><pre>[a-zA-Z_][a-zA-Z_0-9]*
 </pre></div>
 <p>If you did think of regular expressions, your intuition is a deep one. The rules
 that determine how a particular language groups characters into lexemes are
@@ -483,7 +483,7 @@ mega billionaire among us.</p>
 delegating that task. We&rsquo;re about handcrafted goods.</p>
 <h2><a href="#the-scanner-class" id="the-scanner-class"><small>4&#8202;.&#8202;4</small>The Scanner Class</a></h2>
 <p>Without further ado, let&rsquo;s make ourselves a scanner.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Scanner.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -513,7 +513,7 @@ every character counts in a book.</p>
 <p>We store the raw source code as a simple string, and we have a list ready to
 fill with tokens we&rsquo;re going to generate. The aforementioned loop that does that
 looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>Scanner</em>()</div>
 <pre>  <span class="t">List</span>&lt;<span class="t">Token</span>&gt; <span class="i">scanTokens</span>() {
     <span class="k">while</span> (!<span class="i">isAtEnd</span>()) {
@@ -533,7 +533,7 @@ out of characters. Then it appends one final &ldquo;end of file&rdquo; token. Th
 strictly needed, but it makes our parser a little cleaner.</p>
 <p>This loop depends on a couple of fields to keep track of where the scanner is in
 the source code.</p>
-<div class="codehilite"><pre class="insert-before">  private final List&lt;Token&gt; tokens = new ArrayList&lt;&gt;();
+<div class="codehilite" translate="no"><pre class="insert-before">  private final List&lt;Token&gt; tokens = new ArrayList&lt;&gt;();
 </pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in class <em>Scanner</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="t">int</span> <span class="i">start</span> = <span class="n">0</span>;
@@ -552,7 +552,7 @@ tracks what source line <code>current</code> is on so we can produce tokens that
 location.</p>
 <p>Then we have one little helper function that tells us if we&rsquo;ve consumed all the
 characters.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>scanTokens</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isAtEnd</span>() {
     <span class="k">return</span> <span class="i">current</span> &gt;= <span class="i">source</span>.<span class="i">length</span>();
@@ -566,7 +566,7 @@ scanner. We&rsquo;ll start simple. Imagine if every lexeme were only a single ch
 long. All you would need to do is consume the next character and pick a token type for
 it. Several lexemes <em>are</em> only a single character in Lox, so let&rsquo;s start with
 those.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>scanTokens</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">scanToken</span>() {
     <span class="t">char</span> <span class="i">c</span> = <span class="i">advance</span>();
@@ -590,7 +590,7 @@ add after <em>scanTokens</em>()</div>
 <p>Wondering why <code>/</code> isn&rsquo;t in here? Don&rsquo;t worry, we&rsquo;ll get to it.</p>
 </aside>
 <p>Again, we need a couple of helper methods.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>isAtEnd</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">char</span> <span class="i">advance</span>() {
     <span class="k">return</span> <span class="i">source</span>.<span class="i">charAt</span>(<span class="i">current</span>++);
@@ -618,7 +618,7 @@ characters Lox doesn&rsquo;t use, like <code>@#^</code>, at our interpreter? Rig
 characters get silently discarded. They aren&rsquo;t used by the Lox language, but
 that doesn&rsquo;t mean the interpreter can pretend they aren&rsquo;t there. Instead, we
 report an error.</p>
-<div class="codehilite"><pre class="insert-before">      case '*': addToken(STAR); break;<span name="slash"> </span>
+<div class="codehilite" translate="no"><pre class="insert-before">      case '*': addToken(STAR); break;<span name="slash"> </span>
 </pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">
@@ -655,7 +655,7 @@ That&rsquo;s why we need to scan <code>!=</code> as a single lexeme. Likewise, <
 can all be followed by <code>=</code> to create the other equality and comparison
 operators.</p>
 <p>For all of these, we need to look at the second character.</p>
-<div class="codehilite"><pre class="insert-before">      case '*': addToken(STAR); break;<span name="slash"> </span>
+<div class="codehilite" translate="no"><pre class="insert-before">      case '*': addToken(STAR); break;<span name="slash"> </span>
 </pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="s">&#39;!&#39;</span>:
@@ -677,7 +677,7 @@ in <em>scanToken</em>()</div>
 <div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>()</div>
 
 <p>Those cases use this new method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>scanToken</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">match</span>(<span class="t">char</span> <span class="i">expected</span>) {
     <span class="k">if</span> (<span class="i">isAtEnd</span>()) <span class="k">return</span> <span class="k">false</span>;
@@ -698,7 +698,7 @@ merely a <code>!</code>.</p>
 <h2><a href="#longer-lexemes" id="longer-lexemes"><small>4&#8202;.&#8202;6</small>Longer Lexemes</a></h2>
 <p>We&rsquo;re still missing one operator: <code>/</code> for division. That character needs a
 little special handling because comments begin with a slash too.</p>
-<div class="codehilite"><pre class="insert-before">        break;
+<div class="codehilite" translate="no"><pre class="insert-before">        break;
 </pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="s">&#39;/&#39;</span>:
@@ -722,7 +722,7 @@ until we reach the end of the line.</p>
 beginning of one, we shunt over to some lexeme-specific code that keeps eating
 characters until it sees the end.</p>
 <p>We&rsquo;ve got another helper:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>match</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">char</span> <span class="i">peek</span>() {
     <span class="k">if</span> (<span class="i">isAtEnd</span>()) <span class="k">return</span> <span class="s">&#39;\0&#39;</span>;
@@ -747,7 +747,7 @@ to deal with them. So when we reach the end of the comment, we <em>don&rsquo;t</
 reset and the comment&rsquo;s lexeme disappears in a puff of smoke.</p>
 <p>While we&rsquo;re at it, now&rsquo;s a good time to skip over those other meaningless
 characters: newlines and whitespace.</p>
-<div class="codehilite"><pre class="insert-before">        break;
+<div class="codehilite" translate="no"><pre class="insert-before">        break;
 </pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">
@@ -774,14 +774,14 @@ we do the same thing, but we also increment the line counter. (This is why we
 used <code>peek()</code> to find the newline ending a comment instead of <code>match()</code>. We want
 that newline to get us here so we can update <code>line</code>.)</p>
 <p>Our scanner is getting smarter. It can handle fairly free-form code like:</p>
-<div class="codehilite"><pre><span class="c">// this is a comment</span>
+<div class="codehilite" translate="no"><pre><span class="c">// this is a comment</span>
 (( )){} <span class="c">// grouping stuff</span>
 !*+-/=&lt;&gt; &lt;= == <span class="c">// operators</span>
 </pre></div>
 <h3><a href="#string-literals" id="string-literals"><small>4&#8202;.&#8202;6&#8202;.&#8202;1</small>String literals</a></h3>
 <p>Now that we&rsquo;re comfortable with longer lexemes, we&rsquo;re ready to tackle literals.
 We&rsquo;ll do strings first, since they always begin with a specific character, <code>"</code>.</p>
-<div class="codehilite"><pre class="insert-before">        break;
+<div class="codehilite" translate="no"><pre class="insert-before">        break;
 </pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">
@@ -794,7 +794,7 @@ in <em>scanToken</em>()</div>
 <div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>()</div>
 
 <p>That calls:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>scanToken</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">string</span>() {
     <span class="k">while</span> (<span class="i">peek</span>() != <span class="s">&#39;&quot;&#39;</span> &amp;&amp; !<span class="i">isAtEnd</span>()) {
@@ -838,21 +838,21 @@ digits.</p>
 number <em>literal</em>. Instead, <code>-123</code>, is an <em>expression</em> that applies <code>-</code> to the
 number literal <code>123</code>. In practice, the result is the same, though it has one
 interesting edge case if we were to add method calls on numbers. Consider:</p>
-<div class="codehilite"><pre><span class="k">print</span> -<span class="n">123</span>.<span class="i">abs</span>();
+<div class="codehilite" translate="no"><pre><span class="k">print</span> -<span class="n">123</span>.<span class="i">abs</span>();
 </pre></div>
 <p>This prints <code>-123</code> because negation has lower precedence than method calls. We
 could fix that by making <code>-</code> part of the number literal. But then consider:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">n</span> = <span class="n">123</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">n</span> = <span class="n">123</span>;
 <span class="k">print</span> -<span class="i">n</span>.<span class="i">abs</span>();
 </pre></div>
 <p>This still produces <code>-123</code>, so now the language seems inconsistent. No matter
 what you do, some case ends up weird.</p>
 </aside>
-<div class="codehilite"><pre><span class="n">1234</span>
+<div class="codehilite" translate="no"><pre><span class="n">1234</span>
 <span class="n">12.34</span>
 </pre></div>
 <p>We don&rsquo;t allow a leading or trailing decimal point, so these are both invalid:</p>
-<div class="codehilite"><pre>.<span class="n">1234</span>
+<div class="codehilite" translate="no"><pre>.<span class="n">1234</span>
 <span class="n">1234</span>.
 </pre></div>
 <p>We could easily support the former, but I left it out to keep things simple. The
@@ -860,7 +860,7 @@ latter gets weird if we ever want to allow methods on numbers like <code>123.sqr
 <p>To recognize the beginning of a number lexeme, we look for any digit. It&rsquo;s kind
 of tedious to add cases for every decimal digit, so we&rsquo;ll stuff it in the
 default case instead.</p>
-<div class="codehilite"><pre class="insert-before">      default:
+<div class="codehilite" translate="no"><pre class="insert-before">      default:
 </pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()<br>
 replace 1 line</div>
@@ -874,7 +874,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>(), replace 1 line</div>
 
 <p>This relies on this little utility:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>peek</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isDigit</span>(<span class="t">char</span> <span class="i">c</span>) {
     <span class="k">return</span> <span class="i">c</span> &gt;= <span class="s">&#39;0&#39;</span> &amp;&amp; <span class="i">c</span> &lt;= <span class="s">&#39;9&#39;</span>;
@@ -889,7 +889,7 @@ full-width numbers, and other funny stuff we don&rsquo;t want.</p>
 </aside>
 <p>Once we know we are in a number, we branch to a separate method to consume the
 rest of the literal, like we do with strings.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>scanToken</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">number</span>() {
     <span class="k">while</span> (<span class="i">isDigit</span>(<span class="i">peek</span>())) <span class="i">advance</span>();
@@ -915,7 +915,7 @@ digits as we can find.</p>
 <p>Looking past the decimal point requires a second character of lookahead since we
 don&rsquo;t want to consume the <code>.</code> until we&rsquo;re sure there is a digit <em>after</em> it. So
 we add:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>peek</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">char</span> <span class="i">peekNext</span>() {
     <span class="k">if</span> (<span class="i">current</span> + <span class="n">1</span> &gt;= <span class="i">source</span>.<span class="i">length</span>()) <span class="k">return</span> <span class="s">&#39;\0&#39;</span>;
@@ -942,7 +942,7 @@ which gets us to<span class="ellipse">&thinsp;.&thinsp;.&thinsp;.&nbsp;</span></
 implement are identifiers and their close cousins, the reserved words. You might
 think we could match keywords like <code>or</code> in the same way we handle
 multiple-character operators like <code>&lt;=</code>.</p>
-<div class="codehilite"><pre><span class="k">case</span> <span class="s">&#39;o&#39;</span>:
+<div class="codehilite" translate="no"><pre><span class="k">case</span> <span class="s">&#39;o&#39;</span>:
   <span class="k">if</span> (<span class="i">match</span>(<span class="s">&#39;r&#39;</span>)) {
     <span class="i">addToken</span>(<span class="i">OR</span>);
   }
@@ -959,16 +959,16 @@ keyword, then the former wins. This is also why we tacitly assumed, previously,
 that <code>&lt;=</code> should be scanned as a single <code>&lt;=</code> token and not <code>&lt;</code> followed by <code>=</code>.</p>
 <aside name="maximal">
 <p>Consider this nasty bit of C code:</p>
-<div class="codehilite"><pre>---<span class="i">a</span>;
+<div class="codehilite" translate="no"><pre>---<span class="i">a</span>;
 </pre></div>
 <p>Is it valid? That depends on how the scanner splits the lexemes. What if the scanner
 sees it like this:</p>
-<div class="codehilite"><pre>- --<span class="i">a</span>;
+<div class="codehilite" translate="no"><pre>- --<span class="i">a</span>;
 </pre></div>
 <p>Then it could be parsed. But that would require the scanner to know about the
 grammatical structure of the surrounding code, which entangles things more than
 we want. Instead, the maximal munch rule says that it is <em>always</em> scanned like:</p>
-<div class="codehilite"><pre>-- -<span class="i">a</span>;
+<div class="codehilite" translate="no"><pre>-- -<span class="i">a</span>;
 </pre></div>
 <p>It scans it that way even though doing so leads to a syntax error later in the
 parser.</p>
@@ -979,7 +979,7 @@ an identifier, it&rsquo;s just one that has been claimed by the language for its
 use. That&rsquo;s where the term <strong>reserved word</strong> comes from.</p>
 <p>So we begin by assuming any lexeme starting with a letter or underscore is an
 identifier.</p>
-<div class="codehilite"><pre class="insert-before">      default:
+<div class="codehilite" translate="no"><pre class="insert-before">      default:
         if (isDigit(c)) {
           number();
 </pre><div class="source-file"><em>lox/Scanner.java</em><br>
@@ -993,7 +993,7 @@ in <em>scanToken</em>()</div>
 <div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>()</div>
 
 <p>The rest of the code lives over here:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>scanToken</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">identifier</span>() {
     <span class="k">while</span> (<span class="i">isAlphaNumeric</span>(<span class="i">peek</span>())) <span class="i">advance</span>();
@@ -1004,7 +1004,7 @@ add after <em>scanToken</em>()</div>
 <div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>scanToken</em>()</div>
 
 <p>We define that in terms of these helpers:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>peekNext</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isAlpha</span>(<span class="t">char</span> <span class="i">c</span>) {
     <span class="k">return</span> (<span class="i">c</span> &gt;= <span class="s">&#39;a&#39;</span> &amp;&amp; <span class="i">c</span> &lt;= <span class="s">&#39;z&#39;</span>) ||
@@ -1021,7 +1021,7 @@ add after <em>peekNext</em>()</div>
 <p>That gets identifiers working. To handle keywords, we see if the identifier&rsquo;s
 lexeme is one of the reserved words. If so, we use a token type specific to that
 keyword. We define the set of reserved words in a map.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Scanner.java</em><br>
 in class <em>Scanner</em></div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="k">final</span> <span class="t">Map</span>&lt;<span class="t">String</span>, <span class="t">TokenType</span>&gt; <span class="i">keywords</span>;
 
@@ -1049,7 +1049,7 @@ in class <em>Scanner</em></div>
 
 <p>Then, after we scan an identifier, we check to see if it matches anything in the
 map.</p>
-<div class="codehilite"><pre class="insert-before">    while (isAlphaNumeric(peek())) advance();
+<div class="codehilite" translate="no"><pre class="insert-before">    while (isAlphaNumeric(peek())) advance();
 
 </pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>identifier</em>()<br>
@@ -1109,7 +1109,7 @@ detect, but there are a handful of nasty ones:</p>
 <ul>
 <li>
 <p>A return value on the next line:</p>
-<div class="codehilite"><pre><span class="k">if</span> (<span class="i">condition</span>) <span class="k">return</span>
+<div class="codehilite" translate="no"><pre><span class="k">if</span> (<span class="i">condition</span>) <span class="k">return</span>
 <span class="s">&quot;value&quot;</span>
 </pre></div>
 <p>Is &ldquo;value&rdquo; the value being returned, or do we have a <code>return</code> statement with
@@ -1117,7 +1117,7 @@ detect, but there are a handful of nasty ones:</p>
 </li>
 <li>
 <p>A parenthesized expression on the next line:</p>
-<div class="codehilite"><pre><span class="i">func</span>
+<div class="codehilite" translate="no"><pre><span class="i">func</span>
 (<span class="i">parenthesized</span>)
 </pre></div>
 <p>Is this a call to <code>func(parenthesized)</code>, or two expression statements, one
@@ -1125,7 +1125,7 @@ detect, but there are a handful of nasty ones:</p>
 </li>
 <li>
 <p>A <code>-</code> on the next line:</p>
-<div class="codehilite"><pre><span class="i">first</span>
+<div class="codehilite" translate="no"><pre><span class="i">first</span>
 -<span class="i">second</span>
 </pre></div>
 <p>Is this <code>first - second</code><span class="em">&mdash;</span>an infix subtraction<span class="em">&mdash;</span>or two expression
@@ -1141,7 +1141,7 @@ separators. Here are a couple:</p>
 <p><a href="https://www.lua.org/pil/1.1.html">Lua</a> completely ignores newlines, but carefully controls its grammar such
 that no separator between statements is needed at all in most cases. This is
 perfectly legit:</p>
-<div class="codehilite"><pre><span class="i">a</span> = <span class="n">1</span> <span class="i">b</span> = <span class="n">2</span>
+<div class="codehilite" translate="no"><pre><span class="i">a</span> = <span class="n">1</span> <span class="i">b</span> = <span class="n">2</span>
 </pre></div>
 <p>Lua avoids the <code>return</code> problem by requiring a <code>return</code> statement to be the
 very last statement in a block. If there is a value after <code>return</code> before
@@ -1168,7 +1168,7 @@ language. In particular, Python&rsquo;s grammar ensures a statement never appear
 inside an expression. C does the same, but many other languages which have a
 &ldquo;lambda&rdquo; or function literal syntax do not.</p>
 <p>An example in JavaScript:</p>
-<div class="codehilite"><pre><span class="i">console</span>.<span class="i">log</span>(<span class="k">function</span>() {
+<div class="codehilite" translate="no"><pre><span class="i">console</span>.<span class="i">log</span>(<span class="k">function</span>() {
   <span class="i">statement</span>();
 });
 </pre></div>

--- a/site/statements-and-state.html
+++ b/site/statements-and-state.html
@@ -161,7 +161,7 @@ Python did remove their <code>print</code> statement in 3.0<span class="ellipse"
 to parse an entire Lox script. Since Lox is an imperative, dynamically typed
 language, the &ldquo;top level&rdquo; of a script is simply a list of statements. The new
 rules are:</p>
-<div class="codehilite"><pre><span class="i">program</span>        → <span class="i">statement</span>* <span class="t">EOF</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">program</span>        → <span class="i">statement</span>* <span class="t">EOF</span> ;
 
 <span class="i">statement</span>      → <span class="i">exprStmt</span>
                | <span class="i">printStmt</span> ;
@@ -194,7 +194,7 @@ another call to define Stmt and its <span name="stmt-ast">subclasses</span>.</p>
 <p>Not really foresight: I wrote all the code for the book before I sliced it into
 chapters.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">      &quot;Unary    : Token operator, Expr right&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">      &quot;Unary    : Token operator, Expr right&quot;
     ));
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
@@ -218,7 +218,7 @@ to add the file to your IDE project or makefile or whatever.</p>
 <p>The parser&rsquo;s <code>parse()</code> method that parses and returns a single expression was a
 temporary hack to get the last chapter up and running. Now that our grammar has
 the correct starting rule, <code>program</code>, we can turn <code>parse()</code> into the real deal.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 method <em>parse</em>()<br>
 replace 7 lines</div>
 <pre>  <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">parse</span>() {
@@ -241,7 +241,7 @@ statement types.</p>
 of the input. This is a pretty direct translation of the <code>program</code> rule into
 recursive descent style. We must also chant a minor prayer to the Java verbosity
 gods since we are using ArrayList now.</p>
-<div class="codehilite"><pre class="insert-before">package com.craftinginterpreters.lox;
+<div class="codehilite" translate="no"><pre class="insert-before">package com.craftinginterpreters.lox;
 
 </pre><div class="source-file"><em>lox/Parser.java</em></div>
 <pre class="insert"><span class="k">import</span> <span class="i">java.util.ArrayList</span>;
@@ -251,7 +251,7 @@ gods since we are using ArrayList now.</p>
 
 <p>A program is a list of statements, and we parse one of those statements using
 this method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>expression</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">statement</span>() {
     <span class="k">if</span> (<span class="i">match</span>(<span class="i">PRINT</span>)) <span class="k">return</span> <span class="i">printStatement</span>();
@@ -269,7 +269,7 @@ must be an expression statement. That&rsquo;s the typical final fallthrough case
 parsing a statement, since it&rsquo;s hard to proactively recognize an expression from
 its first token.</p>
 <p>Each statement kind gets its own method. First <code>print</code>:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>statement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">printStatement</span>() {
     <span class="t">Expr</span> <span class="i">value</span> = <span class="i">expression</span>();
@@ -283,7 +283,7 @@ add after <em>statement</em>()</div>
 do that here. We parse the subsequent expression, consume the terminating
 semicolon, and emit the syntax tree.</p>
 <p>If we didn&rsquo;t match a <code>print</code> statement, we must have one of these:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>printStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">expressionStatement</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">expression</span>();
@@ -302,7 +302,7 @@ the next and final step is to interpret them. As in expressions, we use the
 Visitor pattern, but we have a new visitor interface, Stmt.Visitor, to
 implement since statements have their own base class.</p>
 <p>We add that to the list of interfaces Interpreter implements.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 replace 1 line</div>
 <pre class="insert"><span class="k">class</span> <span class="t">Interpreter</span> <span class="k">implements</span> <span class="t">Expr</span>.<span class="t">Visitor</span>&lt;<span class="t">Object</span>&gt;,
                              <span class="t">Stmt</span>.<span class="t">Visitor</span>&lt;<span class="t">Void</span>&gt; {
@@ -319,7 +319,7 @@ separate &ldquo;Void&rdquo; type specifically for this use. Sort of a &ldquo;box
 <p>Unlike expressions, statements produce no values, so the return type of the
 visit methods is Void, not Object. We have two statement types, and we need a
 visit method for each. The easiest is expression statements.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>evaluate</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitExpressionStmt</span>(<span class="t">Stmt</span>.<span class="t">Expression</span> <span class="i">stmt</span>) {
@@ -338,7 +338,7 @@ what can you do?</p>
 that call inside a <em>Java</em> expression statement.</p>
 </aside>
 <p>The <code>print</code> statement&rsquo;s visit method isn&rsquo;t much different.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitExpressionStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitPrintStmt</span>(<span class="t">Stmt</span>.<span class="t">Print</span> <span class="i">stmt</span>) {
@@ -355,7 +355,7 @@ stdout.</p>
 <p>Our interpreter is able to visit statements now, but we have some work to do to
 feed them to it. First, modify the old <code>interpret()</code> method in the Interpreter
 class to accept a list of statements<span class="em">&mdash;</span>in other words, a program.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 method <em>interpret</em>()<br>
 replace 8 lines</div>
 <pre>  <span class="t">void</span> <span class="i">interpret</span>(<span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span>) {
@@ -372,7 +372,7 @@ replace 8 lines</div>
 
 <p>This replaces the old code which took a single expression. The new code relies
 on this tiny helper method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>evaluate</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">execute</span>(<span class="t">Stmt</span> <span class="i">stmt</span>) {
     <span class="i">stmt</span>.<span class="i">accept</span>(<span class="k">this</span>);
@@ -382,7 +382,7 @@ add after <em>evaluate</em>()</div>
 
 <p>That&rsquo;s the statement analogue to the <code>evaluate()</code> method we have for
 expressions. Since we&rsquo;re working with lists now, we need to let Java know.</p>
-<div class="codehilite"><pre class="insert-before">package com.craftinginterpreters.lox;
+<div class="codehilite" translate="no"><pre class="insert-before">package com.craftinginterpreters.lox;
 </pre><div class="source-file"><em>lox/Interpreter.java</em></div>
 <pre class="insert">
 
@@ -395,7 +395,7 @@ class Interpreter implements Expr.Visitor&lt;Object&gt;,
 
 <p>The main Lox class is still trying to parse a single expression and pass it to
 the interpreter. We fix the parsing line like so:</p>
-<div class="codehilite"><pre class="insert-before">    Parser parser = new Parser(tokens);
+<div class="codehilite" translate="no"><pre class="insert-before">    Parser parser = new Parser(tokens);
 </pre><div class="source-file"><em>lox/Lox.java</em><br>
 in <em>run</em>()<br>
 replace 1 line</div>
@@ -407,7 +407,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>run</em>(), replace 1 line</div>
 
 <p>And then replace the call to the interpreter with this:</p>
-<div class="codehilite"><pre class="insert-before">    if (hadError) return;
+<div class="codehilite" translate="no"><pre class="insert-before">    if (hadError) return;
 
 </pre><div class="source-file"><em>lox/Lox.java</em><br>
 in <em>run</em>()<br>
@@ -420,7 +420,7 @@ replace 1 line</div>
 <p>Basically just plumbing the new syntax through. OK, fire up the interpreter and
 give it a try. At this point, it&rsquo;s worth sketching out a little Lox program in a
 text file to run as a script. Something like:</p>
-<div class="codehilite"><pre><span class="k">print</span> <span class="s">&quot;one&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">print</span> <span class="s">&quot;one&quot;</span>;
 <span class="k">print</span> <span class="k">true</span>;
 <span class="k">print</span> <span class="n">2</span> + <span class="n">1</span>;
 </pre></div>
@@ -434,7 +434,7 @@ of variables<span class="em">&mdash;</span><span name="globals">globals</span>. 
 <ol>
 <li>
 <p>A <strong>variable declaration</strong> statement brings a new variable into the world.</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">beverage</span> = <span class="s">&quot;espresso&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">beverage</span> = <span class="s">&quot;espresso&quot;</span>;
 </pre></div>
 <p>This creates a new binding that associates a name (here &ldquo;beverage&rdquo;) with a
 value (here, the string <code>"espresso"</code>).</p>
@@ -443,7 +443,7 @@ value (here, the string <code>"espresso"</code>).</p>
 <p>Once that&rsquo;s done, a <strong>variable expression</strong> accesses that binding. When the
 identifier &ldquo;beverage&rdquo; is used as an expression, it looks up the value bound
 to that name and returns it.</p>
-<div class="codehilite"><pre><span class="k">print</span> <span class="i">beverage</span>; <span class="c">// &quot;espresso&quot;.</span>
+<div class="codehilite" translate="no"><pre><span class="k">print</span> <span class="i">beverage</span>; <span class="c">// &quot;espresso&quot;.</span>
 </pre></div>
 </li>
 </ol>
@@ -467,10 +467,10 @@ are allowed.</p>
 <p>The clauses in control flow statements<span class="em">&mdash;</span>think the then and else branches of
 an <code>if</code> statement or the body of a <code>while</code><span class="em">&mdash;</span>are each a single statement. But
 that statement is not allowed to be one that declares a name. This is OK:</p>
-<div class="codehilite"><pre><span class="k">if</span> (<span class="i">monday</span>) <span class="k">print</span> <span class="s">&quot;Ugh, already?&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">if</span> (<span class="i">monday</span>) <span class="k">print</span> <span class="s">&quot;Ugh, already?&quot;</span>;
 </pre></div>
 <p>But this is not:</p>
-<div class="codehilite"><pre><span class="k">if</span> (<span class="i">monday</span>) <span class="k">var</span> <span class="i">beverage</span> = <span class="s">&quot;espresso&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">if</span> (<span class="i">monday</span>) <span class="k">var</span> <span class="i">beverage</span> = <span class="s">&quot;espresso&quot;</span>;
 </pre></div>
 <p>We <em>could</em> allow the latter, but it&rsquo;s confusing. What is the scope of that
 <code>beverage</code> variable? Does it persist after the <code>if</code> statement? If so, what is
@@ -491,7 +491,7 @@ statement grammar from a place where only some statements are allowed.</p>
 </aside>
 <p>To accommodate the distinction, we add another rule for kinds of statements that
 declare names.</p>
-<div class="codehilite"><pre><span class="i">program</span>        → <span class="i">declaration</span>* <span class="t">EOF</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">program</span>        → <span class="i">declaration</span>* <span class="t">EOF</span> ;
 
 <span class="i">declaration</span>    → <span class="i">varDecl</span>
                | <span class="i">statement</span> ;
@@ -505,14 +505,14 @@ declaration is allowed also allows non-declaring statements, so the
 <code>declaration</code> rule falls through to <code>statement</code>. Obviously, you can declare
 stuff at the top level of a script, so <code>program</code> routes to the new rule.</p>
 <p>The rule for declaring a variable looks like:</p>
-<div class="codehilite"><pre><span class="i">varDecl</span>        → <span class="s">&quot;var&quot;</span> <span class="t">IDENTIFIER</span> ( <span class="s">&quot;=&quot;</span> <span class="i">expression</span> )? <span class="s">&quot;;&quot;</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">varDecl</span>        → <span class="s">&quot;var&quot;</span> <span class="t">IDENTIFIER</span> ( <span class="s">&quot;=&quot;</span> <span class="i">expression</span> )? <span class="s">&quot;;&quot;</span> ;
 </pre></div>
 <p>Like most statements, it starts with a leading keyword. In this case, <code>var</code>.
 Then an identifier token for the name of the variable being declared, followed
 by an optional initializer expression. Finally, we put a bow on it with the
 semicolon.</p>
 <p>To access a variable, we define a new kind of primary expression.</p>
-<div class="codehilite"><pre><span class="i">primary</span>        → <span class="s">&quot;true&quot;</span> | <span class="s">&quot;false&quot;</span> | <span class="s">&quot;nil&quot;</span>
+<div class="codehilite" translate="no"><pre><span class="i">primary</span>        → <span class="s">&quot;true&quot;</span> | <span class="s">&quot;false&quot;</span> | <span class="s">&quot;nil&quot;</span>
                | <span class="t">NUMBER</span> | <span class="t">STRING</span>
                | <span class="s">&quot;(&quot;</span> <span class="i">expression</span> <span class="s">&quot;)&quot;</span>
                | <span class="t">IDENTIFIER</span> ;
@@ -522,7 +522,7 @@ to be the name of the variable being accessed.</p>
 <p>These new grammar rules get their corresponding syntax trees. Over in the AST
 generator, we add a <span name="var-stmt-ast">new statement</span> node for a
 variable declaration.</p>
-<div class="codehilite"><pre class="insert-before">      &quot;Expression : Expr expression&quot;,
+<div class="codehilite" translate="no"><pre class="insert-before">      &quot;Expression : Expr expression&quot;,
 </pre><pre class="insert-before">      <span class="s">&quot;Print      : Expr expression&quot;</span><span class="insert-comma">,</span>
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()<br>
@@ -538,7 +538,7 @@ add <em>&ldquo;,&rdquo;</em> to previous line</div>
 <p>It stores the name token so we know what it&rsquo;s declaring, along with the
 initializer expression. (If there isn&rsquo;t an initializer, that field is <code>null</code>.)</p>
 <p>Then we add an expression node for accessing a variable.</p>
-<div class="codehilite"><pre class="insert-before">      &quot;Literal  : Object value&quot;,
+<div class="codehilite" translate="no"><pre class="insert-before">      &quot;Literal  : Object value&quot;,
 </pre><pre class="insert-before">      <span class="s">&quot;Unary    : Token operator, Expr right&quot;</span><span class="insert-comma">,</span>
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()<br>
@@ -558,7 +558,7 @@ script so that you get updated &ldquo;Expr.java&rdquo; and &ldquo;Stmt.java&rdqu
 <p>Before we parse variable statements, we need to shift around some code to make
 room for the new <code>declaration</code> rule in the grammar. The top level of a program
 is now a list of declarations, so the entrypoint method to the parser changes.</p>
-<div class="codehilite"><pre class="insert-before">  List&lt;Stmt&gt; parse() {
+<div class="codehilite" translate="no"><pre class="insert-before">  List&lt;Stmt&gt; parse() {
     List&lt;Stmt&gt; statements = new ArrayList&lt;&gt;();
     while (!isAtEnd()) {
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
@@ -573,7 +573,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>parse</em>(), replace 1 line</div>
 
 <p>That calls this new method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>expression</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">declaration</span>() {
     <span class="k">try</span> {
@@ -606,7 +606,7 @@ statement matches? And <code>expression()</code> reports a syntax error if it ca
 an expression at the current token? That chain of calls ensures we report an
 error if a valid declaration or statement isn&rsquo;t parsed.</p>
 <p>When the parser matches a <code>var</code> token, it branches to:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>printStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">varDeclaration</span>() {
     <span class="t">Token</span> <span class="i">name</span> = <span class="i">consume</span>(<span class="i">IDENTIFIER</span>, <span class="s">&quot;Expect variable name.&quot;</span>);
@@ -631,7 +631,7 @@ required semicolon at the end of the statement. All this gets wrapped in a
 Stmt.Var syntax tree node and we&rsquo;re groovy.</p>
 <p>Parsing a variable expression is even easier. In <code>primary()</code>, we look for an
 identifier token.</p>
-<div class="codehilite"><pre class="insert-before">      return new Expr.Literal(previous().literal);
+<div class="codehilite" translate="no"><pre class="insert-before">      return new Expr.Literal(previous().literal);
     }
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>primary</em>()</div>
@@ -669,7 +669,7 @@ tables</strong>, <strong>dictionaries</strong> (Python and C#), <strong>hashes</
 <strong>tables</strong> (Lua), or <strong>associative arrays</strong> (PHP). Way back when, they were
 known as <strong>scatter tables</strong>.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Environment.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -689,7 +689,7 @@ with the same name should refer to the same variable (ignoring scope for now).
 Using the raw string ensures all of those tokens refer to the same map key.</p>
 <p>There are two operations we need to support. First, a variable definition binds
 a new name to a value.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Environment.java</em><br>
 in class <em>Environment</em></div>
 <pre>  <span class="t">void</span> <span class="i">define</span>(<span class="t">String</span> <span class="i">name</span>, <span class="t">Object</span> <span class="i">value</span>) {
     <span class="i">values</span>.<span class="i">put</span>(<span class="i">name</span>, <span class="i">value</span>);
@@ -700,7 +700,7 @@ in class <em>Environment</em></div>
 <p>Not exactly brain surgery, but we have made one interesting semantic choice.
 When we add the key to the map, we don&rsquo;t check to see if it&rsquo;s already present.
 That means that this program works:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;before&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;before&quot;</span>;
 <span class="k">print</span> <span class="i">a</span>; <span class="c">// &quot;before&quot;.</span>
 <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;after&quot;</span>;
 <span class="k">print</span> <span class="i">a</span>; <span class="c">// &quot;after&quot;.</span>
@@ -725,7 +725,7 @@ footsteps.</p>
 </aside>
 <p>So, to keep the two modes consistent, we&rsquo;ll allow it<span class="em">&mdash;</span>at least for global
 variables. Once a variable exists, we need a way to look it up.</p>
-<div class="codehilite"><pre class="insert-before">class Environment {
+<div class="codehilite" translate="no"><pre class="insert-before">class Environment {
   private final Map&lt;String, Object&gt; values = new HashMap&lt;&gt;();
 </pre><div class="source-file"><em>lox/Environment.java</em><br>
 in class <em>Environment</em></div>
@@ -771,7 +771,7 @@ recursive functions.</p>
 declaring the function&rsquo;s own name before we examine its body. But that doesn&rsquo;t
 help with mutually recursive procedures that call each other. Consider:</p>
 <p><span name="contrived"></span></p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">isOdd</span>(<span class="i">n</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">isOdd</span>(<span class="i">n</span>) {
   <span class="k">if</span> (<span class="i">n</span> == <span class="n">0</span>) <span class="k">return</span> <span class="k">false</span>;
   <span class="k">return</span> <span class="i">isEven</span>(<span class="i">n</span> - <span class="n">1</span>);
 }
@@ -807,7 +807,7 @@ processing function bodies.</p>
 we&rsquo;ll defer the error to runtime. It&rsquo;s OK to refer to a variable before it&rsquo;s
 defined as long as you don&rsquo;t <em>evaluate</em> the reference. That lets the program
 for even and odd numbers work, but you&rsquo;d get a runtime error in:</p>
-<div class="codehilite"><pre><span class="k">print</span> <span class="i">a</span>;
+<div class="codehilite" translate="no"><pre><span class="k">print</span> <span class="i">a</span>;
 <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;too late!&quot;</span>;
 </pre></div>
 <p>As with type errors in the expression evaluation code, we report a runtime error
@@ -815,7 +815,7 @@ by throwing an exception. The exception contains the variable&rsquo;s token so w
 tell the user where in their code they messed up.</p>
 <h3><a href="#interpreting-global-variables" id="interpreting-global-variables"><small>8&#8202;.&#8202;3&#8202;.&#8202;1</small>Interpreting global variables</a></h3>
 <p>The Interpreter class gets an instance of the new Environment class.</p>
-<div class="codehilite"><pre class="insert-before">class Interpreter implements Expr.Visitor&lt;Object&gt;,
+<div class="codehilite" translate="no"><pre class="insert-before">class Interpreter implements Expr.Visitor&lt;Object&gt;,
                              Stmt.Visitor&lt;Void&gt; {
 </pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
@@ -829,7 +829,7 @@ in class <em>Interpreter</em></div>
 memory as long as the interpreter is still running.</p>
 <p>We have two new syntax trees, so that&rsquo;s two new visit methods. The first is for
 declaration statements.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitPrintStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitVarStmt</span>(<span class="t">Stmt</span>.<span class="t">Var</span> <span class="i">stmt</span>) {
@@ -853,14 +853,14 @@ but if you accessed it before assigning to it, a runtime error would occur. It&r
 not a bad idea, but most dynamically typed languages don&rsquo;t do that. Instead,
 we&rsquo;ll keep it simple and say that Lox sets a variable to <code>nil</code> if it isn&rsquo;t
 explicitly initialized.</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span>;
 <span class="k">print</span> <span class="i">a</span>; <span class="c">// &quot;nil&quot;.</span>
 </pre></div>
 <p>Thus, if there isn&rsquo;t an initializer, we set the value to <code>null</code>, which is the
 Java representation of Lox&rsquo;s <code>nil</code> value. Then we tell the environment to bind
 the variable to that value.</p>
 <p>Next, we evaluate a variable expression.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitUnaryExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitVariableExpr</span>(<span class="t">Expr</span>.<span class="t">Variable</span> <span class="i">expr</span>) {
@@ -872,7 +872,7 @@ add after <em>visitUnaryExpr</em>()</div>
 <p>This simply forwards to the environment which does the heavy lifting to make
 sure the variable is defined. With that, we&rsquo;ve got rudimentary variables
 working. Try this out:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>;
 <span class="k">var</span> <span class="i">b</span> = <span class="n">2</span>;
 <span class="k">print</span> <span class="i">a</span> + <span class="i">b</span>;
 </pre></div>
@@ -907,7 +907,7 @@ expression).</p>
 <aside name="assign">
 <p>In some other languages, like Pascal, Python, and Go, assignment is a statement.</p>
 </aside>
-<div class="codehilite"><pre><span class="i">expression</span>     → <span class="i">assignment</span> ;
+<div class="codehilite" translate="no"><pre><span class="i">expression</span>     → <span class="i">assignment</span> ;
 <span class="i">assignment</span>     → <span class="t">IDENTIFIER</span> <span class="s">&quot;=&quot;</span> <span class="i">assignment</span>
                | <span class="i">equality</span> ;
 </pre></div>
@@ -915,10 +915,10 @@ expression).</p>
 expression for the value, or an <code>equality</code> (and thus any other) expression.
 Later, <code>assignment</code> will get more complex when we add property setters on
 objects, like:</p>
-<div class="codehilite"><pre><span class="i">instance</span>.<span class="i">field</span> = <span class="s">&quot;value&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="i">instance</span>.<span class="i">field</span> = <span class="s">&quot;value&quot;</span>;
 </pre></div>
 <p>The easy part is adding the <span name="assign-ast">new syntax tree node</span>.</p>
-<div class="codehilite"><pre class="insert-before">    defineAst(outputDir, &quot;Expr&quot;, Arrays.asList(
+<div class="codehilite" translate="no"><pre class="insert-before">    defineAst(outputDir, &quot;Expr&quot;, Arrays.asList(
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Assign   : Token name, Expr value&quot;</span>,
@@ -933,7 +933,7 @@ in <em>main</em>()</div>
 value. After you run the AstGenerator to get the new Expr.Assign class, swap out
 the body of the parser&rsquo;s existing <code>expression()</code> method to match the updated
 rule.</p>
-<div class="codehilite"><pre class="insert-before">  private Expr expression() {
+<div class="codehilite" translate="no"><pre class="insert-before">  private Expr expression() {
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>expression</em>()<br>
 replace 1 line</div>
@@ -950,7 +950,7 @@ until after we&rsquo;ve finished parsing the left operand.</p>
 <p>The difference is that the left-hand side of an assignment isn&rsquo;t an expression
 that evaluates to a value. It&rsquo;s a sort of pseudo-expression that evaluates to a
 &ldquo;thing&rdquo; you can assign to. Consider:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;before&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;before&quot;</span>;
 <span class="i">a</span> = <span class="s">&quot;value&quot;</span>;
 </pre></div>
 <p>On the second line, we don&rsquo;t <em>evaluate</em> <code>a</code> (which would return the string
@@ -968,7 +968,7 @@ expression. That&rsquo;s why the Expr.Assign node has a <em>Token</em> for the l
 side, not an Expr. The problem is that the parser doesn&rsquo;t know it&rsquo;s parsing an
 l-value until it hits the <code>=</code>. In a complex l-value, that may occur <span
 name="many">many</span> tokens later.</p>
-<div class="codehilite"><pre><span class="i">makeList</span>().<span class="i">head</span>.<span class="i">next</span> = <span class="i">node</span>;
+<div class="codehilite" translate="no"><pre><span class="i">makeList</span>().<span class="i">head</span>.<span class="i">next</span> = <span class="i">node</span>;
 </pre></div>
 <aside name="many">
 <p>Since the receiver of a field assignment can be any expression, and expressions
@@ -977,7 +977,7 @@ tokens of lookahead to find the <code>=</code>.</p>
 </aside>
 <p>We have only a single token of lookahead, so what do we do? We use a little
 trick, and it looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>expressionStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">assignment</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">equality</span>();
@@ -1025,10 +1025,10 @@ an <code>=</code>, report an error if the left-hand side isn&rsquo;t within the 
 target grammar. Conversely, if you <em>don&rsquo;t</em> hit an <code>=</code>, report an error if the
 left-hand side isn&rsquo;t a valid <em>expression</em>.</p>
 </aside>
-<div class="codehilite"><pre><span class="i">newPoint</span>(<span class="i">x</span> + <span class="n">2</span>, <span class="n">0</span>).<span class="i">y</span> = <span class="n">3</span>;
+<div class="codehilite" translate="no"><pre><span class="i">newPoint</span>(<span class="i">x</span> + <span class="n">2</span>, <span class="n">0</span>).<span class="i">y</span> = <span class="n">3</span>;
 </pre></div>
 <p>The left-hand side of that assignment could also work as a valid expression.</p>
-<div class="codehilite"><pre><span class="i">newPoint</span>(<span class="i">x</span> + <span class="n">2</span>, <span class="n">0</span>).<span class="i">y</span>;
+<div class="codehilite" translate="no"><pre><span class="i">newPoint</span>(<span class="i">x</span> + <span class="n">2</span>, <span class="n">0</span>).<span class="i">y</span>;
 </pre></div>
 <p>The first example sets the field, the second gets it.</p>
 <p>This means we can parse the left-hand side <em>as if it were</em> an expression and
@@ -1036,13 +1036,13 @@ then after the fact produce a syntax tree that turns it into an assignment
 target. If the left-hand side expression isn&rsquo;t a <span name="paren">valid</span>
 assignment target, we fail with a syntax error. That ensures we report an error
 on code like this:</p>
-<div class="codehilite"><pre><span class="i">a</span> + <span class="i">b</span> = <span class="i">c</span>;
+<div class="codehilite" translate="no"><pre><span class="i">a</span> + <span class="i">b</span> = <span class="i">c</span>;
 </pre></div>
 <aside name="paren">
 <p>Way back in the parsing chapter, I said we represent parenthesized expressions
 in the syntax tree because we&rsquo;ll need them later. This is why. We need to be
 able to distinguish these cases:</p>
-<div class="codehilite"><pre><span class="i">a</span> = <span class="n">3</span>;   <span class="c">// OK.</span>
+<div class="codehilite" translate="no"><pre><span class="i">a</span> = <span class="n">3</span>;   <span class="c">// OK.</span>
 (<span class="i">a</span>) = <span class="n">3</span>; <span class="c">// Error.</span>
 </pre></div>
 </aside>
@@ -1052,7 +1052,7 @@ that knows what it is assigning to and has an expression subtree for the value
 being assigned. All with only a single token of lookahead and no backtracking.</p>
 <h3><a href="#assignment-semantics" id="assignment-semantics"><small>8&#8202;.&#8202;4&#8202;.&#8202;2</small>Assignment semantics</a></h3>
 <p>We have a new syntax tree node, so our interpreter gets a new visit method.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitVarStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitAssignExpr</span>(<span class="t">Expr</span>.<span class="t">Assign</span> <span class="i">expr</span>) {
@@ -1066,7 +1066,7 @@ add after <em>visitVarStmt</em>()</div>
 <p>For obvious reasons, it&rsquo;s similar to variable declaration. It evaluates the
 right-hand side to get the value, then stores it in the named variable. Instead
 of using <code>define()</code> on Environment, it calls this new method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Environment.java</em><br>
 add after <em>get</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">assign</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">Object</span> <span class="i">value</span>) {
     <span class="k">if</span> (<span class="i">values</span>.<span class="i">containsKey</span>(<span class="i">name</span>.<span class="i">lexeme</span>)) {
@@ -1090,7 +1090,7 @@ in the environment&rsquo;s variable map.</p>
 <p>The last thing the <code>visit()</code> method does is return the assigned value. That&rsquo;s
 because assignment is an expression that can be nested inside other expressions,
 like so:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>;
 <span class="k">print</span> <span class="i">a</span> = <span class="n">2</span>; <span class="c">// &quot;2&quot;.</span>
 </pre></div>
 <p>Our interpreter can now create, read, and modify variables. It&rsquo;s about as
@@ -1127,7 +1127,7 @@ it. The widely disliked <a href="https://developer.mozilla.org/en-US/docs/Web/Ja
 on an object into dynamically scoped variables.</p>
 </aside>
 <p>For example:</p>
-<div class="codehilite"><pre>{
+<div class="codehilite" translate="no"><pre>{
   <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;first&quot;</span>;
   <span class="k">print</span> <span class="i">a</span>; <span class="c">// &quot;first&quot;.</span>
 }
@@ -1144,7 +1144,7 @@ second.</p><img src="image/statements-and-state/blocks.png" alt="An environment 
 <p>This is in contrast to <strong>dynamic scope</strong> where you don&rsquo;t know what a name refers
 to until you execute the code. Lox doesn&rsquo;t have dynamically scoped <em>variables</em>,
 but methods and fields on objects are dynamically scoped.</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Saxophone</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Saxophone</span> {
   <span class="i">play</span>() {
     <span class="k">print</span> <span class="s">&quot;Careless Whisper&quot;</span>;
   }
@@ -1168,7 +1168,7 @@ and the latter is the machinery that implements it. As our interpreter works its
 way through code, syntax tree nodes that affect scope will change the
 environment. In a C-ish syntax like Lox&rsquo;s, scope is controlled by curly-braced
 blocks. (That&rsquo;s why we call it <strong>block scope</strong>.)</p>
-<div class="codehilite"><pre>{
+<div class="codehilite" translate="no"><pre>{
   <span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;in block&quot;</span>;
 }
 <span class="k">print</span> <span class="i">a</span>; <span class="c">// Error! No more &quot;a&quot;.</span>
@@ -1191,7 +1191,7 @@ those variables.</p>
 <p>That would work for the previous example. But remember, one motivation for
 local scope is encapsulation<span class="em">&mdash;</span>a block of code in one corner of the program
 shouldn&rsquo;t interfere with some other block. Check this out:</p>
-<div class="codehilite"><pre><span class="c">// How loud?</span>
+<div class="codehilite" translate="no"><pre><span class="c">// How loud?</span>
 <span class="k">var</span> <span class="i">volume</span> = <span class="n">11</span>;
 
 <span class="c">// Silence.</span>
@@ -1218,7 +1218,7 @@ defining a fresh environment for each block containing only the variables
 defined in that scope. When we exit the block, we discard its environment and
 restore the previous one.</p>
 <p>We also need to handle enclosing variables that are <em>not</em> shadowed.</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">global</span> = <span class="s">&quot;outside&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">global</span> = <span class="s">&quot;outside&quot;</span>;
 {
   <span class="k">var</span> <span class="i">local</span> = <span class="s">&quot;inside&quot;</span>;
   <span class="k">print</span> <span class="i">global</span> + <span class="i">local</span>;
@@ -1245,7 +1245,7 @@ much prefer the evocative <strong>cactus stack</strong>.</p><img class="above" s
 <p>Before we add block syntax to the grammar, we&rsquo;ll beef up our Environment class
 with support for this nesting. First, we give each environment a reference to
 its enclosing one.</p>
-<div class="codehilite"><pre class="insert-before">class Environment {
+<div class="codehilite" translate="no"><pre class="insert-before">class Environment {
 </pre><div class="source-file"><em>lox/Environment.java</em><br>
 in class <em>Environment</em></div>
 <pre class="insert">  <span class="k">final</span> <span class="t">Environment</span> <span class="i">enclosing</span>;
@@ -1254,7 +1254,7 @@ in class <em>Environment</em></div>
 <div class="source-file-narrow"><em>lox/Environment.java</em>, in class <em>Environment</em></div>
 
 <p>This field needs to be initialized, so we add a couple of constructors.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Environment.java</em><br>
 in class <em>Environment</em></div>
 <pre>  <span class="t">Environment</span>() {
     <span class="i">enclosing</span> = <span class="k">null</span>;
@@ -1273,7 +1273,7 @@ given outer one.</p>
 declared in the current innermost scope. But variable lookup and assignment work
 with existing variables and they need to walk the chain to find them. First,
 lookup:</p>
-<div class="codehilite"><pre class="insert-before">      return values.get(name.lexeme);
+<div class="codehilite" translate="no"><pre class="insert-before">      return values.get(name.lexeme);
     }
 </pre><div class="source-file"><em>lox/Environment.java</em><br>
 in <em>get</em>()</div>
@@ -1297,7 +1297,7 @@ an error as before.</p>
 <p>It&rsquo;s likely faster to iteratively walk the chain, but I think the recursive
 solution is prettier. We&rsquo;ll do something <em>much</em> faster in clox.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">      values.put(name.lexeme, value);
+<div class="codehilite" translate="no"><pre class="insert-before">      values.put(name.lexeme, value);
       return;
     }
 
@@ -1317,7 +1317,7 @@ recursively.</p>
 <h3><a href="#block-syntax-and-semantics" id="block-syntax-and-semantics"><small>8&#8202;.&#8202;5&#8202;.&#8202;2</small>Block syntax and semantics</a></h3>
 <p>Now that Environments nest, we&rsquo;re ready to add blocks to the language. Behold
 the grammar:</p>
-<div class="codehilite"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
+<div class="codehilite" translate="no"><pre><span class="i">statement</span>      → <span class="i">exprStmt</span>
                | <span class="i">printStmt</span>
                | <span class="i">block</span> ;
 
@@ -1326,7 +1326,7 @@ the grammar:</p>
 <p>A block is a (possibly empty) series of statements or declarations surrounded by
 curly braces. A block is itself a statement and can appear anywhere a statement
 is allowed. The <span name="block-ast">syntax tree</span> node looks like this:</p>
-<div class="codehilite"><pre class="insert-before">    defineAst(outputDir, &quot;Stmt&quot;, Arrays.asList(
+<div class="codehilite" translate="no"><pre class="insert-before">    defineAst(outputDir, &quot;Stmt&quot;, Arrays.asList(
 </pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Block      : List&lt;Stmt&gt; statements&quot;</span>,
@@ -1344,7 +1344,7 @@ beginning of a block by its leading token<span class="em">&mdash;</span>in this 
 <aside name="generate">
 <p>As always, don&rsquo;t forget to run &ldquo;GenerateAst.java&rdquo;.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">    if (match(PRINT)) return printStatement();
+<div class="codehilite" translate="no"><pre class="insert-before">    if (match(PRINT)) return printStatement();
 </pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">match</span>(<span class="i">LEFT_BRACE</span>)) <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Block</span>(<span class="i">block</span>());
@@ -1355,7 +1355,7 @@ in <em>statement</em>()</div>
 <div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>statement</em>()</div>
 
 <p>All the real work happens here:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>expressionStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">block</span>() {
     <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span> = <span class="k">new</span> <span class="t">ArrayList</span>&lt;&gt;();
@@ -1382,7 +1382,7 @@ way because we&rsquo;ll reuse <code>block()</code> later for parsing function bo
 want that body wrapped in a Stmt.Block.</p>
 </aside>
 <p>That&rsquo;s it for syntax. For semantics, we add another visit method to Interpreter.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>execute</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitBlockStmt</span>(<span class="t">Stmt</span>.<span class="t">Block</span> <span class="i">stmt</span>) {
@@ -1394,7 +1394,7 @@ add after <em>execute</em>()</div>
 
 <p>To execute a block, we create a new environment for the block&rsquo;s scope and pass
 it off to this other method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>execute</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">executeBlock</span>(<span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span>,
                     <span class="t">Environment</span> <span class="i">environment</span>) {
@@ -1435,7 +1435,7 @@ simpler, I went with the mutable field.</p>
 </aside>
 <p>Surprisingly, that&rsquo;s all we need to do in order to fully support local
 variables, nesting, and shadowing. Go ahead and try this out:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;global a&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="s">&quot;global a&quot;</span>;
 <span class="k">var</span> <span class="i">b</span> = <span class="s">&quot;global b&quot;</span>;
 <span class="k">var</span> <span class="i">c</span> = <span class="s">&quot;global c&quot;</span>;
 {
@@ -1472,7 +1472,7 @@ value.</p>
 initialization. Instead of implicitly initializing variables to <code>nil</code>, make
 it a runtime error to access a variable that has not been initialized or
 assigned to, as in:</p>
-<div class="codehilite"><pre><span class="c">// No initializers.</span>
+<div class="codehilite" translate="no"><pre><span class="c">// No initializers.</span>
 <span class="k">var</span> <span class="i">a</span>;
 <span class="k">var</span> <span class="i">b</span>;
 
@@ -1484,7 +1484,7 @@ assigned to, as in:</p>
 </li>
 <li>
 <p>What does the following program do?</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>;
 {
   <span class="k">var</span> <span class="i">a</span> = <span class="i">a</span> + <span class="n">2</span>;
   <span class="k">print</span> <span class="i">a</span>;

--- a/site/strings.html
+++ b/site/strings.html
@@ -136,7 +136,7 @@ ValueType case to refer to all heap-allocated types.</p>
 <aside name="short">
 <p>&ldquo;Obj&rdquo; is short for &ldquo;object&rdquo;, natch.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">  VAL_NUMBER,
+<div class="codehilite" translate="no"><pre class="insert-before">  VAL_NUMBER,
 </pre><div class="source-file"><em>value.h</em><br>
 in enum <em>ValueType</em></div>
 <pre class="insert">  <span class="a">VAL_OBJ</span>
@@ -146,7 +146,7 @@ in enum <em>ValueType</em></div>
 
 <p>When a Value&rsquo;s type is <code>VAL_OBJ</code>, the payload is a pointer to the heap memory,
 so we add another case to the union for that.</p>
-<div class="codehilite"><pre class="insert-before">    double number;
+<div class="codehilite" translate="no"><pre class="insert-before">    double number;
 </pre><div class="source-file"><em>value.h</em><br>
 in struct <em>Value</em></div>
 <pre class="insert">    <span class="t">Obj</span>* <span class="i">obj</span>;
@@ -156,7 +156,7 @@ in struct <em>Value</em></div>
 
 <p>As we did with the other value types, we crank out a couple of helpful macros
 for working with Obj values.</p>
-<div class="codehilite"><pre class="insert-before">#define IS_NUMBER(value)  ((value).type == VAL_NUMBER)
+<div class="codehilite" translate="no"><pre class="insert-before">#define IS_NUMBER(value)  ((value).type == VAL_NUMBER)
 </pre><div class="source-file"><em>value.h</em><br>
 add after struct <em>Value</em></div>
 <pre class="insert"><span class="a">#define IS_OBJ(value)     ((value).type == VAL_OBJ)</span>
@@ -167,7 +167,7 @@ add after struct <em>Value</em></div>
 <div class="source-file-narrow"><em>value.h</em>, add after struct <em>Value</em></div>
 
 <p>This evaluates to <code>true</code> if the given Value is an Obj. If so, we can use this:</p>
-<div class="codehilite"><pre class="insert-before">#define IS_OBJ(value)     ((value).type == VAL_OBJ)
+<div class="codehilite" translate="no"><pre class="insert-before">#define IS_OBJ(value)     ((value).type == VAL_OBJ)
 
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="a">#define AS_OBJ(value)     ((value).as.obj)</span>
@@ -176,7 +176,7 @@ add after struct <em>Value</em></div>
 <div class="source-file-narrow"><em>value.h</em></div>
 
 <p>It extracts the Obj pointer from the value. We can also go the other way.</p>
-<div class="codehilite"><pre class="insert-before">#define NUMBER_VAL(value) ((Value){VAL_NUMBER, {.number = value}})
+<div class="codehilite" translate="no"><pre class="insert-before">#define NUMBER_VAL(value) ((Value){VAL_NUMBER, {.number = value}})
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="a">#define OBJ_VAL(object)   ((Value){VAL_OBJ, {.obj = (Obj*)object}})</span>
 </pre><pre class="insert-after">
@@ -212,7 +212,7 @@ get the preliminary stuff out of the way.</p>
 all object types. It&rsquo;s sort of like the &ldquo;base class&rdquo; for objects. Because of
 some cyclic dependencies between values and objects, we forward-declare it in
 the &ldquo;value&rdquo; module.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;common.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;common.h&quot;
 
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="k">typedef</span> <span class="k">struct</span> <span class="t">Obj</span> <span class="t">Obj</span>;
@@ -222,7 +222,7 @@ the &ldquo;value&rdquo; module.</p>
 <div class="source-file-narrow"><em>value.h</em></div>
 
 <p>And the actual definition is in a new module.</p>
-<div class="codehilite"><div class="source-file"><em>object.h</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.h</em><br>
 create new file</div>
 <pre><span class="a">#ifndef clox_object_h</span>
 <span class="a">#define clox_object_h</span>
@@ -240,7 +240,7 @@ create new file</div>
 
 <p>Right now, it contains only the type tag. Shortly, we&rsquo;ll add some other
 bookkeeping information for memory management. The type enum is this:</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;value.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;value.h&quot;
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert">
 
@@ -257,7 +257,7 @@ struct Obj {
 heap-allocated types. Since we&rsquo;ll be accessing these tag types frequently, it&rsquo;s
 worth making a little macro that extracts the object type tag from a given
 Value.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;value.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;value.h&quot;
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert">
 
@@ -271,7 +271,7 @@ typedef enum {
 <p>That&rsquo;s our foundation.</p>
 <p>Now, let&rsquo;s build strings on top of it. The payload for strings is defined in a
 separate struct. Again, we need to forward-declare it.</p>
-<div class="codehilite"><pre class="insert-before">typedef struct Obj Obj;
+<div class="codehilite" translate="no"><pre class="insert-before">typedef struct Obj Obj;
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="k">typedef</span> <span class="k">struct</span> <span class="t">ObjString</span> <span class="t">ObjString</span>;
 </pre><pre class="insert-after">
@@ -281,7 +281,7 @@ typedef enum {
 <div class="source-file-narrow"><em>value.h</em></div>
 
 <p>The definition lives alongside Obj.</p>
-<div class="codehilite"><pre class="insert-before">};
+<div class="codehilite" translate="no"><pre class="insert-before">};
 </pre><div class="source-file"><em>object.h</em><br>
 add after struct <em>Obj</em></div>
 <pre class="insert">
@@ -333,7 +333,7 @@ an <code>ObjString*</code>. Of course, you need to ensure that the <code>Obj*</c
 does point to the <code>obj</code> field of an actual ObjString. Otherwise, you are
 unsafely reinterpreting random bits of memory. To detect that such a cast is
 safe, we add another macro.</p>
-<div class="codehilite"><pre class="insert-before">#define OBJ_TYPE(value)        (AS_OBJ(value)-&gt;type)
+<div class="codehilite" translate="no"><pre class="insert-before">#define OBJ_TYPE(value)        (AS_OBJ(value)-&gt;type)
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert">
 
@@ -346,7 +346,7 @@ typedef enum {
 
 <p>It takes a Value, not a raw <code>Obj*</code> because most code in the VM works with
 Values. It relies on this inline function:</p>
-<div class="codehilite"><pre class="insert-before">};
+<div class="codehilite" translate="no"><pre class="insert-before">};
 
 </pre><div class="source-file"><em>object.h</em><br>
 add after struct <em>ObjString</em></div>
@@ -365,13 +365,13 @@ every place the parameter name appears in the body. If a macro uses a parameter
 more than once, that expression gets evaluated multiple times.</p>
 <p>That&rsquo;s bad if the expression has side effects. If we put the body of
 <code>isObjType()</code> into the macro definition and then you did, say,</p>
-<div class="codehilite"><pre><span class="a">IS_STRING</span>(<span class="a">POP</span>())
+<div class="codehilite" translate="no"><pre><span class="a">IS_STRING</span>(<span class="a">POP</span>())
 </pre></div>
 <p>then it would pop two values off the stack! Using a function fixes that.</p>
 <p>As long as we ensure that we set the type tag correctly whenever we create an
 Obj of some type, this macro will tell us when it&rsquo;s safe to cast a value to a
 specific object type. We can do that using these:</p>
-<div class="codehilite"><pre class="insert-before">#define IS_STRING(value)       isObjType(value, OBJ_STRING)
+<div class="codehilite" translate="no"><pre class="insert-before">#define IS_STRING(value)       isObjType(value, OBJ_STRING)
 </pre><div class="source-file"><em>object.h</em></div>
 <pre class="insert">
 
@@ -391,7 +391,7 @@ often what we&rsquo;ll end up needing.</p>
 <p>OK, our VM can now represent string values. It&rsquo;s time to add strings to the
 language itself. As usual, we begin in the front end. The lexer already
 tokenizes string literals, so it&rsquo;s the parser&rsquo;s turn.</p>
-<div class="codehilite"><pre class="insert-before">  [TOKEN_IDENTIFIER]    = {NULL,     NULL,   PREC_NONE},
+<div class="codehilite" translate="no"><pre class="insert-before">  [TOKEN_IDENTIFIER]    = {NULL,     NULL,   PREC_NONE},
 </pre><div class="source-file"><em>compiler.c</em><br>
 replace 1 line</div>
 <pre class="insert">  [<span class="a">TOKEN_STRING</span>]        = {<span class="i">string</span>,   <span class="a">NULL</span>,   <span class="a">PREC_NONE</span>},
@@ -400,7 +400,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, replace 1 line</div>
 
 <p>When the parser hits a string token, it calls this parse function:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>number</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">string</span>() {
   <span class="i">emitConstant</span>(<span class="a">OBJ_VAL</span>(<span class="i">copyString</span>(<span class="i">parser</span>.<span class="i">previous</span>.<span class="i">start</span> + <span class="n">1</span>,
@@ -418,7 +418,7 @@ constant table.</p>
 Since it doesn&rsquo;t, we can take the characters as they are.</p>
 </aside>
 <p>To create the string, we use <code>copyString()</code>, which is declared in <code>object.h</code>.</p>
-<div class="codehilite"><pre class="insert-before">};
+<div class="codehilite" translate="no"><pre class="insert-before">};
 
 </pre><div class="source-file"><em>object.h</em><br>
 add after struct <em>ObjString</em></div>
@@ -429,7 +429,7 @@ add after struct <em>ObjString</em></div>
 <div class="source-file-narrow"><em>object.h</em>, add after struct <em>ObjString</em></div>
 
 <p>The compiler module needs to include that.</p>
-<div class="codehilite"><pre class="insert-before">#define clox_compiler_h
+<div class="codehilite" translate="no"><pre class="insert-before">#define clox_compiler_h
 
 </pre><div class="source-file"><em>compiler.h</em></div>
 <pre class="insert"><span class="a">#include &quot;object.h&quot;</span>
@@ -439,7 +439,7 @@ add after struct <em>ObjString</em></div>
 
 <p>Our &ldquo;object&rdquo; module gets an implementation file where we define the new
 function.</p>
-<div class="codehilite"><div class="source-file"><em>object.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.c</em><br>
 create new file</div>
 <pre><span class="a">#include &lt;stdio.h&gt;</span>
 <span class="a">#include &lt;string.h&gt;</span>
@@ -462,7 +462,7 @@ create new file</div>
 characters and the trailing <span name="terminator">terminator</span>, using
 this low-level macro that allocates an array with a given element type and
 count:</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;common.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;common.h&quot;
 
 </pre><div class="source-file"><em>memory.h</em></div>
 <pre class="insert"><span class="a">#define ALLOCATE(type, count) \</span>
@@ -492,7 +492,7 @@ array that pointed into the original source code string, bad things would
 happen. So, for literals, we preemptively copy the characters over to the heap.
 This way, every ObjString reliably owns its character array and can free it.</p>
 <p>The real work of creating a string object happens in this function:</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;vm.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;vm.h&quot;
 
 </pre><div class="source-file"><em>object.c</em></div>
 <pre class="insert"><span class="k">static</span> <span class="t">ObjString</span>* <span class="i">allocateString</span>(<span class="t">char</span>* <span class="i">chars</span>, <span class="t">int</span> <span class="i">length</span>) {
@@ -507,7 +507,7 @@ This way, every ObjString reliably owns its character array and can free it.</p>
 <p>It creates a new ObjString on the heap and then initializes its fields. It&rsquo;s
 sort of like a constructor in an OOP language. As such, it first calls the &ldquo;base
 class&rdquo; constructor to initialize the Obj state, using a new macro.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;vm.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;vm.h&quot;
 </pre><div class="source-file"><em>object.c</em></div>
 <pre class="insert">
 
@@ -527,7 +527,7 @@ actual functionality is here:</p>
 try to keep the code nicely factored, but that leads to a scattering of tiny
 functions. They will pay off when we reuse them later.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">#define ALLOCATE_OBJ(type, objectType) \
+<div class="codehilite" translate="no"><pre class="insert-before">#define ALLOCATE_OBJ(type, objectType) \
     (type*)allocateObject(sizeof(type), objectType)
 </pre><div class="source-file"><em>object.c</em></div>
 <pre class="insert">
@@ -559,7 +559,7 @@ did spend two hours drawing a viola just to mention that.</p>
 <h2><a href="#operations-on-strings" id="operations-on-strings"><small>19&#8202;.&#8202;4</small>Operations on Strings</a></h2>
 <p>Our fancy strings are there, but they don&rsquo;t do much of anything yet. A good
 first step is to make the existing print code not barf on the new value type.</p>
-<div class="codehilite"><pre class="insert-before">    case VAL_NUMBER: printf(&quot;%g&quot;, AS_NUMBER(value)); break;
+<div class="codehilite" translate="no"><pre class="insert-before">    case VAL_NUMBER: printf(&quot;%g&quot;, AS_NUMBER(value)); break;
 </pre><div class="source-file"><em>value.c</em><br>
 in <em>printValue</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">VAL_OBJ</span>: <span class="i">printObject</span>(<span class="i">value</span>); <span class="k">break</span>;
@@ -569,7 +569,7 @@ in <em>printValue</em>()</div>
 
 <p>If the value is a heap-allocated object, it defers to a helper function over in
 the &ldquo;object&rdquo; module.</p>
-<div class="codehilite"><pre class="insert-before">ObjString* copyString(const char* chars, int length);
+<div class="codehilite" translate="no"><pre class="insert-before">ObjString* copyString(const char* chars, int length);
 </pre><div class="source-file"><em>object.h</em><br>
 add after <em>copyString</em>()</div>
 <pre class="insert"><span class="t">void</span> <span class="i">printObject</span>(<span class="t">Value</span> <span class="i">value</span>);
@@ -580,7 +580,7 @@ static inline bool isObjType(Value value, ObjType type) {
 <div class="source-file-narrow"><em>object.h</em>, add after <em>copyString</em>()</div>
 
 <p>The implementation looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>object.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.c</em><br>
 add after <em>copyString</em>()</div>
 <pre><span class="t">void</span> <span class="i">printObject</span>(<span class="t">Value</span> <span class="i">value</span>) {
   <span class="k">switch</span> (<span class="a">OBJ_TYPE</span>(<span class="i">value</span>)) {
@@ -599,14 +599,14 @@ name="term-2">prints</span> the character array as a C string.</p>
 <p>I told you terminating the string would come in handy.</p>
 </aside>
 <p>The equality operators also need to gracefully handle strings. Consider:</p>
-<div class="codehilite"><pre><span class="s">&quot;string&quot;</span> == <span class="s">&quot;string&quot;</span>
+<div class="codehilite" translate="no"><pre><span class="s">&quot;string&quot;</span> == <span class="s">&quot;string&quot;</span>
 </pre></div>
 <p>These are two separate string literals. The compiler will make two separate
 calls to <code>copyString()</code>, create two distinct ObjString objects and store them as
 two constants in the chunk. They are different objects in the heap. But our
 users (and thus we) expect strings to have value equality. The above expression
 should evaluate to <code>true</code>. That requires a little special support.</p>
-<div class="codehilite"><pre class="insert-before">    case VAL_NUMBER: return AS_NUMBER(a) == AS_NUMBER(b);
+<div class="codehilite" translate="no"><pre class="insert-before">    case VAL_NUMBER: return AS_NUMBER(a) == AS_NUMBER(b);
 </pre><div class="source-file"><em>value.c</em><br>
 in <em>valuesEqual</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">VAL_OBJ</span>: {
@@ -627,7 +627,7 @@ than equality on other types since it has to walk the whole string. We&rsquo;ll 
 that <a href="hash-tables.html">later</a>, but this gives us the right semantics for now.</p>
 <p>Finally, in order to use <code>memcmp()</code> and the new stuff in the &ldquo;object&rdquo; module, we
 need a couple of includes. Here:</p>
-<div class="codehilite"><pre class="insert-before">#include &lt;stdio.h&gt;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &lt;stdio.h&gt;
 </pre><div class="source-file"><em>value.c</em></div>
 <pre class="insert"><span class="a">#include &lt;string.h&gt;</span>
 </pre><pre class="insert-after">
@@ -637,7 +637,7 @@ need a couple of includes. Here:</p>
 <div class="source-file-narrow"><em>value.c</em></div>
 
 <p>And here:</p>
-<div class="codehilite"><pre class="insert-before">#include &lt;string.h&gt;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &lt;string.h&gt;
 
 </pre><div class="source-file"><em>value.c</em></div>
 <pre class="insert"><span class="a">#include &quot;object.h&quot;</span>
@@ -655,7 +655,7 @@ of the two operands. Since Lox is dynamically typed, we can&rsquo;t tell which
 behavior is needed at compile time because we don&rsquo;t know the types of the
 operands until runtime. Thus, the <code>OP_ADD</code> instruction dynamically inspects the
 operands and chooses the right operation.</p>
-<div class="codehilite"><pre class="insert-before">      case OP_LESS:     BINARY_OP(BOOL_VAL, &lt;); break;
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_LESS:     BINARY_OP(BOOL_VAL, &lt;); break;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
 replace 1 line</div>
@@ -688,7 +688,7 @@ converted to a string before concatenating the two.</p>
 string&rdquo; code for each type, so I left it out of Lox.</p>
 </aside>
 <p>To concatenate strings, we define a new function.</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>isFalsey</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">concatenate</span>() {
   <span class="t">ObjString</span>* <span class="i">b</span> = <span class="a">AS_STRING</span>(<span class="i">pop</span>());
@@ -711,7 +711,7 @@ calculate the length of the result string based on the lengths of the operands.
 We allocate a character array for the result and then copy the two halves in. As
 always, we carefully ensure the string is terminated.</p>
 <p>In order to call <code>memcpy()</code>, the VM needs an include.</p>
-<div class="codehilite"><pre class="insert-before">#include &lt;stdio.h&gt;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &lt;stdio.h&gt;
 </pre><div class="source-file"><em>vm.c</em></div>
 <pre class="insert"><span class="a">#include &lt;string.h&gt;</span>
 </pre><pre class="insert-after">
@@ -722,7 +722,7 @@ always, we carefully ensure the string is terminated.</p>
 
 <p>Finally, we produce an ObjString to contain those characters. This time we use a
 new function, <code>takeString()</code>.</p>
-<div class="codehilite"><pre class="insert-before">};
+<div class="codehilite" translate="no"><pre class="insert-before">};
 
 </pre><div class="source-file"><em>object.h</em><br>
 add after struct <em>ObjString</em></div>
@@ -732,7 +732,7 @@ add after struct <em>ObjString</em></div>
 <div class="source-file-narrow"><em>object.h</em>, add after struct <em>ObjString</em></div>
 
 <p>The implementation looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>object.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>object.c</em><br>
 add after <em>allocateString</em>()</div>
 <pre><span class="t">ObjString</span>* <span class="i">takeString</span>(<span class="t">char</span>* <span class="i">chars</span>, <span class="t">int</span> <span class="i">length</span>) {
   <span class="k">return</span> <span class="i">allocateString</span>(<span class="i">chars</span>, <span class="i">length</span>);
@@ -750,7 +750,7 @@ the heap. Making another copy of that would be redundant (and would mean
 <code>concatenate()</code> has to remember to free its copy). Instead, this function claims
 ownership of the string you give it.</p>
 <p>As usual, stitching this functionality together requires a couple of includes.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;debug.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;debug.h&quot;
 </pre><div class="source-file"><em>vm.c</em></div>
 <pre class="insert"><span class="a">#include &quot;object.h&quot;</span>
 <span class="a">#include &quot;memory.h&quot;</span>
@@ -760,7 +760,7 @@ ownership of the string you give it.</p>
 
 <h2><a href="#freeing-objects" id="freeing-objects"><small>19&#8202;.&#8202;5</small>Freeing Objects</a></h2>
 <p>Behold this innocuous-seeming expression:</p>
-<div class="codehilite"><pre><span class="s">&quot;st&quot;</span> + <span class="s">&quot;ri&quot;</span> + <span class="s">&quot;ng&quot;</span>
+<div class="codehilite" translate="no"><pre><span class="s">&quot;st&quot;</span> + <span class="s">&quot;ri&quot;</span> + <span class="s">&quot;ng&quot;</span>
 </pre></div>
 <p>When the compiler chews through this, it allocates an ObjString for each of
 those three string literals and stores them in the chunk&rsquo;s constant table and
@@ -768,7 +768,7 @@ generates this <span name="stack">bytecode</span>:</p>
 <aside name="stack">
 <p>Here&rsquo;s what the stack looks like after each instruction:</p><img src="image/strings/stack.png" alt="The state of the stack at each instruction." />
 </aside>
-<div class="codehilite"><pre>0000    OP_CONSTANT         0 &quot;st&quot;
+<div class="codehilite" translate="no"><pre>0000    OP_CONSTANT         0 &quot;st&quot;
 0002    OP_CONSTANT         1 &quot;ri&quot;
 0004    OP_ADD
 0005    OP_CONSTANT         2 &quot;ng&quot;
@@ -819,7 +819,7 @@ not the user&rsquo;s program or the VM&rsquo;s stack still has a reference to it
 allocate those too. Instead, we&rsquo;ll use an <strong>intrusive list</strong><span class="em">&mdash;</span>the Obj struct
 itself will be the linked list node. Each Obj gets a pointer to the next Obj in
 the chain.</p>
-<div class="codehilite"><pre class="insert-before">struct Obj {
+<div class="codehilite" translate="no"><pre class="insert-before">struct Obj {
   ObjType type;
 </pre><div class="source-file"><em>object.h</em><br>
 in struct <em>Obj</em></div>
@@ -829,7 +829,7 @@ in struct <em>Obj</em></div>
 <div class="source-file-narrow"><em>object.h</em>, in struct <em>Obj</em></div>
 
 <p>The VM stores a pointer to the head of the list.</p>
-<div class="codehilite"><pre class="insert-before">  Value* stackTop;
+<div class="codehilite" translate="no"><pre class="insert-before">  Value* stackTop;
 </pre><div class="source-file"><em>vm.h</em><br>
 in struct <em>VM</em></div>
 <pre class="insert">  <span class="t">Obj</span>* <span class="i">objects</span>;
@@ -838,7 +838,7 @@ in struct <em>VM</em></div>
 <div class="source-file-narrow"><em>vm.h</em>, in struct <em>VM</em></div>
 
 <p>When we first initialize the VM, there are no allocated objects.</p>
-<div class="codehilite"><pre class="insert-before">  resetStack();
+<div class="codehilite" translate="no"><pre class="insert-before">  resetStack();
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>initVM</em>()</div>
 <pre class="insert">  <span class="i">vm</span>.<span class="i">objects</span> = <span class="a">NULL</span>;
@@ -847,7 +847,7 @@ in <em>initVM</em>()</div>
 <div class="source-file-narrow"><em>vm.c</em>, in <em>initVM</em>()</div>
 
 <p>Every time we allocate an Obj, we insert it in the list.</p>
-<div class="codehilite"><pre class="insert-before">  object-&gt;type = type;
+<div class="codehilite" translate="no"><pre class="insert-before">  object-&gt;type = type;
 </pre><div class="source-file"><em>object.c</em><br>
 in <em>allocateObject</em>()</div>
 <pre class="insert">
@@ -863,7 +863,7 @@ head. That way, we don&rsquo;t need to also store a pointer to the tail and keep
 updated.</p>
 <p>The &ldquo;object&rdquo; module is directly using the global <code>vm</code> variable from the &ldquo;vm&rdquo;
 module, so we need to expose that externally.</p>
-<div class="codehilite"><pre class="insert-before">} InterpretResult;
+<div class="codehilite" translate="no"><pre class="insert-before">} InterpretResult;
 
 </pre><div class="source-file"><em>vm.h</em><br>
 add after enum <em>InterpretResult</em></div>
@@ -878,7 +878,7 @@ running. But, even then, there will usually be unused objects still lingering in
 memory when the user&rsquo;s program completes. The VM should free those too.</p>
 <p>There&rsquo;s no sophisticated logic for that. Once the program is done, we can free
 <em>every</em> object. We can and should implement that now.</p>
-<div class="codehilite"><pre class="insert-before">void freeVM() {
+<div class="codehilite" translate="no"><pre class="insert-before">void freeVM() {
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>freeVM</em>()</div>
 <pre class="insert">  <span class="i">freeObjects</span>();
@@ -888,7 +888,7 @@ in <em>freeVM</em>()</div>
 
 <p>That empty function we defined <a href="a-virtual-machine.html#an-instruction-execution-machine">way back when</a> finally does something! It
 calls this:</p>
-<div class="codehilite"><pre class="insert-before">void* reallocate(void* pointer, size_t oldSize, size_t newSize);
+<div class="codehilite" translate="no"><pre class="insert-before">void* reallocate(void* pointer, size_t oldSize, size_t newSize);
 </pre><div class="source-file"><em>memory.h</em><br>
 add after <em>reallocate</em>()</div>
 <pre class="insert"><span class="t">void</span> <span class="i">freeObjects</span>();
@@ -899,7 +899,7 @@ add after <em>reallocate</em>()</div>
 <div class="source-file-narrow"><em>memory.h</em>, add after <em>reallocate</em>()</div>
 
 <p>Here&rsquo;s how we free the objects:</p>
-<div class="codehilite"><div class="source-file"><em>memory.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>memory.c</em><br>
 add after <em>reallocate</em>()</div>
 <pre><span class="t">void</span> <span class="i">freeObjects</span>() {
   <span class="t">Obj</span>* <span class="i">object</span> = <span class="i">vm</span>.<span class="i">objects</span>;
@@ -914,7 +914,7 @@ add after <em>reallocate</em>()</div>
 
 <p>This is a CS 101 textbook implementation of walking a linked list and freeing
 its nodes. For each node, we call:</p>
-<div class="codehilite"><div class="source-file"><em>memory.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>memory.c</em><br>
 add after <em>reallocate</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">freeObject</span>(<span class="t">Obj</span>* <span class="i">object</span>) {
   <span class="k">switch</span> (<span class="i">object</span>-&gt;<span class="i">type</span>) {
@@ -933,7 +933,7 @@ add after <em>reallocate</em>()</div>
 other memory that they own, we also need a little type-specific code to handle
 each object type&rsquo;s special needs. Here, that means we free the character array
 and then free the ObjString. Those both use one last memory management macro.</p>
-<div class="codehilite"><pre class="insert-before">    (type*)reallocate(NULL, 0, sizeof(type) * (count))
+<div class="codehilite" translate="no"><pre class="insert-before">    (type*)reallocate(NULL, 0, sizeof(type) * (count))
 </pre><div class="source-file"><em>memory.h</em></div>
 <pre class="insert">
 
@@ -953,7 +953,7 @@ used. If all allocation and freeing goes through <code>reallocate()</code>, it&r
 keep a running count of the number of bytes of allocated memory.</p>
 </aside>
 <p>As usual, we need an include to wire everything together.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;common.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;common.h&quot;
 </pre><div class="source-file"><em>memory.h</em></div>
 <pre class="insert"><span class="a">#include &quot;object.h&quot;</span>
 </pre><pre class="insert-after">
@@ -963,7 +963,7 @@ keep a running count of the number of bytes of allocated memory.</p>
 <div class="source-file-narrow"><em>memory.h</em></div>
 
 <p>Then in the implementation file:</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;memory.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;memory.h&quot;
 </pre><div class="source-file"><em>memory.c</em></div>
 <pre class="insert"><span class="a">#include &quot;vm.h&quot;</span>
 </pre><pre class="insert-after">

--- a/site/superclasses.html
+++ b/site/superclasses.html
@@ -115,7 +115,7 @@ much faster, way of handling inherited method calls this time around.</p>
 <h2><a href="#inheriting-methods" id="inheriting-methods"><small>29&#8202;.&#8202;1</small>Inheriting Methods</a></h2>
 <p>We&rsquo;ll kick things off with method inheritance since it&rsquo;s the simpler piece. To
 refresh your memory, Lox inheritance syntax looks like this:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Doughnut</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Doughnut</span> {
   <span class="i">cook</span>() {
     <span class="k">print</span> <span class="s">&quot;Dunk in the fryer.&quot;</span>;
   }
@@ -130,7 +130,7 @@ refresh your memory, Lox inheritance syntax looks like this:</p>
 <p>Here, the Cruller class inherits from Doughnut and thus, instances of Cruller
 inherit the <code>cook()</code> method. I don&rsquo;t know why I&rsquo;m belaboring this. You know how
 inheritance works. Let&rsquo;s start compiling the new syntax.</p>
-<div class="codehilite"><pre class="insert-before">  currentClass = &amp;classCompiler;
+<div class="codehilite" translate="no"><pre class="insert-before">  currentClass = &amp;classCompiler;
 
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>classDeclaration</em>()</div>
@@ -157,12 +157,12 @@ wires up the superclass to the new subclass. In the last chapter, we defined an
 its method table. This is similar<span class="em">&mdash;</span>the <code>OP_INHERIT</code> instruction takes an
 existing class and applies the effect of inheritance to it.</p>
 <p>In the previous example, when the compiler works through this bit of syntax:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Cruller</span> &lt; <span class="t">Doughnut</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Cruller</span> &lt; <span class="t">Doughnut</span> {
 </pre></div>
 <p>The result is this bytecode:</p><img src="image/superclasses/inherit-stack.png" alt="The series of bytecode instructions for a Cruller class inheriting from Doughnut." />
 <p>Before we implement the new <code>OP_INHERIT</code> instruction, we have an edge case to
 detect.</p>
-<div class="codehilite"><pre class="insert-before">    variable(false);
+<div class="codehilite" translate="no"><pre class="insert-before">    variable(false);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>classDeclaration</em>()</div>
 <pre class="insert">
@@ -185,7 +185,7 @@ anything <em>useful</em>, but I don&rsquo;t think it would cause a crash or infi
 </aside>
 <h3><a href="#executing-inheritance" id="executing-inheritance"><small>29&#8202;.&#8202;1&#8202;.&#8202;1</small>Executing inheritance</a></h3>
 <p>Now onto the new instruction.</p>
-<div class="codehilite"><pre class="insert-before">  OP_CLASS,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_CLASS,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_INHERIT</span>,
@@ -195,7 +195,7 @@ in enum <em>OpCode</em></div>
 
 <p>There are no operands to worry about. The two values we need<span class="em">&mdash;</span>superclass and
 subclass<span class="em">&mdash;</span>are both found on the stack. That means disassembling is easy.</p>
-<div class="codehilite"><pre class="insert-before">      return constantInstruction(&quot;OP_CLASS&quot;, chunk, offset);
+<div class="codehilite" translate="no"><pre class="insert-before">      return constantInstruction(&quot;OP_CLASS&quot;, chunk, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OP_INHERIT</span>:
@@ -205,7 +205,7 @@ in <em>disassembleInstruction</em>()</div>
 <div class="source-file-narrow"><em>debug.c</em>, in <em>disassembleInstruction</em>()</div>
 
 <p>The interpreter is where the action happens.</p>
-<div class="codehilite"><pre class="insert-before">        break;
+<div class="codehilite" translate="no"><pre class="insert-before">        break;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_INHERIT</span>: {
@@ -274,13 +274,13 @@ overwrite those inherited entries in the table.</p>
 <p>Our implementation is simple and fast, which is just the way I like my VM code.
 But it&rsquo;s not robust. Nothing prevents a user from inheriting from an object that
 isn&rsquo;t a class at all:</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="t">NotClass</span> = <span class="s">&quot;So not a class&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="t">NotClass</span> = <span class="s">&quot;So not a class&quot;</span>;
 <span class="k">class</span> <span class="t">OhNo</span> &lt; <span class="t">NotClass</span> {}
 </pre></div>
 <p>Obviously, no self-respecting programmer would write that, but we have to guard
 against potential Lox users who have no self respect. A simple runtime check
 fixes that.</p>
-<div class="codehilite"><pre class="insert-before">        Value superclass = peek(1);
+<div class="codehilite" translate="no"><pre class="insert-before">        Value superclass = peek(1);
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">        <span class="k">if</span> (!<span class="a">IS_CLASS</span>(<span class="i">superclass</span>)) {
@@ -311,7 +311,7 @@ calling it directly?</p>
 </aside>
 <p>Back in the halcyon days of jlox, I showed you <a href="inheritance.html#semantics">this tricky example</a> to
 explain the way super calls are dispatched:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">A</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">A</span> {
   <span class="i">method</span>() {
     <span class="k">print</span> <span class="s">&quot;A method&quot;</span>;
   }
@@ -343,7 +343,7 @@ lexical<span class="em">&mdash;</span>property of where the call occurs. When we
 we took advantage of that static aspect by storing the superclass in the same
 Environment structure we used for all lexical scopes. Almost as if the
 interpreter saw the above program like this:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">A</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">A</span> {
   <span class="i">method</span>() {
     <span class="k">print</span> <span class="s">&quot;A method&quot;</span>;
   }
@@ -376,7 +376,7 @@ the same.</p>
 <p>Our compiler already emits code to load the superclass onto the stack. Instead
 of leaving that slot as a temporary, we create a new scope and make it a local
 variable.</p>
-<div class="codehilite"><pre class="insert-before">    }
+<div class="codehilite" translate="no"><pre class="insert-before">    }
 
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>classDeclaration</em>()</div>
@@ -401,7 +401,7 @@ with a user-defined one.</p>
 token sitting around whose lexeme is &ldquo;this&rdquo;. We aren&rsquo;t so lucky here. Instead,
 we add a little helper function to create a synthetic token for the given <span
 name="constant">constant</span> string.</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>variable</em>()</div>
 <pre><span class="k">static</span> <span class="t">Token</span> <span class="i">syntheticToken</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">text</span>) {
   <span class="t">Token</span> <span class="i">token</span>;
@@ -420,7 +420,7 @@ in the executable&rsquo;s constant data section and never needs to be freed, so 
 fine.</p>
 </aside>
 <p>Since we opened a local scope for the superclass variable, we need to close it.</p>
-<div class="codehilite"><pre class="insert-before">  emitByte(OP_POP);
+<div class="codehilite" translate="no"><pre class="insert-before">  emitByte(OP_POP);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>classDeclaration</em>()</div>
 <pre class="insert">
@@ -443,7 +443,7 @@ there is one.</p>
 But soon, other functions in the compiler will need to know whether the
 surrounding class is a subclass or not. So we may as well give our future selves
 a hand and store this fact as a field in the ClassCompiler now.</p>
-<div class="codehilite"><pre class="insert-before">typedef struct ClassCompiler {
+<div class="codehilite" translate="no"><pre class="insert-before">typedef struct ClassCompiler {
   struct ClassCompiler* enclosing;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in struct <em>ClassCompiler</em></div>
@@ -453,7 +453,7 @@ in struct <em>ClassCompiler</em></div>
 <div class="source-file-narrow"><em>compiler.c</em>, in struct <em>ClassCompiler</em></div>
 
 <p>When we first initialize a ClassCompiler, we assume it is not a subclass.</p>
-<div class="codehilite"><pre class="insert-before">  ClassCompiler classCompiler;
+<div class="codehilite" translate="no"><pre class="insert-before">  ClassCompiler classCompiler;
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>classDeclaration</em>()</div>
 <pre class="insert">  <span class="i">classCompiler</span>.<span class="i">hasSuperclass</span> = <span class="k">false</span>;
@@ -462,7 +462,7 @@ in <em>classDeclaration</em>()</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>classDeclaration</em>()</div>
 
 <p>Then, if we see a superclass clause, we know we are compiling a subclass.</p>
-<div class="codehilite"><pre class="insert-before">    emitByte(OP_INHERIT);
+<div class="codehilite" translate="no"><pre class="insert-before">    emitByte(OP_INHERIT);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>classDeclaration</em>()</div>
 <pre class="insert">    <span class="i">classCompiler</span>.<span class="i">hasSuperclass</span> = <span class="k">true</span>;
@@ -483,7 +483,7 @@ name="last">begins</span>, naturally enough, with the <code>super</code> keyword
 <aside name="last">
 <p>This is it, friend. The very last entry you&rsquo;ll add to the parsing table.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">  [TOKEN_RETURN]        = {NULL,     NULL,   PREC_NONE},
+<div class="codehilite" translate="no"><pre class="insert-before">  [TOKEN_RETURN]        = {NULL,     NULL,   PREC_NONE},
 </pre><div class="source-file"><em>compiler.c</em><br>
 replace 1 line</div>
 <pre class="insert">  [<span class="a">TOKEN_SUPER</span>]         = {<span class="i">super_</span>,   <span class="a">NULL</span>,   <span class="a">PREC_NONE</span>},
@@ -493,7 +493,7 @@ replace 1 line</div>
 
 <p>When the expression parser lands on a <code>super</code> token, control jumps to a new
 parsing function which starts off like so:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>syntheticToken</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">super_</span>(<span class="t">bool</span> <span class="i">canAssign</span>) {
   <span class="i">consume</span>(<span class="a">TOKEN_DOT</span>, <span class="s">&quot;Expect &#39;.&#39; after &#39;super&#39;.&quot;</span>);
@@ -513,7 +513,7 @@ closure without invoking it:</p>
 <p>Hypothetical question: If a bare <code>super</code> token <em>was</em> an expression, what kind of
 object would it evaluate to?</p>
 </aside>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">A</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">A</span> {
   <span class="i">method</span>() {
     <span class="k">print</span> <span class="s">&quot;A&quot;</span>;
   }
@@ -533,7 +533,7 @@ then look for a method name. Methods are looked up dynamically, so we use
 <code>identifierConstant()</code> to take the lexeme of the method name token and store it
 in the constant table just like we do for property access expressions.</p>
 <p>Here is what the compiler does after consuming those tokens:</p>
-<div class="codehilite"><pre class="insert-before">  uint8_t name = identifierConstant(&amp;parser.previous);
+<div class="codehilite" translate="no"><pre class="insert-before">  uint8_t name = identifierConstant(&amp;parser.previous);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>super_</em>()</div>
 <pre class="insert">
@@ -554,7 +554,7 @@ variable and push that on top.</p>
 <p>Finally, we emit a new <code>OP_GET_SUPER</code> instruction with an operand for the
 constant table index of the method name. That&rsquo;s a lot to hold in your head. To
 make it tangible, consider this example program:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Doughnut</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Doughnut</span> {
   <span class="i">cook</span>() {
     <span class="k">print</span> <span class="s">&quot;Dunk in the fryer.&quot;</span>;
     <span class="k">this</span>.<span class="i">finish</span>(<span class="s">&quot;sprinkles&quot;</span>);
@@ -594,7 +594,7 @@ list and calling a function.</p>
 <p>We&rsquo;re almost ready to implement the new <code>OP_GET_SUPER</code> instruction in the
 interpreter. But before we do, the compiler has some errors it is responsible
 for reporting.</p>
-<div class="codehilite"><pre class="insert-before">static void super_(bool canAssign) {
+<div class="codehilite" translate="no"><pre class="insert-before">static void super_(bool canAssign) {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>super_</em>()</div>
 <pre class="insert">  <span class="k">if</span> (<span class="i">currentClass</span> == <span class="a">NULL</span>) {
@@ -615,7 +615,7 @@ that&rsquo;s <code>NULL</code> or points to a class with no superclass, we repor
 <p>Assuming the user didn&rsquo;t put a <code>super</code> expression where it&rsquo;s not allowed, their
 code passes from the compiler over to the runtime. We&rsquo;ve got ourselves a new
 instruction.</p>
-<div class="codehilite"><pre class="insert-before">  OP_SET_PROPERTY,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_SET_PROPERTY,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_GET_SUPER</span>,
@@ -624,7 +624,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>We disassemble it like other opcodes that take a constant table index operand.</p>
-<div class="codehilite"><pre class="insert-before">      return constantInstruction(&quot;OP_SET_PROPERTY&quot;, chunk, offset);
+<div class="codehilite" translate="no"><pre class="insert-before">      return constantInstruction(&quot;OP_SET_PROPERTY&quot;, chunk, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OP_GET_SUPER</span>:
@@ -635,7 +635,7 @@ in <em>disassembleInstruction</em>()</div>
 
 <p>You might anticipate something harder, but interpreting the new instruction is
 similar to executing a normal property access.</p>
-<div class="codehilite"><pre class="insert-before">      }
+<div class="codehilite" translate="no"><pre class="insert-before">      }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_GET_SUPER</span>: {
@@ -695,7 +695,7 @@ you invoke it immediately or not.</p>
 parenthesis after the superclass method name, so we&rsquo;ll go ahead and perform the
 same optimization we did for method calls. Take out the two lines of code that
 load the superclass and emit <code>OP_GET_SUPER</code>, and replace them with this:</p>
-<div class="codehilite"><pre class="insert-before">  namedVariable(syntheticToken(&quot;this&quot;), false);
+<div class="codehilite" translate="no"><pre class="insert-before">  namedVariable(syntheticToken(&quot;this&quot;), false);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>super_</em>()<br>
 replace 2 lines</div>
@@ -725,7 +725,7 @@ I<span class="ellipse">&thinsp;.&thinsp;.&thinsp;.&nbsp;</span>I&rsquo;m sorry f
 <p>Otherwise, if we don&rsquo;t find a <code>(</code>, we continue to compile the expression as a
 super access like we did before and emit an <code>OP_GET_SUPER</code>.</p>
 <p>Drifting down the compilation pipeline, our first stop is a new instruction.</p>
-<div class="codehilite"><pre class="insert-before">  OP_INVOKE,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_INVOKE,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_SUPER_INVOKE</span>,
@@ -734,7 +734,7 @@ in enum <em>OpCode</em></div>
 <div class="source-file-narrow"><em>chunk.h</em>, in enum <em>OpCode</em></div>
 
 <p>And just past that, its disassembler support.</p>
-<div class="codehilite"><pre class="insert-before">      return invokeInstruction(&quot;OP_INVOKE&quot;, chunk, offset);
+<div class="codehilite" translate="no"><pre class="insert-before">      return invokeInstruction(&quot;OP_INVOKE&quot;, chunk, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">OP_SUPER_INVOKE</span>:
@@ -746,7 +746,7 @@ in <em>disassembleInstruction</em>()</div>
 <p>A super invocation instruction has the same set of operands as <code>OP_INVOKE</code>, so
 we reuse the same helper to disassemble it. Finally, the pipeline dumps us into
 the interpreter.</p>
-<div class="codehilite"><pre class="insert-before">        break;
+<div class="codehilite" translate="no"><pre class="insert-before">        break;
       }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
@@ -870,7 +870,7 @@ there is no matching method, the <code>inner</code> call does nothing.</p>
 </li>
 </ul>
 <p>For example:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Doughnut</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Doughnut</span> {
   <span class="i">cook</span>() {
     <span class="k">print</span> <span class="s">&quot;Fry until golden brown.&quot;</span>;
     <span class="i">inner</span>();
@@ -887,7 +887,7 @@ there is no matching method, the <code>inner</code> call does nothing.</p>
 <span class="t">BostonCream</span>().<span class="i">cook</span>();
 </pre></div>
 <p>This should print:</p>
-<div class="codehilite"><pre>Fry until golden brown.
+<div class="codehilite" translate="no"><pre>Fry until golden brown.
 Pipe full of custard and coat with chocolate.
 Place in a nice box.
 </pre></div>

--- a/site/the-lox-language.html
+++ b/site/the-lox-language.html
@@ -128,7 +128,7 @@ don&rsquo;t have a Lox interpreter yet, since you haven&rsquo;t built one!</p>
 <p>Your first taste of Lox, the language, that is. I don&rsquo;t know if you&rsquo;ve ever had
 the cured, cold-smoked salmon before. If not, give it a try too.</p>
 </aside>
-<div class="codehilite"><pre><span class="c">// Your first Lox program!</span>
+<div class="codehilite" translate="no"><pre><span class="c">// Your first Lox program!</span>
 <span class="k">print</span> <span class="s">&quot;Hello, world!&quot;</span>;
 </pre></div>
 <p>As that <code>//</code> line comment and the trailing semicolon imply, Lox&rsquo;s syntax is a
@@ -230,7 +230,7 @@ wonder what he&rsquo;d think to see his name all over billions of lines of Java
 code.</p>
 </aside>
 <p>There are two Boolean values, obviously, and a literal for each one.</p>
-<div class="codehilite"><pre><span class="k">true</span>;  <span class="c">// Not false.</span>
+<div class="codehilite" translate="no"><pre><span class="k">true</span>;  <span class="c">// Not false.</span>
 <span class="k">false</span>; <span class="c">// Not *not* false.</span>
 </pre></div>
 </li>
@@ -241,14 +241,14 @@ integers, that covers a lot of territory, while keeping things simple.</p>
 <p>Full-featured languages have lots of syntax for numbers<span class="em">&mdash;</span>hexadecimal,
 scientific notation, octal, all sorts of fun stuff. We&rsquo;ll settle for basic
 integer and decimal literals.</p>
-<div class="codehilite"><pre><span class="n">1234</span>;  <span class="c">// An integer.</span>
+<div class="codehilite" translate="no"><pre><span class="n">1234</span>;  <span class="c">// An integer.</span>
 <span class="n">12.34</span>; <span class="c">// A decimal number.</span>
 </pre></div>
 </li>
 <li>
 <p><strong>Strings.</strong> We&rsquo;ve already seen one string literal in the first example.
 Like most languages, they are enclosed in double quotes.</p>
-<div class="codehilite"><pre><span class="s">&quot;I am a string&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="s">&quot;I am a string&quot;</span>;
 <span class="s">&quot;&quot;</span>;    <span class="c">// The empty string.</span>
 <span class="s">&quot;123&quot;</span>; <span class="c">// This is a string, not a number.</span>
 </pre></div>
@@ -279,7 +279,7 @@ be the molecules. Most of these will be familiar.</p>
 <h3><a href="#arithmetic" id="arithmetic"><small>3&#8202;.&#8202;4&#8202;.&#8202;1</small>Arithmetic</a></h3>
 <p>Lox features the basic arithmetic operators you know and love from C and other
 languages:</p>
-<div class="codehilite"><pre><span class="i">add</span> + <span class="i">me</span>;
+<div class="codehilite" translate="no"><pre><span class="i">add</span> + <span class="i">me</span>;
 <span class="i">subtract</span> - <span class="i">me</span>;
 <span class="i">multiply</span> * <span class="i">me</span>;
 <span class="i">divide</span> / <span class="i">me</span>;
@@ -294,14 +294,14 @@ operator comes before the operands, and <strong>postfix</strong> where it comes 
 <p>There are some operators that have more than two operands and the operators are
 interleaved between them. The only one in wide usage is the &ldquo;conditional&rdquo; or
 &ldquo;ternary&rdquo; operator of C and friends:</p>
-<div class="codehilite"><pre><span class="i">condition</span> ? <span class="i">thenArm</span> : <span class="i">elseArm</span>;
+<div class="codehilite" translate="no"><pre><span class="i">condition</span> ? <span class="i">thenArm</span> : <span class="i">elseArm</span>;
 </pre></div>
 <p>Some call these <strong>mixfix</strong> operators. A few languages let you define your own
 operators and control how they are positioned<span class="em">&mdash;</span>their &ldquo;fixity&rdquo;.</p>
 </aside>
 <p>One arithmetic operator is actually <em>both</em> an infix and a prefix one. The <code>-</code>
 operator can also be used to negate a number.</p>
-<div class="codehilite"><pre>-<span class="i">negateMe</span>;
+<div class="codehilite" translate="no"><pre>-<span class="i">negateMe</span>;
 </pre></div>
 <p>All of these operators work on numbers, and it&rsquo;s an error to pass any other
 types to them. The exception is the <code>+</code> operator<span class="em">&mdash;</span>you can also pass it two
@@ -309,38 +309,38 @@ strings to concatenate them.</p>
 <h3><a href="#comparison-and-equality" id="comparison-and-equality"><small>3&#8202;.&#8202;4&#8202;.&#8202;2</small>Comparison and equality</a></h3>
 <p>Moving along, we have a few more operators that always return a Boolean result.
 We can compare numbers (and only numbers), using Ye Olde Comparison Operators.</p>
-<div class="codehilite"><pre><span class="i">less</span> &lt; <span class="i">than</span>;
+<div class="codehilite" translate="no"><pre><span class="i">less</span> &lt; <span class="i">than</span>;
 <span class="i">lessThan</span> &lt;= <span class="i">orEqual</span>;
 <span class="i">greater</span> &gt; <span class="i">than</span>;
 <span class="i">greaterThan</span> &gt;= <span class="i">orEqual</span>;
 </pre></div>
 <p>We can test two values of any kind for equality or inequality.</p>
-<div class="codehilite"><pre><span class="n">1</span> == <span class="n">2</span>;         <span class="c">// false.</span>
+<div class="codehilite" translate="no"><pre><span class="n">1</span> == <span class="n">2</span>;         <span class="c">// false.</span>
 <span class="s">&quot;cat&quot;</span> != <span class="s">&quot;dog&quot;</span>; <span class="c">// true.</span>
 </pre></div>
 <p>Even different types.</p>
-<div class="codehilite"><pre><span class="n">314</span> == <span class="s">&quot;pi&quot;</span>; <span class="c">// false.</span>
+<div class="codehilite" translate="no"><pre><span class="n">314</span> == <span class="s">&quot;pi&quot;</span>; <span class="c">// false.</span>
 </pre></div>
 <p>Values of different types are <em>never</em> equivalent.</p>
-<div class="codehilite"><pre><span class="n">123</span> == <span class="s">&quot;123&quot;</span>; <span class="c">// false.</span>
+<div class="codehilite" translate="no"><pre><span class="n">123</span> == <span class="s">&quot;123&quot;</span>; <span class="c">// false.</span>
 </pre></div>
 <p>I&rsquo;m generally against implicit conversions.</p>
 <h3><a href="#logical-operators" id="logical-operators"><small>3&#8202;.&#8202;4&#8202;.&#8202;3</small>Logical operators</a></h3>
 <p>The not operator, a prefix <code>!</code>, returns <code>false</code> if its operand is true, and vice
 versa.</p>
-<div class="codehilite"><pre>!<span class="k">true</span>;  <span class="c">// false.</span>
+<div class="codehilite" translate="no"><pre>!<span class="k">true</span>;  <span class="c">// false.</span>
 !<span class="k">false</span>; <span class="c">// true.</span>
 </pre></div>
 <p>The other two logical operators really are control flow constructs in the guise
 of expressions. An <span name="and"><code>and</code></span> expression determines if two
 values are <em>both</em> true. It returns the left operand if it&rsquo;s false, or the
 right operand otherwise.</p>
-<div class="codehilite"><pre><span class="k">true</span> <span class="k">and</span> <span class="k">false</span>; <span class="c">// false.</span>
+<div class="codehilite" translate="no"><pre><span class="k">true</span> <span class="k">and</span> <span class="k">false</span>; <span class="c">// false.</span>
 <span class="k">true</span> <span class="k">and</span> <span class="k">true</span>;  <span class="c">// true.</span>
 </pre></div>
 <p>And an <code>or</code> expression determines if <em>either</em> of two values (or both) are true.
 It returns the left operand if it is true and the right operand otherwise.</p>
-<div class="codehilite"><pre><span class="k">false</span> <span class="k">or</span> <span class="k">false</span>; <span class="c">// false.</span>
+<div class="codehilite" translate="no"><pre><span class="k">false</span> <span class="k">or</span> <span class="k">false</span>; <span class="c">// false.</span>
 <span class="k">true</span> <span class="k">or</span> <span class="k">false</span>;  <span class="c">// true.</span>
 </pre></div>
 <aside name="and">
@@ -360,7 +360,7 @@ skipped.</p>
 expect coming from C. (When we get to parsing, we&rsquo;ll get <em>way</em> more precise
 about that.) In cases where the precedence isn&rsquo;t what you want, you can use <code>()</code>
 to group stuff.</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">average</span> = (<span class="i">min</span> + <span class="i">max</span>) / <span class="n">2</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">average</span> = (<span class="i">min</span> + <span class="i">max</span>) / <span class="n">2</span>;
 </pre></div>
 <p>Since they aren&rsquo;t very technically interesting, I&rsquo;ve cut the remainder of the
 typical operator menagerie out of our little language. No bitwise, shift,
@@ -374,7 +374,7 @@ a statement&rsquo;s job is to produce an <em>effect</em>. Since, by definition, 
 don&rsquo;t evaluate to a value, to be useful they have to otherwise change the world
 in some way<span class="em">&mdash;</span>usually modifying some state, reading input, or producing output.</p>
 <p>You&rsquo;ve seen a couple of kinds of statements already. The first one was:</p>
-<div class="codehilite"><pre><span class="k">print</span> <span class="s">&quot;Hello, world!&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">print</span> <span class="s">&quot;Hello, world!&quot;</span>;
 </pre></div>
 <p>A <span name="print"><code>print</code> statement</span> evaluates a single expression
 and displays the result to the user. You&rsquo;ve also seen some statements like:</p>
@@ -384,14 +384,14 @@ function is a hack. But it&rsquo;s a <em>useful</em> hack for us: it means our i
 interpreter can start producing output before we&rsquo;ve implemented all of the
 machinery required to define functions, look them up by name, and call them.</p>
 </aside>
-<div class="codehilite"><pre><span class="s">&quot;some expression&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="s">&quot;some expression&quot;</span>;
 </pre></div>
 <p>An expression followed by a semicolon (<code>;</code>) promotes the expression to
 statement-hood. This is called (imaginatively enough), an <strong>expression
 statement</strong>.</p>
 <p>If you want to pack a series of statements where a single one is expected, you
 can wrap them up in a <strong>block</strong>.</p>
-<div class="codehilite"><pre>{
+<div class="codehilite" translate="no"><pre>{
   <span class="k">print</span> <span class="s">&quot;One statement.&quot;</span>;
   <span class="k">print</span> <span class="s">&quot;Two statements.&quot;</span>;
 }
@@ -405,12 +405,12 @@ name="omit">omit</span> the initializer, the variable&rsquo;s value defaults to 
 be initialized to some value would be more annoying than dealing with <code>nil</code>
 itself.</p>
 </aside>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">imAVariable</span> = <span class="s">&quot;here is my value&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">imAVariable</span> = <span class="s">&quot;here is my value&quot;</span>;
 <span class="k">var</span> <span class="i">iAmNil</span>;
 </pre></div>
 <p>Once declared, you can, naturally, access and assign a variable using its name.</p>
 <p><span name="breakfast"></span></p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">breakfast</span> = <span class="s">&quot;bagels&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">breakfast</span> = <span class="s">&quot;bagels&quot;</span>;
 <span class="k">print</span> <span class="i">breakfast</span>; <span class="c">// &quot;bagels&quot;.</span>
 <span class="i">breakfast</span> = <span class="s">&quot;beignets&quot;</span>;
 <span class="k">print</span> <span class="i">breakfast</span>; <span class="c">// &quot;beignets&quot;.</span>
@@ -436,7 +436,7 @@ recursion for repetition. Smalltalk has no built-in branching constructs, and
 relies on dynamic dispatch for selectively executing code.</p>
 </aside>
 <p>An <code>if</code> statement executes one of two statements based on some condition.</p>
-<div class="codehilite"><pre><span class="k">if</span> (<span class="i">condition</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">if</span> (<span class="i">condition</span>) {
   <span class="k">print</span> <span class="s">&quot;yes&quot;</span>;
 } <span class="k">else</span> {
   <span class="k">print</span> <span class="s">&quot;no&quot;</span>;
@@ -444,7 +444,7 @@ relies on dynamic dispatch for selectively executing code.</p>
 </pre></div>
 <p>A <code>while</code> <span name="do">loop</span> executes the body repeatedly as long as
 the condition expression evaluates to true.</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>;
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>;
 <span class="k">while</span> (<span class="i">a</span> &lt; <span class="n">10</span>) {
   <span class="k">print</span> <span class="i">a</span>;
   <span class="i">a</span> = <span class="i">a</span> + <span class="n">1</span>;
@@ -456,7 +456,7 @@ teach you anything that you won&rsquo;t already learn from <code>while</code>. G
 it to your implementation if it makes you happy. It&rsquo;s your party.</p>
 </aside>
 <p>Finally, we have <code>for</code> loops.</p>
-<div class="codehilite"><pre><span class="k">for</span> (<span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>; <span class="i">a</span> &lt; <span class="n">10</span>; <span class="i">a</span> = <span class="i">a</span> + <span class="n">1</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">for</span> (<span class="k">var</span> <span class="i">a</span> = <span class="n">1</span>; <span class="i">a</span> &lt; <span class="n">10</span>; <span class="i">a</span> = <span class="i">a</span> + <span class="n">1</span>) {
   <span class="k">print</span> <span class="i">a</span>;
 }
 </pre></div>
@@ -474,10 +474,10 @@ later, but I didn&rsquo;t think doing so would teach you anything super interest
 </aside>
 <h2><a href="#functions" id="functions"><small>3&#8202;.&#8202;8</small>Functions</a></h2>
 <p>A function call expression looks the same as it does in C.</p>
-<div class="codehilite"><pre><span class="i">makeBreakfast</span>(<span class="i">bacon</span>, <span class="i">eggs</span>, <span class="i">toast</span>);
+<div class="codehilite" translate="no"><pre><span class="i">makeBreakfast</span>(<span class="i">bacon</span>, <span class="i">eggs</span>, <span class="i">toast</span>);
 </pre></div>
 <p>You can also call a function without passing anything to it.</p>
-<div class="codehilite"><pre><span class="i">makeBreakfast</span>();
+<div class="codehilite" translate="no"><pre><span class="i">makeBreakfast</span>();
 </pre></div>
 <p>Unlike in, say, Ruby, the parentheses are mandatory in this case. If you leave them
 off, the name doesn&rsquo;t <em>call</em> the function, it just refers to it.</p>
@@ -487,7 +487,7 @@ that with <span name="fun"><code>fun</code></span>.</p>
 <p>I&rsquo;ve seen languages that use <code>fn</code>, <code>fun</code>, <code>func</code>, and <code>function</code>. I&rsquo;m still
 hoping to discover a <code>funct</code>, <code>functi</code>, or <code>functio</code> somewhere.</p>
 </aside>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">printSum</span>(<span class="i">a</span>, <span class="i">b</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">printSum</span>(<span class="i">a</span>, <span class="i">b</span>) {
   <span class="k">print</span> <span class="i">a</span> + <span class="i">b</span>;
 }
 </pre></div>
@@ -518,7 +518,7 @@ declaration fully specifies the function including its body.</p>
 </aside>
 <p>The body of a function is always a block. Inside it, you can return a value
 using a <code>return</code> statement.</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">returnSum</span>(<span class="i">a</span>, <span class="i">b</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">returnSum</span>(<span class="i">a</span>, <span class="i">b</span>) {
   <span class="k">return</span> <span class="i">a</span> + <span class="i">b</span>;
 }
 </pre></div>
@@ -530,7 +530,7 @@ using a <code>return</code> statement.</p>
 <h3><a href="#closures" id="closures"><small>3&#8202;.&#8202;8&#8202;.&#8202;1</small>Closures</a></h3>
 <p>Functions are <em>first class</em> in Lox, which just means they are real values that
 you can get a reference to, store in variables, pass around, etc. This works:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">addPair</span>(<span class="i">a</span>, <span class="i">b</span>) {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">addPair</span>(<span class="i">a</span>, <span class="i">b</span>) {
   <span class="k">return</span> <span class="i">a</span> + <span class="i">b</span>;
 }
 
@@ -542,7 +542,7 @@ you can get a reference to, store in variables, pass around, etc. This works:</p
 </pre></div>
 <p>Since function declarations are statements, you can declare local functions
 inside another function.</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">outerFunction</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">outerFunction</span>() {
   <span class="k">fun</span> <span class="i">localFunction</span>() {
     <span class="k">print</span> <span class="s">&quot;I&#39;m local!&quot;</span>;
   }
@@ -552,7 +552,7 @@ inside another function.</p>
 </pre></div>
 <p>If you combine local functions, first-class functions, and block scope, you run
 into this interesting situation:</p>
-<div class="codehilite"><pre><span class="k">fun</span> <span class="i">returnFunction</span>() {
+<div class="codehilite" translate="no"><pre><span class="k">fun</span> <span class="i">returnFunction</span>() {
   <span class="k">var</span> <span class="i">outside</span> = <span class="s">&quot;outside&quot;</span>;
 
   <span class="k">fun</span> <span class="i">inner</span>() {
@@ -674,7 +674,7 @@ metaprogramming libraries.</p>
 <p>Enough rationale, let&rsquo;s see what we actually have. Classes encompass a
 constellation of features in most languages. For Lox, I&rsquo;ve selected what I think
 are the brightest stars. You declare a class and its methods like so:</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Breakfast</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Breakfast</span> {
   <span class="i">cook</span>() {
     <span class="k">print</span> <span class="s">&quot;Eggs a-fryin&#39;!&quot;</span>;
   }
@@ -692,7 +692,7 @@ Lox.</p>
 <aside name="method">
 <p>They are still just as fun, though.</p>
 </aside>
-<div class="codehilite"><pre><span class="c">// Store it in variables.</span>
+<div class="codehilite" translate="no"><pre><span class="c">// Store it in variables.</span>
 <span class="k">var</span> <span class="i">someVariable</span> = <span class="t">Breakfast</span>;
 
 <span class="c">// Pass it to functions.</span>
@@ -702,7 +702,7 @@ Lox.</p>
 keyword, but to keep things simple, in Lox the class itself is a factory
 function for instances. Call a class like a function, and it produces a new
 instance of itself.</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">breakfast</span> = <span class="t">Breakfast</span>();
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">breakfast</span> = <span class="t">Breakfast</span>();
 <span class="k">print</span> <span class="i">breakfast</span>; <span class="c">// &quot;Breakfast instance&quot;.</span>
 </pre></div>
 <h3><a href="#instantiation-and-initialization" id="instantiation-and-initialization"><small>3&#8202;.&#8202;9&#8202;.&#8202;5</small>Instantiation and initialization</a></h3>
@@ -710,13 +710,13 @@ instance of itself.</p>
 object-oriented programming is encapsulating behavior <em>and state</em> together. To
 do that, you need fields. Lox, like other dynamically typed languages, lets you
 freely add properties onto objects.</p>
-<div class="codehilite"><pre><span class="i">breakfast</span>.<span class="i">meat</span> = <span class="s">&quot;sausage&quot;</span>;
+<div class="codehilite" translate="no"><pre><span class="i">breakfast</span>.<span class="i">meat</span> = <span class="s">&quot;sausage&quot;</span>;
 <span class="i">breakfast</span>.<span class="i">bread</span> = <span class="s">&quot;sourdough&quot;</span>;
 </pre></div>
 <p>Assigning to a field creates it if it doesn&rsquo;t already exist.</p>
 <p>If you want to access a field or method on the current object from within a
 method, you use good old <code>this</code>.</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Breakfast</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Breakfast</span> {
   <span class="i">serve</span>(<span class="i">who</span>) {
     <span class="k">print</span> <span class="s">&quot;Enjoy your &quot;</span> + <span class="k">this</span>.<span class="i">meat</span> + <span class="s">&quot; and &quot;</span> +
         <span class="k">this</span>.<span class="i">bread</span> + <span class="s">&quot;, &quot;</span> + <span class="i">who</span> + <span class="s">&quot;.&quot;</span>;
@@ -730,7 +730,7 @@ state when it&rsquo;s created. To do that, you can define an initializer. If you
 class has a method named <code>init()</code>, it is called automatically when the object is
 constructed. Any parameters passed to the class are forwarded to its
 initializer.</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Breakfast</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Breakfast</span> {
   <span class="i">init</span>(<span class="i">meat</span>, <span class="i">bread</span>) {
     <span class="k">this</span>.<span class="i">meat</span> = <span class="i">meat</span>;
     <span class="k">this</span>.<span class="i">bread</span> = <span class="i">bread</span>;
@@ -748,7 +748,7 @@ initializer.</p>
 across multiple classes or objects. For that, Lox supports single inheritance.
 When you declare a class, you can specify a class that it inherits from using a less-than
 <span name="less">(<code>&lt;</code>)</span> operator.</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Brunch</span> &lt; <span class="t">Breakfast</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Brunch</span> &lt; <span class="t">Breakfast</span> {
   <span class="i">drink</span>() {
     <span class="k">print</span> <span class="s">&quot;How about a Bloody Mary?&quot;</span>;
   }
@@ -767,7 +767,7 @@ than the superclass&rsquo;s set, though type nerds usually use <code>&lt;:</code
 <p>Here, Brunch is the <strong>derived class</strong> or <strong>subclass</strong>, and Breakfast is the
 <strong>base class</strong> or <strong>superclass</strong>.</p>
 <p>Every method defined in the superclass is also available to its subclasses.</p>
-<div class="codehilite"><pre><span class="k">var</span> <span class="i">benedict</span> = <span class="t">Brunch</span>(<span class="s">&quot;ham&quot;</span>, <span class="s">&quot;English muffin&quot;</span>);
+<div class="codehilite" translate="no"><pre><span class="k">var</span> <span class="i">benedict</span> = <span class="t">Brunch</span>(<span class="s">&quot;ham&quot;</span>, <span class="s">&quot;English muffin&quot;</span>);
 <span class="i">benedict</span>.<span class="i">serve</span>(<span class="s">&quot;Noble Reader&quot;</span>);
 </pre></div>
 <p>Even the <code>init()</code> method gets <span name="init">inherited</span>. In practice,
@@ -780,7 +780,7 @@ our own <em>methods</em>.</p>
 similar to Smalltalk and Ruby, which do.</p>
 </aside>
 <p>As in Java, you use <code>super</code> for that.</p>
-<div class="codehilite"><pre><span class="k">class</span> <span class="t">Brunch</span> &lt; <span class="t">Breakfast</span> {
+<div class="codehilite" translate="no"><pre><span class="k">class</span> <span class="t">Brunch</span> &lt; <span class="t">Breakfast</span> {
   <span class="i">init</span>(<span class="i">meat</span>, <span class="i">bread</span>, <span class="i">drink</span>) {
     <span class="k">super</span>.<span class="i">init</span>(<span class="i">meat</span>, <span class="i">bread</span>);
     <span class="k">this</span>.<span class="i">drink</span> = <span class="i">drink</span>;
@@ -864,7 +864,7 @@ array.</p>
 <p>You also have to decide how these statement-like expressions compose with other
 expressions<span class="em">&mdash;</span>you have to fit them into the grammar&rsquo;s precedence table. For
 example, Ruby allows:</p>
-<div class="codehilite"><pre><span class="i">puts</span> <span class="n">1</span> + <span class="k">if</span> <span class="k">true</span> <span class="k">then</span> <span class="n">2</span> <span class="k">else</span> <span class="n">3</span> <span class="k">end</span> + <span class="n">4</span>
+<div class="codehilite" translate="no"><pre><span class="i">puts</span> <span class="n">1</span> + <span class="k">if</span> <span class="k">true</span> <span class="k">then</span> <span class="n">2</span> <span class="k">else</span> <span class="n">3</span> <span class="k">end</span> + <span class="n">4</span>
 </pre></div>
 <p>Is this what you&rsquo;d expect? Is it what your <em>users</em> expect? How does this affect
 how you design the syntax for your &ldquo;statements&rdquo;? Note that Ruby has an explicit

--- a/site/types-of-values.html
+++ b/site/types-of-values.html
@@ -140,7 +140,7 @@ pack the above information into as few bits as possible. For now, we&rsquo;ll st
 with the simplest, classic solution: a <strong>tagged union</strong>. A value contains two
 parts: a type &ldquo;tag&rdquo;, and a payload for the actual value. To store the value&rsquo;s
 type, we define an enum for each kind of value the VM supports.</p>
-<div class="codehilite"><pre class="insert-before">#include &quot;common.h&quot;
+<div class="codehilite" translate="no"><pre class="insert-before">#include &quot;common.h&quot;
 
 </pre><div class="source-file"><em>value.h</em></div>
 <pre class="insert"><span class="k">typedef</span> <span class="k">enum</span> {
@@ -186,7 +186,7 @@ unsafe and will happily saw your fingers off if you don&rsquo;t watch out.</p>
 </aside>
 <p>As the name &ldquo;tagged union&rdquo; implies, our new value representation combines these
 two parts into a single struct.</p>
-<div class="codehilite"><pre class="insert-before">} ValueType;
+<div class="codehilite" translate="no"><pre class="insert-before">} ValueType;
 
 </pre><div class="source-file"><em>value.h</em><br>
 add after enum <em>ValueType</em><br>
@@ -242,7 +242,7 @@ other. We need to go through the code and insert those conversions to get clox
 working again.</p>
 <p>We&rsquo;ll implement these conversions as a handful of macros, one for each type and
 operation. First, to promote a native C value to a clox Value:</p>
-<div class="codehilite"><pre class="insert-before">} Value;
+<div class="codehilite" translate="no"><pre class="insert-before">} Value;
 </pre><div class="source-file"><em>value.h</em><br>
 add after struct <em>Value</em></div>
 <pre class="insert">
@@ -261,7 +261,7 @@ that has the correct type tag and contains the underlying value. This hoists
 statically typed values up into clox&rsquo;s dynamically typed universe. In order to
 <em>do</em> anything with a Value, though, we need to unpack it and get the C value
 back out.</p>
-<div class="codehilite"><pre class="insert-before">} Value;
+<div class="codehilite" translate="no"><pre class="insert-before">} Value;
 </pre><div class="source-file"><em>value.h</em><br>
 add after struct <em>Value</em></div>
 <pre class="insert">
@@ -282,13 +282,13 @@ type <code>VAL_NIL</code> doesn&rsquo;t carry any extra data.</p>
 Value of the right type, they unwrap it and return the corresponding raw C
 value. The &ldquo;right type&rdquo; part is important! These macros directly access the
 union fields. If we were to do something like:</p>
-<div class="codehilite"><pre><span class="t">Value</span> <span class="i">value</span> = <span class="a">BOOL_VAL</span>(<span class="k">true</span>);
+<div class="codehilite" translate="no"><pre><span class="t">Value</span> <span class="i">value</span> = <span class="a">BOOL_VAL</span>(<span class="k">true</span>);
 <span class="t">double</span> <span class="i">number</span> = <span class="a">AS_NUMBER</span>(<span class="i">value</span>);
 </pre></div>
 <p>Then we may open a smoldering portal to the Shadow Realm. It&rsquo;s not safe to use
 any of the <code>AS_</code> macros unless we know the Value contains the appropriate type.
 To that end, we define a last few macros to check a Value&rsquo;s type.</p>
-<div class="codehilite"><pre class="insert-before">} Value;
+<div class="codehilite" translate="no"><pre class="insert-before">} Value;
 </pre><div class="source-file"><em>value.h</em><br>
 add after struct <em>Value</em></div>
 <pre class="insert">
@@ -319,7 +319,7 @@ single line of code, so here we are.</p>
 <p>The first values we create are the constants generated when we compile number
 literals. After we convert the lexeme to a C double, we simply wrap it in a
 Value before storing it in the constant table.</p>
-<div class="codehilite"><pre class="insert-before">  double value = strtod(parser.previous.start, NULL);
+<div class="codehilite" translate="no"><pre class="insert-before">  double value = strtod(parser.previous.start, NULL);
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>number</em>()<br>
 replace 1 line</div>
@@ -329,7 +329,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, in <em>number</em>(), replace 1 line</div>
 
 <p>Over in the runtime, we have a function to print values.</p>
-<div class="codehilite"><pre class="insert-before">void printValue(Value value) {
+<div class="codehilite" translate="no"><pre class="insert-before">void printValue(Value value) {
 </pre><div class="source-file"><em>value.c</em><br>
 in <em>printValue</em>()<br>
 replace 1 line</div>
@@ -345,13 +345,13 @@ let&rsquo;s get our existing code working first.</p>
 <p>The next simplest operation is unary negation. It pops a value off the stack,
 negates it, and pushes the result. Now that we have other types of values, we
 can&rsquo;t assume the operand is a number anymore. The user could just as well do:</p>
-<div class="codehilite"><pre><span class="k">print</span> -<span class="k">false</span>; <span class="c">// Uh...</span>
+<div class="codehilite" translate="no"><pre><span class="k">print</span> -<span class="k">false</span>; <span class="c">// Uh...</span>
 </pre></div>
 <p>We need to handle that gracefully, which means it&rsquo;s time for <em>runtime errors</em>.
 Before performing an operation that requires a certain type, we need to make
 sure the Value <em>is</em> that type.</p>
 <p>For unary negation, the check looks like this:</p>
-<div class="codehilite"><pre class="insert-before">      case OP_DIVIDE:   BINARY_OP(/); break;
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_DIVIDE:   BINARY_OP(/); break;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
 replace 1 line</div>
@@ -377,7 +377,7 @@ an error. If Lox were a real language, this is one of the first things I would
 remedy.</p>
 </aside>
 <p>To access the Value, we use a new little function.</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>pop</em>()</div>
 <pre><span class="k">static</span> <span class="t">Value</span> <span class="i">peek</span>(<span class="t">int</span> <span class="i">distance</span>) {
   <span class="k">return</span> <span class="i">vm</span>.<span class="i">stackTop</span>[-<span class="n">1</span> - <span class="i">distance</span>];
@@ -396,7 +396,7 @@ the operation. I do the same thing here mostly out of habit.</p>
 </aside>
 <p>We report the runtime error using a new function that we&rsquo;ll get a lot of mileage
 out of over the remainder of the book.</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>resetStack</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">runtimeError</span>(<span class="k">const</span> <span class="t">char</span>* <span class="i">format</span>, ...) {
   <span class="t">va_list</span> <span class="i">args</span>;
@@ -447,7 +447,7 @@ call yet, so there is no call stack to trace.</p>
 </aside>
 <p>In order to use <code>va_list</code> and the macros for working with it, we need to bring
 in a standard header.</p>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add to top of file</div>
 <pre class="insert"><span class="a">#include &lt;stdarg.h&gt;</span>
 </pre><pre class="insert-after">#include &lt;stdio.h&gt;
@@ -467,7 +467,7 @@ the operator token as a parameter.</p>
 <p>That macro seemed like overkill a <a href="a-virtual-machine.html#binary-operators">few chapters ago</a>, but we get the benefit
 from it today. It lets us add the necessary type checking and conversions in one
 place.</p>
-<div class="codehilite"><pre class="insert-before">#define READ_CONSTANT() (vm.chunk-&gt;constants.values[READ_BYTE()])
+<div class="codehilite" translate="no"><pre class="insert-before">#define READ_CONSTANT() (vm.chunk-&gt;constants.values[READ_BYTE()])
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
 replace 6 lines</div>
@@ -500,7 +500,7 @@ existing arithmetic operators, the result is a number, so we pass in the
 <aside name="macro">
 <p>Did you know you can pass macros as parameters to macros? Now you do!</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">      }
+<div class="codehilite" translate="no"><pre class="insert-before">      }
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()<br>
 replace 4 lines</div>
@@ -543,7 +543,7 @@ loading 0.0, 1.0, 2.0, and the integer values from -1 through 5. (This ends up
 being a vestigial optimization given that most mature JVMs now JIT-compile the
 bytecode to machine code before execution anyway.)</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">  OP_CONSTANT,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_CONSTANT,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_NIL</span>,
@@ -557,7 +557,7 @@ in enum <em>OpCode</em></div>
 skip right to the parser. With our table-based Pratt parser, we just need to
 slot parser functions into the rows associated with those keyword token types.
 We&rsquo;ll use the same function in all three slots. Here:</p>
-<div class="codehilite"><pre class="insert-before">  [TOKEN_ELSE]          = {NULL,     NULL,   PREC_NONE},
+<div class="codehilite" translate="no"><pre class="insert-before">  [TOKEN_ELSE]          = {NULL,     NULL,   PREC_NONE},
 </pre><div class="source-file"><em>compiler.c</em><br>
 replace 1 line</div>
 <pre class="insert">  [<span class="a">TOKEN_FALSE</span>]         = {<span class="i">literal</span>,  <span class="a">NULL</span>,   <span class="a">PREC_NONE</span>},
@@ -566,7 +566,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, replace 1 line</div>
 
 <p>Here:</p>
-<div class="codehilite"><pre class="insert-before">  [TOKEN_THIS]          = {NULL,     NULL,   PREC_NONE},
+<div class="codehilite" translate="no"><pre class="insert-before">  [TOKEN_THIS]          = {NULL,     NULL,   PREC_NONE},
 </pre><div class="source-file"><em>compiler.c</em><br>
 replace 1 line</div>
 <pre class="insert">  [<span class="a">TOKEN_TRUE</span>]          = {<span class="i">literal</span>,  <span class="a">NULL</span>,   <span class="a">PREC_NONE</span>},
@@ -575,7 +575,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, replace 1 line</div>
 
 <p>And here:</p>
-<div class="codehilite"><pre class="insert-before">  [TOKEN_IF]            = {NULL,     NULL,   PREC_NONE},
+<div class="codehilite" translate="no"><pre class="insert-before">  [TOKEN_IF]            = {NULL,     NULL,   PREC_NONE},
 </pre><div class="source-file"><em>compiler.c</em><br>
 replace 1 line</div>
 <pre class="insert">  [<span class="a">TOKEN_NIL</span>]           = {<span class="i">literal</span>,  <span class="a">NULL</span>,   <span class="a">PREC_NONE</span>},
@@ -585,7 +585,7 @@ replace 1 line</div>
 
 <p>When the parser encounters <code>false</code>, <code>nil</code>, or <code>true</code>, in prefix position, it
 calls this new parser function:</p>
-<div class="codehilite"><div class="source-file"><em>compiler.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>compiler.c</em><br>
 add after <em>binary</em>()</div>
 <pre><span class="k">static</span> <span class="t">void</span> <span class="i">literal</span>() {
   <span class="k">switch</span> (<span class="i">parser</span>.<span class="i">previous</span>.<span class="i">type</span>) {
@@ -608,7 +608,7 @@ interpreter.</p>
 ourselves a switch but that felt needlessly verbose to me. I think it&rsquo;s mostly a
 matter of taste.</p>
 </aside>
-<div class="codehilite"><pre class="insert-before">      case OP_CONSTANT: {
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_CONSTANT: {
         Value constant = READ_CONSTANT();
         push(constant);
         break;
@@ -624,7 +624,7 @@ in <em>run</em>()</div>
 
 <p>This is pretty self-explanatory. Each instruction summons the appropriate value
 and pushes it onto the stack. We shouldn&rsquo;t forget our disassembler either.</p>
-<div class="codehilite"><pre class="insert-before">    case OP_CONSTANT:
+<div class="codehilite" translate="no"><pre class="insert-before">    case OP_CONSTANT:
       return constantInstruction(&quot;OP_CONSTANT&quot;, chunk, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
@@ -639,11 +639,11 @@ in <em>disassembleInstruction</em>()</div>
 <div class="source-file-narrow"><em>debug.c</em>, in <em>disassembleInstruction</em>()</div>
 
 <p>With this in place, we can run this Earth-shattering program:</p>
-<div class="codehilite"><pre><span class="k">true</span>
+<div class="codehilite" translate="no"><pre><span class="k">true</span>
 </pre></div>
 <p>Except that when the interpreter tries to print the result, it blows up. We need
 to extend <code>printValue()</code> to handle the new types too:</p>
-<div class="codehilite"><pre class="insert-before">void printValue(Value value) {
+<div class="codehilite" translate="no"><pre class="insert-before">void printValue(Value value) {
 </pre><div class="source-file"><em>value.c</em><br>
 in <em>printValue</em>()<br>
 replace 1 line</div>
@@ -664,10 +664,10 @@ before <code>nil</code> comes into play, but we can start putting Booleans to wo
 logical operators.</p>
 <h3><a href="#logical-not-and-falsiness" id="logical-not-and-falsiness"><small>18&#8202;.&#8202;4&#8202;.&#8202;1</small>Logical not and falsiness</a></h3>
 <p>The simplest logical operator is our old exclamatory friend unary not.</p>
-<div class="codehilite"><pre><span class="k">print</span> !<span class="k">true</span>; <span class="c">// &quot;false&quot;</span>
+<div class="codehilite" translate="no"><pre><span class="k">print</span> !<span class="k">true</span>; <span class="c">// &quot;false&quot;</span>
 </pre></div>
 <p>This new operation gets a new instruction.</p>
-<div class="codehilite"><pre class="insert-before">  OP_DIVIDE,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_DIVIDE,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_NOT</span>,
@@ -677,7 +677,7 @@ in enum <em>OpCode</em></div>
 
 <p>We can reuse the <code>unary()</code> parser function we wrote for unary negation to
 compile a not expression. We just need to slot it into the parsing table.</p>
-<div class="codehilite"><pre class="insert-before">  [TOKEN_STAR]          = {NULL,     binary, PREC_FACTOR},
+<div class="codehilite" translate="no"><pre class="insert-before">  [TOKEN_STAR]          = {NULL,     binary, PREC_FACTOR},
 </pre><div class="source-file"><em>compiler.c</em><br>
 replace 1 line</div>
 <pre class="insert">  [<span class="a">TOKEN_BANG</span>]          = {<span class="i">unary</span>,    <span class="a">NULL</span>,   <span class="a">PREC_NONE</span>},
@@ -688,7 +688,7 @@ replace 1 line</div>
 <p>Because I knew we were going to do this, the <code>unary()</code> function already has a
 switch on the token type to figure out which bytecode instruction to output. We
 merely add another case.</p>
-<div class="codehilite"><pre class="insert-before">  switch (operatorType) {
+<div class="codehilite" translate="no"><pre class="insert-before">  switch (operatorType) {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>unary</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">TOKEN_BANG</span>: <span class="i">emitByte</span>(<span class="a">OP_NOT</span>); <span class="k">break</span>;
@@ -700,7 +700,7 @@ in <em>unary</em>()</div>
 
 <p>That&rsquo;s it for the front end. Let&rsquo;s head over to the VM and conjure this
 instruction into life.</p>
-<div class="codehilite"><pre class="insert-before">      case OP_DIVIDE:   BINARY_OP(NUMBER_VAL, /); break;
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_DIVIDE:   BINARY_OP(NUMBER_VAL, /); break;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_NOT</span>:
@@ -714,7 +714,7 @@ in <em>run</em>()</div>
 operation, and pushes the result. And, as we did there, we have to worry about
 dynamic typing. Taking the logical not of <code>true</code> is easy, but there&rsquo;s nothing
 preventing an unruly programmer from writing something like this:</p>
-<div class="codehilite"><pre><span class="k">print</span> !<span class="k">nil</span>;
+<div class="codehilite" translate="no"><pre><span class="k">print</span> !<span class="k">nil</span>;
 </pre></div>
 <p>For unary minus, we made it an error to negate anything that isn&rsquo;t a <span
 name="negate">number</span>. But Lox, like most scripting languages, is more
@@ -726,7 +726,7 @@ it here:</p>
 of values. <code>nil</code> is probably its own negation, sort of like a weird pseudo-zero.
 Negating a string could, uh, reverse it?</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>vm.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>vm.c</em><br>
 add after <em>peek</em>()</div>
 <pre><span class="k">static</span> <span class="t">bool</span> <span class="i">isFalsey</span>(<span class="t">Value</span> <span class="i">value</span>) {
   <span class="k">return</span> <span class="a">IS_NIL</span>(<span class="i">value</span>) || (<span class="a">IS_BOOL</span>(<span class="i">value</span>) &amp;&amp; !<span class="a">AS_BOOL</span>(<span class="i">value</span>));
@@ -737,7 +737,7 @@ add after <em>peek</em>()</div>
 <p>Lox follows Ruby in that <code>nil</code> and <code>false</code> are falsey and every other value
 behaves like <code>true</code>. We&rsquo;ve got a new instruction we can generate, so we also
 need to be able to <em>un</em>generate it in the disassembler.</p>
-<div class="codehilite"><pre class="insert-before">    case OP_DIVIDE:
+<div class="codehilite" translate="no"><pre class="insert-before">    case OP_DIVIDE:
       return simpleInstruction(&quot;OP_DIVIDE&quot;, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
@@ -754,7 +754,7 @@ all of the operators that return Boolean results except the logical operators
 <code>and</code> and <code>or</code>. Since those need to short-circuit (basically do a little
 control flow) we aren&rsquo;t ready for them yet.</p>
 <p>Here are the new instructions for those operators:</p>
-<div class="codehilite"><pre class="insert-before">  OP_FALSE,
+<div class="codehilite" translate="no"><pre class="insert-before">  OP_FALSE,
 </pre><div class="source-file"><em>chunk.h</em><br>
 in enum <em>OpCode</em></div>
 <pre class="insert">  <span class="a">OP_EQUAL</span>,
@@ -787,7 +787,7 @@ matter in your real language implementations.</p>
 <p>Over in the parser, though, we do have six new operators to slot into the parse
 table. We use the same <code>binary()</code> parser function from before. Here&rsquo;s the row
 for <code>!=</code>:</p>
-<div class="codehilite"><pre class="insert-before">  [TOKEN_BANG]          = {unary,    NULL,   PREC_NONE},
+<div class="codehilite" translate="no"><pre class="insert-before">  [TOKEN_BANG]          = {unary,    NULL,   PREC_NONE},
 </pre><div class="source-file"><em>compiler.c</em><br>
 replace 1 line</div>
 <pre class="insert">  [<span class="a">TOKEN_BANG_EQUAL</span>]    = {<span class="a">NULL</span>,     <span class="i">binary</span>, <span class="a">PREC_EQUALITY</span>},
@@ -796,7 +796,7 @@ replace 1 line</div>
 <div class="source-file-narrow"><em>compiler.c</em>, replace 1 line</div>
 
 <p>The remaining five operators are a little farther down in the table.</p>
-<div class="codehilite"><pre class="insert-before">  [TOKEN_EQUAL]         = {NULL,     NULL,   PREC_NONE},
+<div class="codehilite" translate="no"><pre class="insert-before">  [TOKEN_EQUAL]         = {NULL,     NULL,   PREC_NONE},
 </pre><div class="source-file"><em>compiler.c</em><br>
 replace 5 lines</div>
 <pre class="insert">  [<span class="a">TOKEN_EQUAL_EQUAL</span>]   = {<span class="a">NULL</span>,     <span class="i">binary</span>, <span class="a">PREC_EQUALITY</span>},
@@ -810,7 +810,7 @@ replace 5 lines</div>
 
 <p>Inside <code>binary()</code> we already have a switch to generate the right bytecode for
 each token type. We add cases for the six new operators.</p>
-<div class="codehilite"><pre class="insert-before">  switch (operatorType) {
+<div class="codehilite" translate="no"><pre class="insert-before">  switch (operatorType) {
 </pre><div class="source-file"><em>compiler.c</em><br>
 in <em>binary</em>()</div>
 <pre class="insert">    <span class="k">case</span> <span class="a">TOKEN_BANG_EQUAL</span>:    <span class="i">emitBytes</span>(<span class="a">OP_EQUAL</span>, <span class="a">OP_NOT</span>); <span class="k">break</span>;
@@ -828,7 +828,7 @@ a pair of instructions, one to evalute the inverse operation, and then an
 <code>OP_NOT</code> to flip the result. Six operators for the price of three instructions!</p>
 <p>That means over in the VM, our job is simpler. Equality is the most general
 operation.</p>
-<div class="codehilite"><pre class="insert-before">      case OP_FALSE: push(BOOL_VAL(false)); break;
+<div class="codehilite" translate="no"><pre class="insert-before">      case OP_FALSE: push(BOOL_VAL(false)); break;
 </pre><div class="source-file"><em>vm.c</em><br>
 in <em>run</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="a">OP_EQUAL</span>: {
@@ -846,7 +846,7 @@ There&rsquo;s enough complexity that it makes sense to shunt that logic over to 
 separate function. That function always returns a C <code>bool</code>, so we can safely
 wrap the result in a <code>BOOL_VAL</code>. The function relates to Values, so it lives
 over in the &ldquo;value&rdquo; module.</p>
-<div class="codehilite"><pre class="insert-before">} ValueArray;
+<div class="codehilite" translate="no"><pre class="insert-before">} ValueArray;
 
 </pre><div class="source-file"><em>value.h</em><br>
 add after struct <em>ValueArray</em></div>
@@ -856,7 +856,7 @@ add after struct <em>ValueArray</em></div>
 <div class="source-file-narrow"><em>value.h</em>, add after struct <em>ValueArray</em></div>
 
 <p>And here&rsquo;s the implementation:</p>
-<div class="codehilite"><div class="source-file"><em>value.c</em><br>
+<div class="codehilite" translate="no"><div class="source-file"><em>value.c</em><br>
 add after <em>printValue</em>()</div>
 <pre><span class="t">bool</span> <span class="i">valuesEqual</span>(<span class="t">Value</span> <span class="i">a</span>, <span class="t">Value</span> <span class="i">b</span>) {
   <span class="k">if</span> (<span class="i">a</span>.<span class="i">type</span> != <span class="i">b</span>.<span class="i">type</span>) <span class="k">return</span> <span class="k">false</span>;
@@ -897,7 +897,7 @@ equal Values actually differ in memory that isn&rsquo;t used.</p><img src="image
 <p>Anyway, as we add more types to clox, this function will grow new cases. For
 now, these three are sufficient. The other comparison operators are easier since
 they work only on numbers.</p>
-<div class="codehilite"><pre class="insert-before">        push(BOOL_VAL(valuesEqual(a, b)));
+<div class="codehilite" translate="no"><pre class="insert-before">        push(BOOL_VAL(valuesEqual(a, b)));
         break;
       }
 </pre><div class="source-file"><em>vm.c</em><br>
@@ -912,7 +912,7 @@ in <em>run</em>()</div>
 non-numeric types. Now we get to use that. We pass in <code>BOOL_VAL</code> since the
 result value type is Boolean. Otherwise, it&rsquo;s no different from plus or minus.</p>
 <p>As always, the coda to today&rsquo;s aria is disassembling the new instructions.</p>
-<div class="codehilite"><pre class="insert-before">    case OP_FALSE:
+<div class="codehilite" translate="no"><pre class="insert-before">    case OP_FALSE:
       return simpleInstruction(&quot;OP_FALSE&quot;, offset);
 </pre><div class="source-file"><em>debug.c</em><br>
 in <em>disassembleInstruction</em>()</div>
@@ -928,7 +928,7 @@ in <em>disassembleInstruction</em>()</div>
 
 <p>With that, our numeric calculator has become something closer to a general
 expression evaluator. Fire up clox and type in:</p>
-<div class="codehilite"><pre>!(<span class="n">5</span> - <span class="n">4</span> &gt; <span class="n">3</span> * <span class="n">2</span> == !<span class="k">nil</span>)
+<div class="codehilite" translate="no"><pre>!(<span class="n">5</span> - <span class="n">4</span> &gt; <span class="n">3</span> * <span class="n">2</span> == !<span class="k">nil</span>)
 </pre></div>
 <p>OK, I&rsquo;ll admit that&rsquo;s maybe not the most <em>useful</em> expression, but we&rsquo;re making
 progress. We have one missing built-in type with its own literal form: strings.

--- a/tool/lib/src/markdown/code_syntax.dart
+++ b/tool/lib/src/markdown/code_syntax.dart
@@ -98,6 +98,7 @@ class HighlightedCodeBlockSyntax extends BlockSyntax {
 
     var element = Element.text("div", code);
     element.attributes["class"] = "codehilite";
+    element.attributes["translate"] = "no";
     return element;
   }
 }
@@ -146,7 +147,7 @@ String _buildSnippet(Format format, CodeTag tag, Snippet snippet) {
   if (tag.showLocation) location = snippet.locationHtmlLines;
 
   var buffer = StringBuffer();
-  buffer.write('<div class="codehilite">');
+  buffer.write('<div class="codehilite" translate="no">');
 
   if (snippet.contextBefore.isNotEmpty) {
     _writeContextHtml(format, buffer, snippet.contextBefore,


### PR DESCRIPTION
ADD attribute translate="no" to code blocks in the book. #1020