### PR TITLE
Update local_inherit_self.lox

### DIFF
--- a/test/class/local_inherit_self.lox
+++ b/test/class/local_inherit_self.lox
@@ -1,4 +1,3 @@
 {
   class Foo < Foo {} // Error at 'Foo': A class can't inherit from itself.
 }
-// [c line 5] Error at end: Expect '}' after block.


### PR DESCRIPTION
Deleting the incorrect line // [c line 5] Error at end: Expect '}' after block.