### PR TITLE
Edited prose on Logical Operators section

### DIFF
--- a/book/the-lox-language.md
+++ b/book/the-lox-language.md
@@ -328,7 +328,7 @@ versa.
 
 The other two logical operators really are control flow constructs in the guise
 of expressions. An <span name="and">`and`</span> expression determines if two
-values are *both* true. It returns the left operand if it's false, or the
+values are *both* true. It returns the left operand if the operand's false, or the
 right operand otherwise.
 
 ```lox
@@ -337,7 +337,7 @@ true and true;  // true.
 ```
 
 And an `or` expression determines if *either* of two values (or both) are true.
-It returns the left operand if it is true and the right operand otherwise.
+It returns the left operand if the operand is true and the right operand otherwise.
 
 ```lox
 false or false; // false.

--- a/book/the-lox-language.md
+++ b/book/the-lox-language.md
@@ -328,20 +328,25 @@ versa.
 
 The other two logical operators really are control flow constructs in the guise
 of expressions. An <span name="and">`and`</span> expression determines if two
-values are *both* true. It returns the left operand if it's false, or the
-right operand otherwise.
+values are *both* true. Consequently if it is able to determine this, it 
+will return true, otherwise false.
 
 ```lox
 true and false; // false.
+false and true; // false.
 true and true;  // true.
+false and false; // false.
 ```
 
 And an `or` expression determines if *either* of two values (or both) are true.
-It returns the left operand if it is true and the right operand otherwise.
+And much like the <span name="and">`and`</span> expression, it will return true,
+otherwise false.
 
 ```lox
-false or false; // false.
 true or false;  // true.
+false or true; // true.
+true or true; // true.
+false or false; // false.
 ```
 
 <aside name="and">

--- a/book/the-lox-language.md
+++ b/book/the-lox-language.md
@@ -328,25 +328,20 @@ versa.
 
 The other two logical operators really are control flow constructs in the guise
 of expressions. An <span name="and">`and`</span> expression determines if two
-values are *both* true. Consequently if it is able to determine this, it 
-will return true, otherwise false.
+values are *both* true. It returns the left operand if it's false, or the
+right operand otherwise.
 
 ```lox
 true and false; // false.
-false and true; // false.
 true and true;  // true.
-false and false; // false.
 ```
 
 And an `or` expression determines if *either* of two values (or both) are true.
-And much like the <span name="and">`and`</span> expression, it will return true,
-otherwise false.
+It returns the left operand if it is true and the right operand otherwise.
 
 ```lox
-true or false;  // true.
-false or true; // true.
-true or true; // true.
 false or false; // false.
+true or false;  // true.
 ```
 
 <aside name="and">

--- a/site/appendix-ii.html
+++ b/site/appendix-ii.html
@@ -86,7 +86,7 @@ we built</a> to automate generating the syntax tree classes for jlox.</p>
 Code</a>&rdquo;. The main Expr class defines the visitor
 interface used to dispatch against the specific expression types, and contains
 the other expression subclasses as nested classes.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -113,12 +113,12 @@ create new file</div>
   <span class="k">abstract</span> &lt;<span class="t">R</span>&gt; <span class="t">R</span> <span class="i">accept</span>(<span class="t">Visitor</span>&lt;<span class="t">R</span>&gt; <span class="i">visitor</span>);
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Expr.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, create new file</div>
 
 <h3><a href="#assign-expression" id="assign-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;1</small>Assign expression</a></h3>
 <p>Variable assignment is introduced in &ldquo;<a href="statements-and-state.html#assignment">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Assign</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Assign</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">Expr</span> <span class="i">value</span>) {
@@ -135,12 +135,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">value</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#binary-expression" id="binary-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;2</small>Binary expression</a></h3>
 <p>Binary operators are introduced in &ldquo;<a href="representing-code.html">Representing
 Code</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Binary</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Binary</span>(<span class="t">Expr</span> <span class="i">left</span>, <span class="t">Token</span> <span class="i">operator</span>, <span class="t">Expr</span> <span class="i">right</span>) {
@@ -159,12 +159,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">right</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#call-expression" id="call-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;3</small>Call expression</a></h3>
 <p>Function call expressions are introduced in
 &ldquo;<a href="functions.html#function-calls">Functions</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Call</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Call</span>(<span class="t">Expr</span> <span class="i">callee</span>, <span class="t">Token</span> <span class="i">paren</span>, <span class="t">List</span>&lt;<span class="t">Expr</span>&gt; <span class="i">arguments</span>) {
@@ -183,12 +183,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">List</span>&lt;<span class="t">Expr</span>&gt; <span class="i">arguments</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#get-expression" id="get-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;4</small>Get expression</a></h3>
 <p>Property access, or &ldquo;get&rdquo; expressions are introduced in
 &ldquo;<a href="classes.html#properties-on-instances">Classes</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Get</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Get</span>(<span class="t">Expr</span> <span class="i">object</span>, <span class="t">Token</span> <span class="i">name</span>) {
@@ -205,12 +205,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Token</span> <span class="i">name</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#grouping-expression" id="grouping-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;5</small>Grouping expression</a></h3>
 <p>Using parentheses to group expressions is introduced in &ldquo;<a href="representing-code.html">Representing
 Code</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Grouping</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Grouping</span>(<span class="t">Expr</span> <span class="i">expression</span>) {
@@ -225,12 +225,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">expression</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#literal-expression" id="literal-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;6</small>Literal expression</a></h3>
 <p>Literal value expressions are introduced in &ldquo;<a href="representing-code.html">Representing
 Code</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Literal</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Literal</span>(<span class="t">Object</span> <span class="i">value</span>) {
@@ -245,12 +245,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Object</span> <span class="i">value</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#logical-expression" id="logical-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;7</small>Logical expression</a></h3>
 <p>The logical <code>and</code> and <code>or</code> operators are introduced in &ldquo;<a href="control-flow.html#logical-operators">Control
 Flow</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Logical</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Logical</span>(<span class="t">Expr</span> <span class="i">left</span>, <span class="t">Token</span> <span class="i">operator</span>, <span class="t">Expr</span> <span class="i">right</span>) {
@@ -269,12 +269,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">right</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#set-expression" id="set-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;8</small>Set expression</a></h3>
 <p>Property assignment, or &ldquo;set&rdquo; expressions are introduced in
 &ldquo;<a href="classes.html#properties-on-instances">Classes</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Set</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Set</span>(<span class="t">Expr</span> <span class="i">object</span>, <span class="t">Token</span> <span class="i">name</span>, <span class="t">Expr</span> <span class="i">value</span>) {
@@ -293,12 +293,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">value</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#super-expression" id="super-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;9</small>Super expression</a></h3>
 <p>The <code>super</code> expression is introduced in
 &ldquo;<a href="inheritance.html#calling-superclass-methods">Inheritance</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Super</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Super</span>(<span class="t">Token</span> <span class="i">keyword</span>, <span class="t">Token</span> <span class="i">method</span>) {
@@ -315,11 +315,11 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Token</span> <span class="i">method</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#this-expression" id="this-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;10</small>This expression</a></h3>
 <p>The <code>this</code> expression is introduced in &ldquo;<a href="classes.html#this">Classes</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">This</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">This</span>(<span class="t">Token</span> <span class="i">keyword</span>) {
@@ -334,11 +334,11 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Token</span> <span class="i">keyword</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#unary-expression" id="unary-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;11</small>Unary expression</a></h3>
 <p>Unary operators are introduced in &ldquo;<a href="representing-code.html">Representing Code</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Unary</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Unary</span>(<span class="t">Token</span> <span class="i">operator</span>, <span class="t">Expr</span> <span class="i">right</span>) {
@@ -355,12 +355,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">right</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#variable-expression" id="variable-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;12</small>Variable expression</a></h3>
 <p>Variable access expressions are introduced in &ldquo;<a href="statements-and-state.html#variable-syntax">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Variable</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Variable</span>(<span class="t">Token</span> <span class="i">name</span>) {
@@ -375,13 +375,13 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Token</span> <span class="i">name</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h2><a href="#statements" id="statements"><small>A2&#8202;.&#8202;2</small>Statements</a></h2>
 <p>Statements form a second hierarchy of syntax tree nodes independent of
 expressions. We add the first couple of them in &ldquo;<a href="statements-and-state.html">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -405,12 +405,12 @@ create new file</div>
   <span class="k">abstract</span> &lt;<span class="t">R</span>&gt; <span class="t">R</span> <span class="i">accept</span>(<span class="t">Visitor</span>&lt;<span class="t">R</span>&gt; <span class="i">visitor</span>);
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Stmt.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, create new file</div>
 
 <h3><a href="#block-statement" id="block-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;1</small>Block statement</a></h3>
 <p>The curly-braced block statement that defines a local scope is introduced in
 &ldquo;<a href="statements-and-state.html#block-syntax-and-semantics">Statements and State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Block</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Block</span>(<span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span>) {
@@ -425,12 +425,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#class-statement" id="class-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;2</small>Class statement</a></h3>
 <p>Class declarations are introduced in, unsurprisingly,
 &ldquo;<a href="classes.html#class-declarations">Classes</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Class</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Class</span>(<span class="t">Token</span> <span class="i">name</span>,
@@ -451,12 +451,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">List</span>&lt;<span class="t">Stmt</span>.<span class="t">Function</span>&gt; <span class="i">methods</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#expression-statement" id="expression-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;3</small>Expression statement</a></h3>
 <p>The expression statement is introduced in &ldquo;<a href="statements-and-state.html#statements">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Expression</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Expression</span>(<span class="t">Expr</span> <span class="i">expression</span>) {
@@ -471,12 +471,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">expression</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#function-statement" id="function-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;4</small>Function statement</a></h3>
 <p>Function declarations are introduced in, you guessed it,
 &ldquo;<a href="functions.html#function-declarations">Functions</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Function</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Function</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">List</span>&lt;<span class="t">Token</span>&gt; <span class="i">params</span>, <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">body</span>) {
@@ -495,12 +495,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">body</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#if-statement" id="if-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;5</small>If statement</a></h3>
 <p>The <code>if</code> statement is introduced in &ldquo;<a href="control-flow.html#conditional-execution">Control
 Flow</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">If</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">If</span>(<span class="t">Expr</span> <span class="i">condition</span>, <span class="t">Stmt</span> <span class="i">thenBranch</span>, <span class="t">Stmt</span> <span class="i">elseBranch</span>) {
@@ -519,12 +519,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">Stmt</span> <span class="i">elseBranch</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#print-statement" id="print-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;6</small>Print statement</a></h3>
 <p>The <code>print</code> statement is introduced in &ldquo;<a href="statements-and-state.html#statements">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Print</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Print</span>(<span class="t">Expr</span> <span class="i">expression</span>) {
@@ -539,12 +539,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">expression</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#return-statement" id="return-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;7</small>Return statement</a></h3>
 <p>You need a function to return from, so <code>return</code> statements are introduced in
 &ldquo;<a href="functions.html#return-statements">Functions</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Return</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Return</span>(<span class="t">Token</span> <span class="i">keyword</span>, <span class="t">Expr</span> <span class="i">value</span>) {
@@ -561,12 +561,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">value</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#variable-statement" id="variable-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;8</small>Variable statement</a></h3>
 <p>Variable declarations are introduced in &ldquo;<a href="statements-and-state.html#variable-syntax">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Var</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Var</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">Expr</span> <span class="i">initializer</span>) {
@@ -583,12 +583,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">initializer</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#while-statement" id="while-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;9</small>While statement</a></h3>
 <p>The <code>while</code> statement is introduced in &ldquo;<a href="control-flow.html#while-loops">Control
 Flow</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">While</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">While</span>(<span class="t">Expr</span> <span class="i">condition</span>, <span class="t">Stmt</span> <span class="i">body</span>) {
@@ -605,7 +605,7 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">Stmt</span> <span class="i">body</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 
 <footer>

--- a/site/appendix-ii.html
+++ b/site/appendix-ii.html
@@ -86,7 +86,7 @@ we built</a> to automate generating the syntax tree classes for jlox.</p>
 Code</a>&rdquo;. The main Expr class defines the visitor
 interface used to dispatch against the specific expression types, and contains
 the other expression subclasses as nested classes.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -113,12 +113,12 @@ create new file</div>
   <span class="k">abstract</span> &lt;<span class="t">R</span>&gt; <span class="t">R</span> <span class="i">accept</span>(<span class="t">Visitor</span>&lt;<span class="t">R</span>&gt; <span class="i">visitor</span>);
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/Expr.java</em>, create new file</div>
 
 <h3><a href="#assign-expression" id="assign-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;1</small>Assign expression</a></h3>
 <p>Variable assignment is introduced in &ldquo;<a href="statements-and-state.html#assignment">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Assign</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Assign</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">Expr</span> <span class="i">value</span>) {
@@ -135,12 +135,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">value</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#binary-expression" id="binary-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;2</small>Binary expression</a></h3>
 <p>Binary operators are introduced in &ldquo;<a href="representing-code.html">Representing
 Code</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Binary</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Binary</span>(<span class="t">Expr</span> <span class="i">left</span>, <span class="t">Token</span> <span class="i">operator</span>, <span class="t">Expr</span> <span class="i">right</span>) {
@@ -159,12 +159,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">right</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#call-expression" id="call-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;3</small>Call expression</a></h3>
 <p>Function call expressions are introduced in
 &ldquo;<a href="functions.html#function-calls">Functions</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Call</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Call</span>(<span class="t">Expr</span> <span class="i">callee</span>, <span class="t">Token</span> <span class="i">paren</span>, <span class="t">List</span>&lt;<span class="t">Expr</span>&gt; <span class="i">arguments</span>) {
@@ -183,12 +183,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">List</span>&lt;<span class="t">Expr</span>&gt; <span class="i">arguments</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#get-expression" id="get-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;4</small>Get expression</a></h3>
 <p>Property access, or &ldquo;get&rdquo; expressions are introduced in
 &ldquo;<a href="classes.html#properties-on-instances">Classes</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Get</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Get</span>(<span class="t">Expr</span> <span class="i">object</span>, <span class="t">Token</span> <span class="i">name</span>) {
@@ -205,12 +205,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Token</span> <span class="i">name</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#grouping-expression" id="grouping-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;5</small>Grouping expression</a></h3>
 <p>Using parentheses to group expressions is introduced in &ldquo;<a href="representing-code.html">Representing
 Code</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Grouping</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Grouping</span>(<span class="t">Expr</span> <span class="i">expression</span>) {
@@ -225,12 +225,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">expression</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#literal-expression" id="literal-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;6</small>Literal expression</a></h3>
 <p>Literal value expressions are introduced in &ldquo;<a href="representing-code.html">Representing
 Code</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Literal</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Literal</span>(<span class="t">Object</span> <span class="i">value</span>) {
@@ -245,12 +245,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Object</span> <span class="i">value</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#logical-expression" id="logical-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;7</small>Logical expression</a></h3>
 <p>The logical <code>and</code> and <code>or</code> operators are introduced in &ldquo;<a href="control-flow.html#logical-operators">Control
 Flow</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Logical</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Logical</span>(<span class="t">Expr</span> <span class="i">left</span>, <span class="t">Token</span> <span class="i">operator</span>, <span class="t">Expr</span> <span class="i">right</span>) {
@@ -269,12 +269,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">right</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#set-expression" id="set-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;8</small>Set expression</a></h3>
 <p>Property assignment, or &ldquo;set&rdquo; expressions are introduced in
 &ldquo;<a href="classes.html#properties-on-instances">Classes</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Set</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Set</span>(<span class="t">Expr</span> <span class="i">object</span>, <span class="t">Token</span> <span class="i">name</span>, <span class="t">Expr</span> <span class="i">value</span>) {
@@ -293,12 +293,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">value</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#super-expression" id="super-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;9</small>Super expression</a></h3>
 <p>The <code>super</code> expression is introduced in
 &ldquo;<a href="inheritance.html#calling-superclass-methods">Inheritance</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Super</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Super</span>(<span class="t">Token</span> <span class="i">keyword</span>, <span class="t">Token</span> <span class="i">method</span>) {
@@ -315,11 +315,11 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Token</span> <span class="i">method</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#this-expression" id="this-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;10</small>This expression</a></h3>
 <p>The <code>this</code> expression is introduced in &ldquo;<a href="classes.html#this">Classes</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">This</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">This</span>(<span class="t">Token</span> <span class="i">keyword</span>) {
@@ -334,11 +334,11 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Token</span> <span class="i">keyword</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#unary-expression" id="unary-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;11</small>Unary expression</a></h3>
 <p>Unary operators are introduced in &ldquo;<a href="representing-code.html">Representing Code</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Unary</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Unary</span>(<span class="t">Token</span> <span class="i">operator</span>, <span class="t">Expr</span> <span class="i">right</span>) {
@@ -355,12 +355,12 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">right</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h3><a href="#variable-expression" id="variable-expression"><small>A2&#8202;.&#8202;1&#8202;.&#8202;12</small>Variable expression</a></h3>
 <p>Variable access expressions are introduced in &ldquo;<a href="statements-and-state.html#variable-syntax">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Expr.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Expr.java</em><br>
 nest inside class <em>Expr</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Variable</span> <span class="k">extends</span> <span class="t">Expr</span> {
     <span class="t">Variable</span>(<span class="t">Token</span> <span class="i">name</span>) {
@@ -375,13 +375,13 @@ nest inside class <em>Expr</em></div>
     <span class="k">final</span> <span class="t">Token</span> <span class="i">name</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Expr.java</em>, nest inside class <em>Expr</em></div>
+<div class="source-file-narrow"><em>lox/Expr.java</em>, nest inside class <em>Expr</em></div>
 
 <h2><a href="#statements" id="statements"><small>A2&#8202;.&#8202;2</small>Statements</a></h2>
 <p>Statements form a second hierarchy of syntax tree nodes independent of
 expressions. We add the first couple of them in &ldquo;<a href="statements-and-state.html">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -405,12 +405,12 @@ create new file</div>
   <span class="k">abstract</span> &lt;<span class="t">R</span>&gt; <span class="t">R</span> <span class="i">accept</span>(<span class="t">Visitor</span>&lt;<span class="t">R</span>&gt; <span class="i">visitor</span>);
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/Stmt.java</em>, create new file</div>
 
 <h3><a href="#block-statement" id="block-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;1</small>Block statement</a></h3>
 <p>The curly-braced block statement that defines a local scope is introduced in
 &ldquo;<a href="statements-and-state.html#block-syntax-and-semantics">Statements and State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Block</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Block</span>(<span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span>) {
@@ -425,12 +425,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#class-statement" id="class-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;2</small>Class statement</a></h3>
 <p>Class declarations are introduced in, unsurprisingly,
 &ldquo;<a href="classes.html#class-declarations">Classes</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Class</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Class</span>(<span class="t">Token</span> <span class="i">name</span>,
@@ -451,12 +451,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">List</span>&lt;<span class="t">Stmt</span>.<span class="t">Function</span>&gt; <span class="i">methods</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#expression-statement" id="expression-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;3</small>Expression statement</a></h3>
 <p>The expression statement is introduced in &ldquo;<a href="statements-and-state.html#statements">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Expression</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Expression</span>(<span class="t">Expr</span> <span class="i">expression</span>) {
@@ -471,12 +471,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">expression</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#function-statement" id="function-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;4</small>Function statement</a></h3>
 <p>Function declarations are introduced in, you guessed it,
 &ldquo;<a href="functions.html#function-declarations">Functions</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Function</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Function</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">List</span>&lt;<span class="t">Token</span>&gt; <span class="i">params</span>, <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">body</span>) {
@@ -495,12 +495,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">body</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#if-statement" id="if-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;5</small>If statement</a></h3>
 <p>The <code>if</code> statement is introduced in &ldquo;<a href="control-flow.html#conditional-execution">Control
 Flow</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">If</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">If</span>(<span class="t">Expr</span> <span class="i">condition</span>, <span class="t">Stmt</span> <span class="i">thenBranch</span>, <span class="t">Stmt</span> <span class="i">elseBranch</span>) {
@@ -519,12 +519,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">Stmt</span> <span class="i">elseBranch</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#print-statement" id="print-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;6</small>Print statement</a></h3>
 <p>The <code>print</code> statement is introduced in &ldquo;<a href="statements-and-state.html#statements">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Print</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Print</span>(<span class="t">Expr</span> <span class="i">expression</span>) {
@@ -539,12 +539,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">expression</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#return-statement" id="return-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;7</small>Return statement</a></h3>
 <p>You need a function to return from, so <code>return</code> statements are introduced in
 &ldquo;<a href="functions.html#return-statements">Functions</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Return</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Return</span>(<span class="t">Token</span> <span class="i">keyword</span>, <span class="t">Expr</span> <span class="i">value</span>) {
@@ -561,12 +561,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">value</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#variable-statement" id="variable-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;8</small>Variable statement</a></h3>
 <p>Variable declarations are introduced in &ldquo;<a href="statements-and-state.html#variable-syntax">Statements and
 State</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">Var</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">Var</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">Expr</span> <span class="i">initializer</span>) {
@@ -583,12 +583,12 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">Expr</span> <span class="i">initializer</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 <h3><a href="#while-statement" id="while-statement"><small>A2&#8202;.&#8202;2&#8202;.&#8202;9</small>While statement</a></h3>
 <p>The <code>while</code> statement is introduced in &ldquo;<a href="control-flow.html#while-loops">Control
 Flow</a>&rdquo;.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Stmt.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Stmt.java</em><br>
 nest inside class <em>Stmt</em></div>
 <pre>  <span class="k">static</span> <span class="k">class</span> <span class="t">While</span> <span class="k">extends</span> <span class="t">Stmt</span> {
     <span class="t">While</span>(<span class="t">Expr</span> <span class="i">condition</span>, <span class="t">Stmt</span> <span class="i">body</span>) {
@@ -605,7 +605,7 @@ nest inside class <em>Stmt</em></div>
     <span class="k">final</span> <span class="t">Stmt</span> <span class="i">body</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Stmt.java</em>, nest inside class <em>Stmt</em></div>
+<div class="source-file-narrow"><em>lox/Stmt.java</em>, nest inside class <em>Stmt</em></div>
 
 
 <footer>

--- a/site/classes.html
+++ b/site/classes.html
@@ -201,12 +201,12 @@ fields to them as you see fit using normal imperative code.</p>
 <p>Over in our AST generator, the <code>classDecl</code> grammar rule gets its own statement
 <span name="class-ast">node</span>.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Block      : List&lt;Stmt&gt; statements&quot;,
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Class      : Token name, List&lt;Stmt.Function&gt; methods&quot;</span>,
 </pre><pre class="insert-after">      &quot;Expression : Expr expression&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="class-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#class-statement">Appendix II</a>.</p>
@@ -218,15 +218,15 @@ method: name, parameter list, and body.</p>
 <p>A class can appear anywhere a named declaration is allowed, triggered by the
 leading <code>class</code> keyword.</p>
 <div class="codehilite"><pre class="insert-before">    try {
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>declaration</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">match</span>(<span class="i">CLASS</span>)) <span class="k">return</span> <span class="i">classDeclaration</span>();
 </pre><pre class="insert-after">      if (match(FUN)) return function(&quot;function&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>declaration</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>declaration</em>()</div>
 
 <p>That calls out to:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>declaration</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">classDeclaration</span>() {
     <span class="t">Token</span> <span class="i">name</span> = <span class="i">consume</span>(<span class="i">IDENTIFIER</span>, <span class="s">&quot;Expect class name.&quot;</span>);
@@ -242,7 +242,7 @@ add after <em>declaration</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Class</span>(<span class="i">name</span>, <span class="i">methods</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>declaration</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>declaration</em>()</div>
 
 <p>There&rsquo;s more meat to this than most of the other parsing methods, but it roughly
 follows the grammar. We&rsquo;ve already consumed the <code>class</code> keyword, so we look for
@@ -258,7 +258,7 @@ class body.</p>
 <p>We wrap the name and list of methods into a Stmt.Class node and we&rsquo;re done.
 Previously, we would jump straight into the interpreter, but now we need to
 plumb the node through the resolver first.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitClassStmt</span>(<span class="t">Stmt</span>.<span class="t">Class</span> <span class="i">stmt</span>) {
@@ -267,14 +267,14 @@ add after <em>visitBlockStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
 
 <p>We aren&rsquo;t going to worry about resolving the methods themselves yet, so for now
 all we need to do is declare the class using its name. It&rsquo;s not common to
 declare a class as a local variable, but Lox permits it, so we need to handle it
 correctly.</p>
 <p>Now we interpret the class declaration.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitClassStmt</span>(<span class="t">Stmt</span>.<span class="t">Class</span> <span class="i">stmt</span>) {
@@ -284,7 +284,7 @@ add after <em>visitBlockStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitBlockStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitBlockStmt</em>()</div>
 
 <p>This looks similar to how we execute function declarations. We declare the
 class&rsquo;s name in the current environment. Then we turn the class <em>syntax node</em>
@@ -293,7 +293,7 @@ store the class object in the variable we previously declared. That two-stage
 variable binding process allows references to the class inside its own methods.</p>
 <p>We will refine it throughout the chapter, but the first draft of LoxClass looks
 like this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxClass.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -313,7 +313,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxClass.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, create new file</div>
 
 <p>Literally a wrapper around a name. We don&rsquo;t even store the methods yet. Not
 super useful, but it does have a <code>toString()</code> method so we can write a trivial
@@ -357,15 +357,15 @@ implements <code>LoxCallable</code> and reports an error since LoxClass doesn&rs
 that is.</p>
 <div class="codehilite"><pre class="insert-before">import java.util.Map;
 
-</pre><div class="source-file"><em>lox/LoxClass.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
 replace 1 line</div>
 <pre class="insert"><span class="k">class</span> <span class="t">LoxClass</span> <span class="k">implements</span> <span class="t">LoxCallable</span> {
 </pre><pre class="insert-after">  final String name;
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxClass.java</em>, replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, replace 1 line</div>
 
 <p>Implementing that interface requires two methods.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxClass.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
 add after <em>toString</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">call</span>(<span class="t">Interpreter</span> <span class="i">interpreter</span>,
@@ -379,7 +379,7 @@ add after <em>toString</em>()</div>
     <span class="k">return</span> <span class="n">0</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxClass.java</em>, add after <em>toString</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, add after <em>toString</em>()</div>
 
 <p>The interesting one is <code>call()</code>. When you &ldquo;call&rdquo; a class, it instantiates a new
 LoxInstance for the called class and returns it. The <code>arity()</code> method is how the
@@ -388,7 +388,7 @@ callable. For now, we&rsquo;ll say you can&rsquo;t pass any. When we get to user
 constructors, we&rsquo;ll revisit this.</p>
 <p>That leads us to LoxInstance, the runtime representation of an instance of a Lox
 class. Again, our first implementation starts small.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxInstance.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxInstance.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -408,7 +408,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxInstance.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxInstance.java</em>, create new file</div>
 
 <p>Like LoxClass, it&rsquo;s pretty bare bones, but we&rsquo;re only getting started. If you
 want to give it a try, here&rsquo;s a script to run:</p>
@@ -450,12 +450,12 @@ here on out, we&rsquo;ll call these &ldquo;get expressions&rdquo;.</p>
 <h3><a href="#get-expressions" id="get-expressions"><small>12&#8202;.&#8202;4&#8202;.&#8202;1</small>Get expressions</a></h3>
 <p>The <span name="get-ast">syntax tree node</span> is:</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Call     : Expr callee, Token paren, List&lt;Expr&gt; arguments&quot;,
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Get      : Expr object, Token name&quot;</span>,
 </pre><pre class="insert-after">      &quot;Grouping : Expr expression&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="get-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#get-expression">Appendix II</a>.</p>
@@ -465,7 +465,7 @@ method.</p>
 <div class="codehilite"><pre class="insert-before">    while (true) {<span name="while-true"> </span>
       if (match(LEFT_PAREN)) {
         expr = finishCall(expr);
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>call</em>()</div>
 <pre class="insert">      } <span class="k">else</span> <span class="k">if</span> (<span class="i">match</span>(<span class="i">DOT</span>)) {
         <span class="t">Token</span> <span class="i">name</span> = <span class="i">consume</span>(<span class="i">IDENTIFIER</span>,
@@ -476,13 +476,13 @@ in <em>call</em>()</div>
       }
     }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>call</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>call</em>()</div>
 
 <p>The outer <code>while</code> loop there corresponds to the <code>*</code> in the grammar rule. We zip
 along the tokens building up a chain of calls and gets as we find parentheses
 and dots, like so:</p><img src="image/classes/zip.png" alt="Parsing a series of '.' and '()' expressions to an AST." />
 <p>Instances of the new Expr.Get node feed into the resolver.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitCallExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitGetExpr</span>(<span class="t">Expr</span>.<span class="t">Get</span> <span class="i">expr</span>) {
@@ -490,7 +490,7 @@ add after <em>visitCallExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitCallExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitCallExpr</em>()</div>
 
 <p>OK, not much to that. Since properties are looked up <span
 name="dispatch">dynamically</span>, they don&rsquo;t get resolved. During resolution,
@@ -500,7 +500,7 @@ access happens in the interpreter.</p>
 <p>You can literally see that property dispatch in Lox is dynamic since we don&rsquo;t
 process the property name during the static resolution pass.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitCallExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitGetExpr</span>(<span class="t">Expr</span>.<span class="t">Get</span> <span class="i">expr</span>) {
@@ -513,7 +513,7 @@ add after <em>visitCallExpr</em>()</div>
         <span class="s">&quot;Only instances have properties.&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitCallExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitCallExpr</em>()</div>
 
 <p>First, we evaluate the expression whose property is being accessed. In Lox, only
 instances of classes have properties. If the object is some other type like a
@@ -521,18 +521,18 @@ number, invoking a getter on it is a runtime error.</p>
 <p>If the object is a LoxInstance, then we ask it to look up the property. It must
 be time to give LoxInstance some actual state. A map will do fine.</p>
 <div class="codehilite"><pre class="insert-before">  private LoxClass klass;
-</pre><div class="source-file"><em>lox/LoxInstance.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxInstance.java</em><br>
 in class <em>LoxInstance</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">Map</span>&lt;<span class="t">String</span>, <span class="t">Object</span>&gt; <span class="i">fields</span> = <span class="k">new</span> <span class="t">HashMap</span>&lt;&gt;();
 </pre><pre class="insert-after">
 
   LoxInstance(LoxClass klass) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxInstance.java</em>, in class <em>LoxInstance</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxInstance.java</em>, in class <em>LoxInstance</em></div>
 
 <p>Each key in the map is a property name and the corresponding value is the
 property&rsquo;s value. To look up a property on an instance:</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxInstance.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxInstance.java</em><br>
 add after <em>LoxInstance</em>()</div>
 <pre>  <span class="t">Object</span> <span class="i">get</span>(<span class="t">Token</span> <span class="i">name</span>) {
     <span class="k">if</span> (<span class="i">fields</span>.<span class="i">containsKey</span>(<span class="i">name</span>.<span class="i">lexeme</span>)) {
@@ -543,7 +543,7 @@ add after <em>LoxInstance</em>()</div>
         <span class="s">&quot;Undefined property &#39;&quot;</span> + <span class="i">name</span>.<span class="i">lexeme</span> + <span class="s">&quot;&#39;.&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxInstance.java</em>, add after <em>LoxInstance</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxInstance.java</em>, add after <em>LoxInstance</em>()</div>
 
 <aside name="hidden">
 <p>Doing a hash table lookup for every field access is fast enough for many
@@ -591,12 +591,12 @@ high-precedence expression before the last dot, including any number of
 assignment, we need a <span name="set-ast">second setter node</span> to
 complement our getter node.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Logical  : Expr left, Token operator, Expr right&quot;,
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Set      : Expr object, Token name, Expr value&quot;</span>,
 </pre><pre class="insert-after">      &quot;Unary    : Token operator, Expr right&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="set-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#set-expression">Appendix II</a>.</p>
@@ -614,17 +614,17 @@ assignment.</p>
 <p>We add another clause to that transformation to handle turning an Expr.Get
 expression on the left into the corresponding Expr.Set.</p>
 <div class="codehilite"><pre class="insert-before">        return new Expr.Assign(name, value);
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>assignment</em>()</div>
 <pre class="insert">      } <span class="k">else</span> <span class="k">if</span> (<span class="i">expr</span> <span class="k">instanceof</span> <span class="t">Expr</span>.<span class="t">Get</span>) {
         <span class="t">Expr</span>.<span class="t">Get</span> <span class="i">get</span> = (<span class="t">Expr</span>.<span class="t">Get</span>)<span class="i">expr</span>;
         <span class="k">return</span> <span class="k">new</span> <span class="t">Expr</span>.<span class="t">Set</span>(<span class="i">get</span>.<span class="i">object</span>, <span class="i">get</span>.<span class="i">name</span>, <span class="i">value</span>);
 </pre><pre class="insert-after">      }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>assignment</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>assignment</em>()</div>
 
 <p>That&rsquo;s parsing our syntax. We push that node through into the resolver.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitLogicalExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitSetExpr</span>(<span class="t">Expr</span>.<span class="t">Set</span> <span class="i">expr</span>) {
@@ -633,14 +633,14 @@ add after <em>visitLogicalExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitLogicalExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitLogicalExpr</em>()</div>
 
 <p>Again, like Expr.Get, the property itself is dynamically evaluated, so there&rsquo;s
 nothing to resolve there. All we need to do is recurse into the two
 subexpressions of Expr.Set, the object whose property is being set, and the
 value it&rsquo;s being set to.</p>
 <p>That leads us to the interpreter.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitLogicalExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitSetExpr</span>(<span class="t">Expr</span>.<span class="t">Set</span> <span class="i">expr</span>) {
@@ -656,7 +656,7 @@ add after <em>visitLogicalExpr</em>()</div>
     <span class="k">return</span> <span class="i">value</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitLogicalExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitLogicalExpr</em>()</div>
 
 <p>We evaluate the object whose property is being set and check to see if it&rsquo;s a
 LoxInstance. If not, that&rsquo;s a runtime error. Otherwise, we evaluate the value
@@ -679,13 +679,13 @@ LoxInstance.</p>
 to carefully specify it and ensure our implementations do these in the same
 order.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/LoxInstance.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxInstance.java</em><br>
 add after <em>get</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">set</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">Object</span> <span class="i">value</span>) {
     <span class="i">fields</span>.<span class="i">put</span>(<span class="i">name</span>.<span class="i">lexeme</span>, <span class="i">value</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxInstance.java</em>, add after <em>get</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxInstance.java</em>, add after <em>get</em>()</div>
 
 <p>No real magic here. We stuff the values straight into the Java map where fields
 live. Since Lox allows freely creating new fields on instances, there&rsquo;s no need
@@ -810,7 +810,7 @@ cases for a bit. We&rsquo;ll get back to those. For now, let&rsquo;s get basic m
 working. We&rsquo;re already parsing the method declarations inside the class body, so
 the next step is to resolve them.</p>
 <div class="codehilite"><pre class="insert-before">    define(stmt.name);
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">
 
@@ -821,7 +821,7 @@ in <em>visitClassStmt</em>()</div>
 
 </pre><pre class="insert-after">    return null;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <aside name="local">
 <p>Storing the function type in a local variable is pointless right now, but we&rsquo;ll
@@ -832,18 +832,18 @@ expand this code before too long and it will make more sense.</p>
 The only difference is that we pass in a new FunctionType enum value.</p>
 <div class="codehilite"><pre class="insert-before">    NONE,
 </pre><pre class="insert-before">    <span class="i">FUNCTION</span><span class="insert-comma">,</span>
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in enum <em>FunctionType</em><br>
 add <em>&ldquo;,&rdquo;</em> to previous line</div>
 <pre class="insert">    <span class="i">METHOD</span>
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in enum <em>FunctionType</em>, add <em>&ldquo;,&rdquo;</em> to previous line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in enum <em>FunctionType</em>, add <em>&ldquo;,&rdquo;</em> to previous line</div>
 
 <p>That&rsquo;s going to be important when we resolve <code>this</code> expressions. For now, don&rsquo;t
 worry about it. The interesting stuff is in the interpreter.</p>
 <div class="codehilite"><pre class="insert-before">    environment.define(stmt.name.lexeme, null);
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitClassStmt</em>()<br>
 replace 1 line</div>
 <pre class="insert">
@@ -857,7 +857,7 @@ replace 1 line</div>
     <span class="t">LoxClass</span> <span class="i">klass</span> = <span class="k">new</span> <span class="t">LoxClass</span>(<span class="i">stmt</span>.<span class="i">name</span>.<span class="i">lexeme</span>, <span class="i">methods</span>);
 </pre><pre class="insert-after">    environment.assign(stmt.name, klass);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitClassStmt</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitClassStmt</em>(), replace 1 line</div>
 
 <p>When we interpret a class declaration statement, we turn the syntactic
 representation of the class<span class="em">&mdash;</span>its AST node<span class="em">&mdash;</span>into its runtime representation.
@@ -866,7 +866,7 @@ method declaration blossoms into a LoxFunction object.</p>
 <p>We take all of those and wrap them up into a map, keyed by the method names.
 That gets stored in LoxClass.</p>
 <div class="codehilite"><pre class="insert-before">  final String name;
-</pre><div class="source-file"><em>lox/LoxClass.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
 in class <em>LoxClass</em><br>
 replace 4 lines</div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">Map</span>&lt;<span class="t">String</span>, <span class="t">LoxFunction</span>&gt; <span class="i">methods</span>;
@@ -880,7 +880,7 @@ replace 4 lines</div>
   @Override
   public String toString() {
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxClass.java</em>, in class <em>LoxClass</em>, replace 4 lines</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, in class <em>LoxClass</em>, replace 4 lines</div>
 
 <p>Where an instance stores state, the class stores behavior. LoxInstance has its
 map of fields, and LoxClass gets a map of methods. Even though methods are
@@ -890,7 +890,7 @@ owned by the class, they are still accessed through instances of that class.</p>
       return fields.get(name.lexeme);
     }
 
-</pre><div class="source-file"><em>lox/LoxInstance.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxInstance.java</em><br>
 in <em>get</em>()</div>
 <pre class="insert">    <span class="t">LoxFunction</span> <span class="i">method</span> = <span class="i">klass</span>.<span class="i">findMethod</span>(<span class="i">name</span>.<span class="i">lexeme</span>);
     <span class="k">if</span> (<span class="i">method</span> != <span class="k">null</span>) <span class="k">return</span> <span class="i">method</span>;
@@ -898,7 +898,7 @@ in <em>get</em>()</div>
 </pre><pre class="insert-after">    throw new RuntimeError(name,<span name="hidden"> </span>
         &quot;Undefined property '&quot; + name.lexeme + &quot;'.&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxInstance.java</em>, in <em>get</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxInstance.java</em>, in <em>get</em>()</div>
 
 <p>When looking up a property on an instance, if we don&rsquo;t <span
 name="shadow">find</span> a matching field, we look for a method with that name
@@ -911,7 +911,7 @@ hit a method defined on the instance&rsquo;s class.</p>
 <p>Looking for a field first implies that fields shadow methods, a subtle but
 important semantic point.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/LoxClass.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
 add after <em>LoxClass</em>()</div>
 <pre>  <span class="t">LoxFunction</span> <span class="i">findMethod</span>(<span class="t">String</span> <span class="i">name</span>) {
     <span class="k">if</span> (<span class="i">methods</span>.<span class="i">containsKey</span>(<span class="i">name</span>)) {
@@ -921,7 +921,7 @@ add after <em>LoxClass</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxClass.java</em>, add after <em>LoxClass</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, add after <em>LoxClass</em>()</div>
 
 <p>You can probably guess this method is going to get more interesting later. For
 now, a simple map lookup on the class&rsquo;s method table is enough to get us
@@ -1026,12 +1026,12 @@ closures and environment chains should do all this correctly.</p>
 <p>Let&rsquo;s code it up. The first step is adding <span name="this-ast">new
 syntax</span> for <code>this</code>.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Set      : Expr object, Token name, Expr value&quot;,
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;This     : Token keyword&quot;</span>,
 </pre><pre class="insert-after">      &quot;Unary    : Token operator, Expr right&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="this-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#this-expression">Appendix II</a>.</p>
@@ -1040,7 +1040,7 @@ in <em>main</em>()</div>
 recognizes as a reserved word.</p>
 <div class="codehilite"><pre class="insert-before">      return new Expr.Literal(previous().literal);
     }
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>primary</em>()</div>
 <pre class="insert">
 
@@ -1049,11 +1049,11 @@ in <em>primary</em>()</div>
 
     if (match(IDENTIFIER)) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>primary</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>primary</em>()</div>
 
 <p>You can start to see how <code>this</code> works like a variable when we get to the
 resolver.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitSetExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitThisExpr</span>(<span class="t">Expr</span>.<span class="t">This</span> <span class="i">expr</span>) {
@@ -1062,34 +1062,34 @@ add after <em>visitSetExpr</em>()</div>
   }
 
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitSetExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitSetExpr</em>()</div>
 
 <p>We resolve it exactly like any other local variable using &ldquo;this&rdquo; as the name for
 the &ldquo;variable&rdquo;. Of course, that&rsquo;s not going to work right now, because &ldquo;this&rdquo;
 <em>isn&rsquo;t</em> declared in any scope. Let&rsquo;s fix that over in <code>visitClassStmt()</code>.</p>
 <div class="codehilite"><pre class="insert-before">    define(stmt.name);
 
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="i">beginScope</span>();
     <span class="i">scopes</span>.<span class="i">peek</span>().<span class="i">put</span>(<span class="s">&quot;this&quot;</span>, <span class="k">true</span>);
 
 </pre><pre class="insert-after">    for (Stmt.Function method : stmt.methods) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>Before we step in and start resolving the method bodies, we push a new scope and
 define &ldquo;this&rdquo; in it as if it were a variable. Then, when we&rsquo;re done, we discard
 that surrounding scope.</p>
 <div class="codehilite"><pre class="insert-before">    }
 
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="i">endScope</span>();
 
 </pre><pre class="insert-after">    return null;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>Now, whenever a <code>this</code> expression is encountered (at least inside a method) it
 will resolve to a &ldquo;local variable&rdquo; defined in an implicit scope just outside of
@@ -1101,7 +1101,7 @@ each other. At runtime, we create the environment after we find the method on
 the instance. We replace the previous line of code that simply returned the
 method&rsquo;s LoxFunction with this:</p>
 <div class="codehilite"><pre class="insert-before">    LoxFunction method = klass.findMethod(name.lexeme);
-</pre><div class="source-file"><em>lox/LoxInstance.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxInstance.java</em><br>
 in <em>get</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">method</span> != <span class="k">null</span>) <span class="k">return</span> <span class="i">method</span>.<span class="i">bind</span>(<span class="k">this</span>);
@@ -1110,10 +1110,10 @@ replace 1 line</div>
     throw new RuntimeError(name,<span name="hidden"> </span>
         &quot;Undefined property '&quot; + name.lexeme + &quot;'.&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxInstance.java</em>, in <em>get</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxInstance.java</em>, in <em>get</em>(), replace 1 line</div>
 
 <p>Note the new call to <code>bind()</code>. That looks like so:</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
 add after <em>LoxFunction</em>()</div>
 <pre>  <span class="t">LoxFunction</span> <span class="i">bind</span>(<span class="t">LoxInstance</span> <span class="i">instance</span>) {
     <span class="t">Environment</span> <span class="i">environment</span> = <span class="k">new</span> <span class="t">Environment</span>(<span class="i">closure</span>);
@@ -1121,7 +1121,7 @@ add after <em>LoxFunction</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">LoxFunction</span>(<span class="i">declaration</span>, <span class="i">environment</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
 
 <p>There isn&rsquo;t much to it. We create a new environment nestled inside the method&rsquo;s
 original closure. Sort of a closure-within-a-closure. When the method is called,
@@ -1132,14 +1132,14 @@ returned LoxFunction now carries around its own little persistent world where
 &ldquo;this&rdquo; is bound to the object.</p>
 <p>The remaining task is interpreting those <code>this</code> expressions. Similar to the
 resolver, it is the same as interpreting a variable expression.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitSetExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitThisExpr</span>(<span class="t">Expr</span>.<span class="t">This</span> <span class="i">expr</span>) {
     <span class="k">return</span> <span class="i">lookUpVariable</span>(<span class="i">expr</span>.<span class="i">keyword</span>, <span class="i">expr</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitSetExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitSetExpr</em>()</div>
 
 <p>Go ahead and give it a try using that cake example from earlier. With less than
 twenty lines of code, our interpreter handles <code>this</code> inside methods even in all
@@ -1164,7 +1164,7 @@ detects <code>return</code> statements outside of functions. We&rsquo;ll do some
 <code>this</code>. In the vein of our existing FunctionType enum, we define a new ClassType
 one.</p>
 <div class="codehilite"><pre class="insert-before">  }
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after enum <em>FunctionType</em></div>
 <pre class="insert">
 
@@ -1177,7 +1177,7 @@ add after enum <em>FunctionType</em></div>
 
 </pre><pre class="insert-after">  void resolve(List&lt;Stmt&gt; statements) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after enum <em>FunctionType</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after enum <em>FunctionType</em></div>
 
 <p>Yes, it could be a Boolean. When we get to inheritance, it will get a third
 value, hence the enum right now. We also add a corresponding field,
@@ -1186,14 +1186,14 @@ declaration while traversing the syntax tree. It starts out <code>NONE</code> wh
 we aren&rsquo;t in one.</p>
 <p>When we begin to resolve a class declaration, we change that.</p>
 <div class="codehilite"><pre class="insert-before">  public Void visitClassStmt(Stmt.Class stmt) {
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="t">ClassType</span> <span class="i">enclosingClass</span> = <span class="i">currentClass</span>;
     <span class="i">currentClass</span> = <span class="t">ClassType</span>.<span class="i">CLASS</span>;
 
 </pre><pre class="insert-after">    declare(stmt.name);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>As with <code>currentFunction</code>, we store the previous value of the field in a local
 variable. This lets us piggyback onto the JVM to keep a stack of <code>currentClass</code>
@@ -1203,18 +1203,18 @@ inside another.</p>
 value.</p>
 <div class="codehilite"><pre class="insert-before">    endScope();
 
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="i">currentClass</span> = <span class="i">enclosingClass</span>;
 </pre><pre class="insert-after">    return null;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>When we resolve a <code>this</code> expression, the <code>currentClass</code> field gives us the bit
 of data we need to report an error if the expression doesn&rsquo;t occur nestled
 inside a method body.</p>
 <div class="codehilite"><pre class="insert-before">  public Void visitThisExpr(Expr.This expr) {
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitThisExpr</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">currentClass</span> == <span class="t">ClassType</span>.<span class="i">NONE</span>) {
       <span class="t">Lox</span>.<span class="i">error</span>(<span class="i">expr</span>.<span class="i">keyword</span>,
@@ -1224,7 +1224,7 @@ in <em>visitThisExpr</em>()</div>
 
 </pre><pre class="insert-after">    resolveLocal(expr, expr.keyword);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitThisExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitThisExpr</em>()</div>
 
 <p>That should help users use <code>this</code> correctly, and it saves us from having to
 handle misuse at runtime in the interpreter.</p>
@@ -1270,7 +1270,7 @@ and Python call it <code>init()</code>. The latter is nice and short, so we&rsqu
 <p>In LoxClass&rsquo;s implementation of LoxCallable, we add a few more lines.</p>
 <div class="codehilite"><pre class="insert-before">                     List&lt;Object&gt; arguments) {
     LoxInstance instance = new LoxInstance(this);
-</pre><div class="source-file"><em>lox/LoxClass.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
 in <em>call</em>()</div>
 <pre class="insert">    <span class="t">LoxFunction</span> <span class="i">initializer</span> = <span class="i">findMethod</span>(<span class="s">&quot;init&quot;</span>);
     <span class="k">if</span> (<span class="i">initializer</span> != <span class="k">null</span>) {
@@ -1279,14 +1279,14 @@ in <em>call</em>()</div>
 
 </pre><pre class="insert-after">    return instance;
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxClass.java</em>, in <em>call</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, in <em>call</em>()</div>
 
 <p>When a class is called, after the LoxInstance is created, we look for an &ldquo;init&rdquo;
 method. If we find one, we immediately bind and invoke it just like a normal
 method call. The argument list is forwarded along.</p>
 <p>That argument list means we also need to tweak how a class declares its arity.</p>
 <div class="codehilite"><pre class="insert-before">  public int arity() {
-</pre><div class="source-file"><em>lox/LoxClass.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
 in <em>arity</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">LoxFunction</span> <span class="i">initializer</span> = <span class="i">findMethod</span>(<span class="s">&quot;init&quot;</span>);
@@ -1294,7 +1294,7 @@ replace 1 line</div>
     <span class="k">return</span> <span class="i">initializer</span>.<span class="i">arity</span>();
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxClass.java</em>, in <em>arity</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, in <em>arity</em>(), replace 1 line</div>
 
 <p>If there is an initializer, that method&rsquo;s arity determines how many arguments
 you must pass when you call the class itself. We don&rsquo;t <em>require</em> a class to
@@ -1334,20 +1334,20 @@ that won&rsquo;t cause your users and future self to curse your shortsightedness
 </aside>
 <div class="codehilite"><pre class="insert-before">      return returnValue.value;
     }
-</pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
 in <em>call</em>()</div>
 <pre class="insert">
 
     <span class="k">if</span> (<span class="i">isInitializer</span>) <span class="k">return</span> <span class="i">closure</span>.<span class="i">getAt</span>(<span class="n">0</span>, <span class="s">&quot;this&quot;</span>);
 </pre><pre class="insert-after">    return null;
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, in <em>call</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, in <em>call</em>()</div>
 
 <p>If the function is an initializer, we override the actual return value and
 forcibly return <code>this</code>. That relies on a new <code>isInitializer</code> field.</p>
 <div class="codehilite"><pre class="insert-before">  private final Environment closure;
 
-</pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
 in class <em>LoxFunction</em><br>
 replace 1 line</div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">boolean</span> <span class="i">isInitializer</span>;
@@ -1358,7 +1358,7 @@ replace 1 line</div>
 </pre><pre class="insert-after">    this.closure = closure;
     this.declaration = declaration;
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, in class <em>LoxFunction</em>, replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, in class <em>LoxFunction</em>, replace 1 line</div>
 
 <p>We can&rsquo;t simply see if the name of the LoxFunction is &ldquo;init&rdquo; because the user
 could have defined a <em>function</em> with that name. In that case, there <em>is</em> no
@@ -1366,38 +1366,38 @@ could have defined a <em>function</em> with that name. In that case, there <em>i
 the LoxFunction represents an initializer method. That means we need to go back
 and fix the few places where we create LoxFunctions.</p>
 <div class="codehilite"><pre class="insert-before">  public Void visitFunctionStmt(Stmt.Function stmt) {
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitFunctionStmt</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">LoxFunction</span> <span class="i">function</span> = <span class="k">new</span> <span class="t">LoxFunction</span>(<span class="i">stmt</span>, <span class="i">environment</span>,
                                            <span class="k">false</span>);
 </pre><pre class="insert-after">    environment.define(stmt.name.lexeme, function);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitFunctionStmt</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitFunctionStmt</em>(), replace 1 line</div>
 
 <p>For actual function declarations, <code>isInitializer</code> is always false. For methods,
 we check the name.</p>
 <div class="codehilite"><pre class="insert-before">    for (Stmt.Function method : stmt.methods) {
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitClassStmt</em>()<br>
 replace 1 line</div>
 <pre class="insert">      <span class="t">LoxFunction</span> <span class="i">function</span> = <span class="k">new</span> <span class="t">LoxFunction</span>(<span class="i">method</span>, <span class="i">environment</span>,
           <span class="i">method</span>.<span class="i">name</span>.<span class="i">lexeme</span>.<span class="i">equals</span>(<span class="s">&quot;init&quot;</span>));
 </pre><pre class="insert-after">      methods.put(method.name.lexeme, function);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitClassStmt</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitClassStmt</em>(), replace 1 line</div>
 
 <p>And then in <code>bind()</code> where we create the closure that binds <code>this</code> to a method,
 we pass along the original method&rsquo;s value.</p>
 <div class="codehilite"><pre class="insert-before">    environment.define(&quot;this&quot;, instance);
-</pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
 in <em>bind</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="k">return</span> <span class="k">new</span> <span class="t">LoxFunction</span>(<span class="i">declaration</span>, <span class="i">environment</span>,
                            <span class="i">isInitializer</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, in <em>bind</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, in <em>bind</em>(), replace 1 line</div>
 
 <h3><a href="#returning-from-init" id="returning-from-init"><small>12&#8202;.&#8202;7&#8202;.&#8202;2</small>Returning from init()</a></h3>
 <p>We aren&rsquo;t out of the woods yet. We&rsquo;ve been assuming that a user-written
@@ -1412,17 +1412,17 @@ What should happen if a user tries:</p>
 <p>It&rsquo;s definitely not going to do what they want, so we may as well make it a
 static error. Back in the resolver, we add another case to FunctionType.</p>
 <div class="codehilite"><pre class="insert-before">    FUNCTION,
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in enum <em>FunctionType</em></div>
 <pre class="insert">    <span class="i">INITIALIZER</span>,
 </pre><pre class="insert-after">    METHOD
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in enum <em>FunctionType</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in enum <em>FunctionType</em></div>
 
 <p>We use the visited method&rsquo;s name to determine if we&rsquo;re resolving an initializer
 or not.</p>
 <div class="codehilite"><pre class="insert-before">      FunctionType declaration = FunctionType.METHOD;
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">method</span>.<span class="i">name</span>.<span class="i">lexeme</span>.<span class="i">equals</span>(<span class="s">&quot;init&quot;</span>)) {
         <span class="i">declaration</span> = <span class="t">FunctionType</span>.<span class="i">INITIALIZER</span>;
@@ -1430,12 +1430,12 @@ in <em>visitClassStmt</em>()</div>
 
 </pre><pre class="insert-after">      resolveFunction(method, declaration);<span name="local"> </span>
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>When we later traverse into a <code>return</code> statement, we check that field and make
 it an error to return a value from inside an <code>init()</code> method.</p>
 <div class="codehilite"><pre class="insert-before">    if (stmt.value != null) {
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitReturnStmt</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">currentFunction</span> == <span class="t">FunctionType</span>.<span class="i">INITIALIZER</span>) {
         <span class="t">Lox</span>.<span class="i">error</span>(<span class="i">stmt</span>.<span class="i">keyword</span>,
@@ -1444,7 +1444,7 @@ in <em>visitReturnStmt</em>()</div>
 
 </pre><pre class="insert-after">      resolve(stmt.value);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitReturnStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitReturnStmt</em>()</div>
 
 <p>We&rsquo;re <em>still</em> not done. We statically disallow returning a <em>value</em> from an
 initializer, but you can still use an empty early <code>return</code>.</p>
@@ -1458,13 +1458,13 @@ initializer, but you can still use an empty early <code>return</code>.</p>
 entirely. Instead, it should return <code>this</code> instead of <code>nil</code>. That&rsquo;s an easy fix
 over in LoxFunction.</p>
 <div class="codehilite"><pre class="insert-before">    } catch (Return returnValue) {
-</pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
 in <em>call</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">isInitializer</span>) <span class="k">return</span> <span class="i">closure</span>.<span class="i">getAt</span>(<span class="n">0</span>, <span class="s">&quot;this&quot;</span>);
 
 </pre><pre class="insert-after">      return returnValue.value;
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, in <em>call</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, in <em>call</em>()</div>
 
 <p>If we&rsquo;re in an initializer and execute a <code>return</code> statement, instead of
 returning the value (which will always be <code>nil</code>), we again return <code>this</code>.</p>

--- a/site/classes.html
+++ b/site/classes.html
@@ -201,12 +201,12 @@ fields to them as you see fit using normal imperative code.</p>
 <p>Over in our AST generator, the <code>classDecl</code> grammar rule gets its own statement
 <span name="class-ast">node</span>.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Block      : List&lt;Stmt&gt; statements&quot;,
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Class      : Token name, List&lt;Stmt.Function&gt; methods&quot;</span>,
 </pre><pre class="insert-after">      &quot;Expression : Expr expression&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="class-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#class-statement">Appendix II</a>.</p>
@@ -218,15 +218,15 @@ method: name, parameter list, and body.</p>
 <p>A class can appear anywhere a named declaration is allowed, triggered by the
 leading <code>class</code> keyword.</p>
 <div class="codehilite"><pre class="insert-before">    try {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>declaration</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">match</span>(<span class="i">CLASS</span>)) <span class="k">return</span> <span class="i">classDeclaration</span>();
 </pre><pre class="insert-after">      if (match(FUN)) return function(&quot;function&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>declaration</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>declaration</em>()</div>
 
 <p>That calls out to:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>declaration</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">classDeclaration</span>() {
     <span class="t">Token</span> <span class="i">name</span> = <span class="i">consume</span>(<span class="i">IDENTIFIER</span>, <span class="s">&quot;Expect class name.&quot;</span>);
@@ -242,7 +242,7 @@ add after <em>declaration</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Class</span>(<span class="i">name</span>, <span class="i">methods</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>declaration</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>declaration</em>()</div>
 
 <p>There&rsquo;s more meat to this than most of the other parsing methods, but it roughly
 follows the grammar. We&rsquo;ve already consumed the <code>class</code> keyword, so we look for
@@ -258,7 +258,7 @@ class body.</p>
 <p>We wrap the name and list of methods into a Stmt.Class node and we&rsquo;re done.
 Previously, we would jump straight into the interpreter, but now we need to
 plumb the node through the resolver first.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitClassStmt</span>(<span class="t">Stmt</span>.<span class="t">Class</span> <span class="i">stmt</span>) {
@@ -267,14 +267,14 @@ add after <em>visitBlockStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
 
 <p>We aren&rsquo;t going to worry about resolving the methods themselves yet, so for now
 all we need to do is declare the class using its name. It&rsquo;s not common to
 declare a class as a local variable, but Lox permits it, so we need to handle it
 correctly.</p>
 <p>Now we interpret the class declaration.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitClassStmt</span>(<span class="t">Stmt</span>.<span class="t">Class</span> <span class="i">stmt</span>) {
@@ -284,7 +284,7 @@ add after <em>visitBlockStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitBlockStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitBlockStmt</em>()</div>
 
 <p>This looks similar to how we execute function declarations. We declare the
 class&rsquo;s name in the current environment. Then we turn the class <em>syntax node</em>
@@ -293,7 +293,7 @@ store the class object in the variable we previously declared. That two-stage
 variable binding process allows references to the class inside its own methods.</p>
 <p>We will refine it throughout the chapter, but the first draft of LoxClass looks
 like this:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/LoxClass.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -313,7 +313,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/LoxClass.java</em>, create new file</div>
 
 <p>Literally a wrapper around a name. We don&rsquo;t even store the methods yet. Not
 super useful, but it does have a <code>toString()</code> method so we can write a trivial
@@ -357,15 +357,15 @@ implements <code>LoxCallable</code> and reports an error since LoxClass doesn&rs
 that is.</p>
 <div class="codehilite"><pre class="insert-before">import java.util.Map;
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
+</pre><div class="source-file"><em>lox/LoxClass.java</em><br>
 replace 1 line</div>
 <pre class="insert"><span class="k">class</span> <span class="t">LoxClass</span> <span class="k">implements</span> <span class="t">LoxCallable</span> {
 </pre><pre class="insert-after">  final String name;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, replace 1 line</div>
+<div class="source-file-narrow"><em>lox/LoxClass.java</em>, replace 1 line</div>
 
 <p>Implementing that interface requires two methods.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/LoxClass.java</em><br>
 add after <em>toString</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">call</span>(<span class="t">Interpreter</span> <span class="i">interpreter</span>,
@@ -379,7 +379,7 @@ add after <em>toString</em>()</div>
     <span class="k">return</span> <span class="n">0</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, add after <em>toString</em>()</div>
+<div class="source-file-narrow"><em>lox/LoxClass.java</em>, add after <em>toString</em>()</div>
 
 <p>The interesting one is <code>call()</code>. When you &ldquo;call&rdquo; a class, it instantiates a new
 LoxInstance for the called class and returns it. The <code>arity()</code> method is how the
@@ -388,7 +388,7 @@ callable. For now, we&rsquo;ll say you can&rsquo;t pass any. When we get to user
 constructors, we&rsquo;ll revisit this.</p>
 <p>That leads us to LoxInstance, the runtime representation of an instance of a Lox
 class. Again, our first implementation starts small.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxInstance.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/LoxInstance.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -408,7 +408,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxInstance.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/LoxInstance.java</em>, create new file</div>
 
 <p>Like LoxClass, it&rsquo;s pretty bare bones, but we&rsquo;re only getting started. If you
 want to give it a try, here&rsquo;s a script to run:</p>
@@ -450,12 +450,12 @@ here on out, we&rsquo;ll call these &ldquo;get expressions&rdquo;.</p>
 <h3><a href="#get-expressions" id="get-expressions"><small>12&#8202;.&#8202;4&#8202;.&#8202;1</small>Get expressions</a></h3>
 <p>The <span name="get-ast">syntax tree node</span> is:</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Call     : Expr callee, Token paren, List&lt;Expr&gt; arguments&quot;,
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Get      : Expr object, Token name&quot;</span>,
 </pre><pre class="insert-after">      &quot;Grouping : Expr expression&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="get-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#get-expression">Appendix II</a>.</p>
@@ -465,7 +465,7 @@ method.</p>
 <div class="codehilite"><pre class="insert-before">    while (true) {<span name="while-true"> </span>
       if (match(LEFT_PAREN)) {
         expr = finishCall(expr);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>call</em>()</div>
 <pre class="insert">      } <span class="k">else</span> <span class="k">if</span> (<span class="i">match</span>(<span class="i">DOT</span>)) {
         <span class="t">Token</span> <span class="i">name</span> = <span class="i">consume</span>(<span class="i">IDENTIFIER</span>,
@@ -476,13 +476,13 @@ in <em>call</em>()</div>
       }
     }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>call</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>call</em>()</div>
 
 <p>The outer <code>while</code> loop there corresponds to the <code>*</code> in the grammar rule. We zip
 along the tokens building up a chain of calls and gets as we find parentheses
 and dots, like so:</p><img src="image/classes/zip.png" alt="Parsing a series of '.' and '()' expressions to an AST." />
 <p>Instances of the new Expr.Get node feed into the resolver.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitCallExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitGetExpr</span>(<span class="t">Expr</span>.<span class="t">Get</span> <span class="i">expr</span>) {
@@ -490,7 +490,7 @@ add after <em>visitCallExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitCallExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitCallExpr</em>()</div>
 
 <p>OK, not much to that. Since properties are looked up <span
 name="dispatch">dynamically</span>, they don&rsquo;t get resolved. During resolution,
@@ -500,7 +500,7 @@ access happens in the interpreter.</p>
 <p>You can literally see that property dispatch in Lox is dynamic since we don&rsquo;t
 process the property name during the static resolution pass.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitCallExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitGetExpr</span>(<span class="t">Expr</span>.<span class="t">Get</span> <span class="i">expr</span>) {
@@ -513,7 +513,7 @@ add after <em>visitCallExpr</em>()</div>
         <span class="s">&quot;Only instances have properties.&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitCallExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitCallExpr</em>()</div>
 
 <p>First, we evaluate the expression whose property is being accessed. In Lox, only
 instances of classes have properties. If the object is some other type like a
@@ -521,18 +521,18 @@ number, invoking a getter on it is a runtime error.</p>
 <p>If the object is a LoxInstance, then we ask it to look up the property. It must
 be time to give LoxInstance some actual state. A map will do fine.</p>
 <div class="codehilite"><pre class="insert-before">  private LoxClass klass;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxInstance.java</em><br>
+</pre><div class="source-file"><em>lox/LoxInstance.java</em><br>
 in class <em>LoxInstance</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">Map</span>&lt;<span class="t">String</span>, <span class="t">Object</span>&gt; <span class="i">fields</span> = <span class="k">new</span> <span class="t">HashMap</span>&lt;&gt;();
 </pre><pre class="insert-after">
 
   LoxInstance(LoxClass klass) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxInstance.java</em>, in class <em>LoxInstance</em></div>
+<div class="source-file-narrow"><em>lox/LoxInstance.java</em>, in class <em>LoxInstance</em></div>
 
 <p>Each key in the map is a property name and the corresponding value is the
 property&rsquo;s value. To look up a property on an instance:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxInstance.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/LoxInstance.java</em><br>
 add after <em>LoxInstance</em>()</div>
 <pre>  <span class="t">Object</span> <span class="i">get</span>(<span class="t">Token</span> <span class="i">name</span>) {
     <span class="k">if</span> (<span class="i">fields</span>.<span class="i">containsKey</span>(<span class="i">name</span>.<span class="i">lexeme</span>)) {
@@ -543,7 +543,7 @@ add after <em>LoxInstance</em>()</div>
         <span class="s">&quot;Undefined property &#39;&quot;</span> + <span class="i">name</span>.<span class="i">lexeme</span> + <span class="s">&quot;&#39;.&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxInstance.java</em>, add after <em>LoxInstance</em>()</div>
+<div class="source-file-narrow"><em>lox/LoxInstance.java</em>, add after <em>LoxInstance</em>()</div>
 
 <aside name="hidden">
 <p>Doing a hash table lookup for every field access is fast enough for many
@@ -591,12 +591,12 @@ high-precedence expression before the last dot, including any number of
 assignment, we need a <span name="set-ast">second setter node</span> to
 complement our getter node.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Logical  : Expr left, Token operator, Expr right&quot;,
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Set      : Expr object, Token name, Expr value&quot;</span>,
 </pre><pre class="insert-after">      &quot;Unary    : Token operator, Expr right&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="set-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#set-expression">Appendix II</a>.</p>
@@ -614,17 +614,17 @@ assignment.</p>
 <p>We add another clause to that transformation to handle turning an Expr.Get
 expression on the left into the corresponding Expr.Set.</p>
 <div class="codehilite"><pre class="insert-before">        return new Expr.Assign(name, value);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>assignment</em>()</div>
 <pre class="insert">      } <span class="k">else</span> <span class="k">if</span> (<span class="i">expr</span> <span class="k">instanceof</span> <span class="t">Expr</span>.<span class="t">Get</span>) {
         <span class="t">Expr</span>.<span class="t">Get</span> <span class="i">get</span> = (<span class="t">Expr</span>.<span class="t">Get</span>)<span class="i">expr</span>;
         <span class="k">return</span> <span class="k">new</span> <span class="t">Expr</span>.<span class="t">Set</span>(<span class="i">get</span>.<span class="i">object</span>, <span class="i">get</span>.<span class="i">name</span>, <span class="i">value</span>);
 </pre><pre class="insert-after">      }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>assignment</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>assignment</em>()</div>
 
 <p>That&rsquo;s parsing our syntax. We push that node through into the resolver.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitLogicalExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitSetExpr</span>(<span class="t">Expr</span>.<span class="t">Set</span> <span class="i">expr</span>) {
@@ -633,14 +633,14 @@ add after <em>visitLogicalExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitLogicalExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitLogicalExpr</em>()</div>
 
 <p>Again, like Expr.Get, the property itself is dynamically evaluated, so there&rsquo;s
 nothing to resolve there. All we need to do is recurse into the two
 subexpressions of Expr.Set, the object whose property is being set, and the
 value it&rsquo;s being set to.</p>
 <p>That leads us to the interpreter.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitLogicalExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitSetExpr</span>(<span class="t">Expr</span>.<span class="t">Set</span> <span class="i">expr</span>) {
@@ -656,7 +656,7 @@ add after <em>visitLogicalExpr</em>()</div>
     <span class="k">return</span> <span class="i">value</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitLogicalExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitLogicalExpr</em>()</div>
 
 <p>We evaluate the object whose property is being set and check to see if it&rsquo;s a
 LoxInstance. If not, that&rsquo;s a runtime error. Otherwise, we evaluate the value
@@ -679,13 +679,13 @@ LoxInstance.</p>
 to carefully specify it and ensure our implementations do these in the same
 order.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxInstance.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/LoxInstance.java</em><br>
 add after <em>get</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">set</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">Object</span> <span class="i">value</span>) {
     <span class="i">fields</span>.<span class="i">put</span>(<span class="i">name</span>.<span class="i">lexeme</span>, <span class="i">value</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxInstance.java</em>, add after <em>get</em>()</div>
+<div class="source-file-narrow"><em>lox/LoxInstance.java</em>, add after <em>get</em>()</div>
 
 <p>No real magic here. We stuff the values straight into the Java map where fields
 live. Since Lox allows freely creating new fields on instances, there&rsquo;s no need
@@ -810,7 +810,7 @@ cases for a bit. We&rsquo;ll get back to those. For now, let&rsquo;s get basic m
 working. We&rsquo;re already parsing the method declarations inside the class body, so
 the next step is to resolve them.</p>
 <div class="codehilite"><pre class="insert-before">    define(stmt.name);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">
 
@@ -821,7 +821,7 @@ in <em>visitClassStmt</em>()</div>
 
 </pre><pre class="insert-after">    return null;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <aside name="local">
 <p>Storing the function type in a local variable is pointless right now, but we&rsquo;ll
@@ -832,18 +832,18 @@ expand this code before too long and it will make more sense.</p>
 The only difference is that we pass in a new FunctionType enum value.</p>
 <div class="codehilite"><pre class="insert-before">    NONE,
 </pre><pre class="insert-before">    <span class="i">FUNCTION</span><span class="insert-comma">,</span>
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in enum <em>FunctionType</em><br>
 add <em>&ldquo;,&rdquo;</em> to previous line</div>
 <pre class="insert">    <span class="i">METHOD</span>
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in enum <em>FunctionType</em>, add <em>&ldquo;,&rdquo;</em> to previous line</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in enum <em>FunctionType</em>, add <em>&ldquo;,&rdquo;</em> to previous line</div>
 
 <p>That&rsquo;s going to be important when we resolve <code>this</code> expressions. For now, don&rsquo;t
 worry about it. The interesting stuff is in the interpreter.</p>
 <div class="codehilite"><pre class="insert-before">    environment.define(stmt.name.lexeme, null);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitClassStmt</em>()<br>
 replace 1 line</div>
 <pre class="insert">
@@ -857,7 +857,7 @@ replace 1 line</div>
     <span class="t">LoxClass</span> <span class="i">klass</span> = <span class="k">new</span> <span class="t">LoxClass</span>(<span class="i">stmt</span>.<span class="i">name</span>.<span class="i">lexeme</span>, <span class="i">methods</span>);
 </pre><pre class="insert-after">    environment.assign(stmt.name, klass);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitClassStmt</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitClassStmt</em>(), replace 1 line</div>
 
 <p>When we interpret a class declaration statement, we turn the syntactic
 representation of the class<span class="em">&mdash;</span>its AST node<span class="em">&mdash;</span>into its runtime representation.
@@ -866,7 +866,7 @@ method declaration blossoms into a LoxFunction object.</p>
 <p>We take all of those and wrap them up into a map, keyed by the method names.
 That gets stored in LoxClass.</p>
 <div class="codehilite"><pre class="insert-before">  final String name;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
+</pre><div class="source-file"><em>lox/LoxClass.java</em><br>
 in class <em>LoxClass</em><br>
 replace 4 lines</div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">Map</span>&lt;<span class="t">String</span>, <span class="t">LoxFunction</span>&gt; <span class="i">methods</span>;
@@ -880,7 +880,7 @@ replace 4 lines</div>
   @Override
   public String toString() {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, in class <em>LoxClass</em>, replace 4 lines</div>
+<div class="source-file-narrow"><em>lox/LoxClass.java</em>, in class <em>LoxClass</em>, replace 4 lines</div>
 
 <p>Where an instance stores state, the class stores behavior. LoxInstance has its
 map of fields, and LoxClass gets a map of methods. Even though methods are
@@ -890,7 +890,7 @@ owned by the class, they are still accessed through instances of that class.</p>
       return fields.get(name.lexeme);
     }
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxInstance.java</em><br>
+</pre><div class="source-file"><em>lox/LoxInstance.java</em><br>
 in <em>get</em>()</div>
 <pre class="insert">    <span class="t">LoxFunction</span> <span class="i">method</span> = <span class="i">klass</span>.<span class="i">findMethod</span>(<span class="i">name</span>.<span class="i">lexeme</span>);
     <span class="k">if</span> (<span class="i">method</span> != <span class="k">null</span>) <span class="k">return</span> <span class="i">method</span>;
@@ -898,7 +898,7 @@ in <em>get</em>()</div>
 </pre><pre class="insert-after">    throw new RuntimeError(name,<span name="hidden"> </span>
         &quot;Undefined property '&quot; + name.lexeme + &quot;'.&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxInstance.java</em>, in <em>get</em>()</div>
+<div class="source-file-narrow"><em>lox/LoxInstance.java</em>, in <em>get</em>()</div>
 
 <p>When looking up a property on an instance, if we don&rsquo;t <span
 name="shadow">find</span> a matching field, we look for a method with that name
@@ -911,7 +911,7 @@ hit a method defined on the instance&rsquo;s class.</p>
 <p>Looking for a field first implies that fields shadow methods, a subtle but
 important semantic point.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/LoxClass.java</em><br>
 add after <em>LoxClass</em>()</div>
 <pre>  <span class="t">LoxFunction</span> <span class="i">findMethod</span>(<span class="t">String</span> <span class="i">name</span>) {
     <span class="k">if</span> (<span class="i">methods</span>.<span class="i">containsKey</span>(<span class="i">name</span>)) {
@@ -921,7 +921,7 @@ add after <em>LoxClass</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, add after <em>LoxClass</em>()</div>
+<div class="source-file-narrow"><em>lox/LoxClass.java</em>, add after <em>LoxClass</em>()</div>
 
 <p>You can probably guess this method is going to get more interesting later. For
 now, a simple map lookup on the class&rsquo;s method table is enough to get us
@@ -1026,12 +1026,12 @@ closures and environment chains should do all this correctly.</p>
 <p>Let&rsquo;s code it up. The first step is adding <span name="this-ast">new
 syntax</span> for <code>this</code>.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Set      : Expr object, Token name, Expr value&quot;,
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;This     : Token keyword&quot;</span>,
 </pre><pre class="insert-after">      &quot;Unary    : Token operator, Expr right&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="this-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#this-expression">Appendix II</a>.</p>
@@ -1040,7 +1040,7 @@ in <em>main</em>()</div>
 recognizes as a reserved word.</p>
 <div class="codehilite"><pre class="insert-before">      return new Expr.Literal(previous().literal);
     }
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>primary</em>()</div>
 <pre class="insert">
 
@@ -1049,11 +1049,11 @@ in <em>primary</em>()</div>
 
     if (match(IDENTIFIER)) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>primary</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>primary</em>()</div>
 
 <p>You can start to see how <code>this</code> works like a variable when we get to the
 resolver.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitSetExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitThisExpr</span>(<span class="t">Expr</span>.<span class="t">This</span> <span class="i">expr</span>) {
@@ -1062,34 +1062,34 @@ add after <em>visitSetExpr</em>()</div>
   }
 
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitSetExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitSetExpr</em>()</div>
 
 <p>We resolve it exactly like any other local variable using &ldquo;this&rdquo; as the name for
 the &ldquo;variable&rdquo;. Of course, that&rsquo;s not going to work right now, because &ldquo;this&rdquo;
 <em>isn&rsquo;t</em> declared in any scope. Let&rsquo;s fix that over in <code>visitClassStmt()</code>.</p>
 <div class="codehilite"><pre class="insert-before">    define(stmt.name);
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="i">beginScope</span>();
     <span class="i">scopes</span>.<span class="i">peek</span>().<span class="i">put</span>(<span class="s">&quot;this&quot;</span>, <span class="k">true</span>);
 
 </pre><pre class="insert-after">    for (Stmt.Function method : stmt.methods) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>Before we step in and start resolving the method bodies, we push a new scope and
 define &ldquo;this&rdquo; in it as if it were a variable. Then, when we&rsquo;re done, we discard
 that surrounding scope.</p>
 <div class="codehilite"><pre class="insert-before">    }
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="i">endScope</span>();
 
 </pre><pre class="insert-after">    return null;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>Now, whenever a <code>this</code> expression is encountered (at least inside a method) it
 will resolve to a &ldquo;local variable&rdquo; defined in an implicit scope just outside of
@@ -1101,7 +1101,7 @@ each other. At runtime, we create the environment after we find the method on
 the instance. We replace the previous line of code that simply returned the
 method&rsquo;s LoxFunction with this:</p>
 <div class="codehilite"><pre class="insert-before">    LoxFunction method = klass.findMethod(name.lexeme);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxInstance.java</em><br>
+</pre><div class="source-file"><em>lox/LoxInstance.java</em><br>
 in <em>get</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">method</span> != <span class="k">null</span>) <span class="k">return</span> <span class="i">method</span>.<span class="i">bind</span>(<span class="k">this</span>);
@@ -1110,10 +1110,10 @@ replace 1 line</div>
     throw new RuntimeError(name,<span name="hidden"> </span>
         &quot;Undefined property '&quot; + name.lexeme + &quot;'.&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxInstance.java</em>, in <em>get</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/LoxInstance.java</em>, in <em>get</em>(), replace 1 line</div>
 
 <p>Note the new call to <code>bind()</code>. That looks like so:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
 add after <em>LoxFunction</em>()</div>
 <pre>  <span class="t">LoxFunction</span> <span class="i">bind</span>(<span class="t">LoxInstance</span> <span class="i">instance</span>) {
     <span class="t">Environment</span> <span class="i">environment</span> = <span class="k">new</span> <span class="t">Environment</span>(<span class="i">closure</span>);
@@ -1121,7 +1121,7 @@ add after <em>LoxFunction</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">LoxFunction</span>(<span class="i">declaration</span>, <span class="i">environment</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
+<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
 
 <p>There isn&rsquo;t much to it. We create a new environment nestled inside the method&rsquo;s
 original closure. Sort of a closure-within-a-closure. When the method is called,
@@ -1132,14 +1132,14 @@ returned LoxFunction now carries around its own little persistent world where
 &ldquo;this&rdquo; is bound to the object.</p>
 <p>The remaining task is interpreting those <code>this</code> expressions. Similar to the
 resolver, it is the same as interpreting a variable expression.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitSetExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitThisExpr</span>(<span class="t">Expr</span>.<span class="t">This</span> <span class="i">expr</span>) {
     <span class="k">return</span> <span class="i">lookUpVariable</span>(<span class="i">expr</span>.<span class="i">keyword</span>, <span class="i">expr</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitSetExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitSetExpr</em>()</div>
 
 <p>Go ahead and give it a try using that cake example from earlier. With less than
 twenty lines of code, our interpreter handles <code>this</code> inside methods even in all
@@ -1164,7 +1164,7 @@ detects <code>return</code> statements outside of functions. We&rsquo;ll do some
 <code>this</code>. In the vein of our existing FunctionType enum, we define a new ClassType
 one.</p>
 <div class="codehilite"><pre class="insert-before">  }
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 add after enum <em>FunctionType</em></div>
 <pre class="insert">
 
@@ -1177,7 +1177,7 @@ add after enum <em>FunctionType</em></div>
 
 </pre><pre class="insert-after">  void resolve(List&lt;Stmt&gt; statements) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after enum <em>FunctionType</em></div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after enum <em>FunctionType</em></div>
 
 <p>Yes, it could be a Boolean. When we get to inheritance, it will get a third
 value, hence the enum right now. We also add a corresponding field,
@@ -1186,14 +1186,14 @@ declaration while traversing the syntax tree. It starts out <code>NONE</code> wh
 we aren&rsquo;t in one.</p>
 <p>When we begin to resolve a class declaration, we change that.</p>
 <div class="codehilite"><pre class="insert-before">  public Void visitClassStmt(Stmt.Class stmt) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="t">ClassType</span> <span class="i">enclosingClass</span> = <span class="i">currentClass</span>;
     <span class="i">currentClass</span> = <span class="t">ClassType</span>.<span class="i">CLASS</span>;
 
 </pre><pre class="insert-after">    declare(stmt.name);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>As with <code>currentFunction</code>, we store the previous value of the field in a local
 variable. This lets us piggyback onto the JVM to keep a stack of <code>currentClass</code>
@@ -1203,18 +1203,18 @@ inside another.</p>
 value.</p>
 <div class="codehilite"><pre class="insert-before">    endScope();
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="i">currentClass</span> = <span class="i">enclosingClass</span>;
 </pre><pre class="insert-after">    return null;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>When we resolve a <code>this</code> expression, the <code>currentClass</code> field gives us the bit
 of data we need to report an error if the expression doesn&rsquo;t occur nestled
 inside a method body.</p>
 <div class="codehilite"><pre class="insert-before">  public Void visitThisExpr(Expr.This expr) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitThisExpr</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">currentClass</span> == <span class="t">ClassType</span>.<span class="i">NONE</span>) {
       <span class="t">Lox</span>.<span class="i">error</span>(<span class="i">expr</span>.<span class="i">keyword</span>,
@@ -1224,7 +1224,7 @@ in <em>visitThisExpr</em>()</div>
 
 </pre><pre class="insert-after">    resolveLocal(expr, expr.keyword);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitThisExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitThisExpr</em>()</div>
 
 <p>That should help users use <code>this</code> correctly, and it saves us from having to
 handle misuse at runtime in the interpreter.</p>
@@ -1270,7 +1270,7 @@ and Python call it <code>init()</code>. The latter is nice and short, so we&rsqu
 <p>In LoxClass&rsquo;s implementation of LoxCallable, we add a few more lines.</p>
 <div class="codehilite"><pre class="insert-before">                     List&lt;Object&gt; arguments) {
     LoxInstance instance = new LoxInstance(this);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
+</pre><div class="source-file"><em>lox/LoxClass.java</em><br>
 in <em>call</em>()</div>
 <pre class="insert">    <span class="t">LoxFunction</span> <span class="i">initializer</span> = <span class="i">findMethod</span>(<span class="s">&quot;init&quot;</span>);
     <span class="k">if</span> (<span class="i">initializer</span> != <span class="k">null</span>) {
@@ -1279,14 +1279,14 @@ in <em>call</em>()</div>
 
 </pre><pre class="insert-after">    return instance;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, in <em>call</em>()</div>
+<div class="source-file-narrow"><em>lox/LoxClass.java</em>, in <em>call</em>()</div>
 
 <p>When a class is called, after the LoxInstance is created, we look for an &ldquo;init&rdquo;
 method. If we find one, we immediately bind and invoke it just like a normal
 method call. The argument list is forwarded along.</p>
 <p>That argument list means we also need to tweak how a class declares its arity.</p>
 <div class="codehilite"><pre class="insert-before">  public int arity() {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
+</pre><div class="source-file"><em>lox/LoxClass.java</em><br>
 in <em>arity</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">LoxFunction</span> <span class="i">initializer</span> = <span class="i">findMethod</span>(<span class="s">&quot;init&quot;</span>);
@@ -1294,7 +1294,7 @@ replace 1 line</div>
     <span class="k">return</span> <span class="i">initializer</span>.<span class="i">arity</span>();
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, in <em>arity</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/LoxClass.java</em>, in <em>arity</em>(), replace 1 line</div>
 
 <p>If there is an initializer, that method&rsquo;s arity determines how many arguments
 you must pass when you call the class itself. We don&rsquo;t <em>require</em> a class to
@@ -1334,20 +1334,20 @@ that won&rsquo;t cause your users and future self to curse your shortsightedness
 </aside>
 <div class="codehilite"><pre class="insert-before">      return returnValue.value;
     }
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
+</pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
 in <em>call</em>()</div>
 <pre class="insert">
 
     <span class="k">if</span> (<span class="i">isInitializer</span>) <span class="k">return</span> <span class="i">closure</span>.<span class="i">getAt</span>(<span class="n">0</span>, <span class="s">&quot;this&quot;</span>);
 </pre><pre class="insert-after">    return null;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, in <em>call</em>()</div>
+<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, in <em>call</em>()</div>
 
 <p>If the function is an initializer, we override the actual return value and
 forcibly return <code>this</code>. That relies on a new <code>isInitializer</code> field.</p>
 <div class="codehilite"><pre class="insert-before">  private final Environment closure;
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
+</pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
 in class <em>LoxFunction</em><br>
 replace 1 line</div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">boolean</span> <span class="i">isInitializer</span>;
@@ -1358,7 +1358,7 @@ replace 1 line</div>
 </pre><pre class="insert-after">    this.closure = closure;
     this.declaration = declaration;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, in class <em>LoxFunction</em>, replace 1 line</div>
+<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, in class <em>LoxFunction</em>, replace 1 line</div>
 
 <p>We can&rsquo;t simply see if the name of the LoxFunction is &ldquo;init&rdquo; because the user
 could have defined a <em>function</em> with that name. In that case, there <em>is</em> no
@@ -1366,38 +1366,38 @@ could have defined a <em>function</em> with that name. In that case, there <em>i
 the LoxFunction represents an initializer method. That means we need to go back
 and fix the few places where we create LoxFunctions.</p>
 <div class="codehilite"><pre class="insert-before">  public Void visitFunctionStmt(Stmt.Function stmt) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitFunctionStmt</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">LoxFunction</span> <span class="i">function</span> = <span class="k">new</span> <span class="t">LoxFunction</span>(<span class="i">stmt</span>, <span class="i">environment</span>,
                                            <span class="k">false</span>);
 </pre><pre class="insert-after">    environment.define(stmt.name.lexeme, function);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitFunctionStmt</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitFunctionStmt</em>(), replace 1 line</div>
 
 <p>For actual function declarations, <code>isInitializer</code> is always false. For methods,
 we check the name.</p>
 <div class="codehilite"><pre class="insert-before">    for (Stmt.Function method : stmt.methods) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitClassStmt</em>()<br>
 replace 1 line</div>
 <pre class="insert">      <span class="t">LoxFunction</span> <span class="i">function</span> = <span class="k">new</span> <span class="t">LoxFunction</span>(<span class="i">method</span>, <span class="i">environment</span>,
           <span class="i">method</span>.<span class="i">name</span>.<span class="i">lexeme</span>.<span class="i">equals</span>(<span class="s">&quot;init&quot;</span>));
 </pre><pre class="insert-after">      methods.put(method.name.lexeme, function);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitClassStmt</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitClassStmt</em>(), replace 1 line</div>
 
 <p>And then in <code>bind()</code> where we create the closure that binds <code>this</code> to a method,
 we pass along the original method&rsquo;s value.</p>
 <div class="codehilite"><pre class="insert-before">    environment.define(&quot;this&quot;, instance);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
+</pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
 in <em>bind</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="k">return</span> <span class="k">new</span> <span class="t">LoxFunction</span>(<span class="i">declaration</span>, <span class="i">environment</span>,
                            <span class="i">isInitializer</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, in <em>bind</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, in <em>bind</em>(), replace 1 line</div>
 
 <h3><a href="#returning-from-init" id="returning-from-init"><small>12&#8202;.&#8202;7&#8202;.&#8202;2</small>Returning from init()</a></h3>
 <p>We aren&rsquo;t out of the woods yet. We&rsquo;ve been assuming that a user-written
@@ -1412,17 +1412,17 @@ What should happen if a user tries:</p>
 <p>It&rsquo;s definitely not going to do what they want, so we may as well make it a
 static error. Back in the resolver, we add another case to FunctionType.</p>
 <div class="codehilite"><pre class="insert-before">    FUNCTION,
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in enum <em>FunctionType</em></div>
 <pre class="insert">    <span class="i">INITIALIZER</span>,
 </pre><pre class="insert-after">    METHOD
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in enum <em>FunctionType</em></div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in enum <em>FunctionType</em></div>
 
 <p>We use the visited method&rsquo;s name to determine if we&rsquo;re resolving an initializer
 or not.</p>
 <div class="codehilite"><pre class="insert-before">      FunctionType declaration = FunctionType.METHOD;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">method</span>.<span class="i">name</span>.<span class="i">lexeme</span>.<span class="i">equals</span>(<span class="s">&quot;init&quot;</span>)) {
         <span class="i">declaration</span> = <span class="t">FunctionType</span>.<span class="i">INITIALIZER</span>;
@@ -1430,12 +1430,12 @@ in <em>visitClassStmt</em>()</div>
 
 </pre><pre class="insert-after">      resolveFunction(method, declaration);<span name="local"> </span>
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>When we later traverse into a <code>return</code> statement, we check that field and make
 it an error to return a value from inside an <code>init()</code> method.</p>
 <div class="codehilite"><pre class="insert-before">    if (stmt.value != null) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitReturnStmt</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">currentFunction</span> == <span class="t">FunctionType</span>.<span class="i">INITIALIZER</span>) {
         <span class="t">Lox</span>.<span class="i">error</span>(<span class="i">stmt</span>.<span class="i">keyword</span>,
@@ -1444,7 +1444,7 @@ in <em>visitReturnStmt</em>()</div>
 
 </pre><pre class="insert-after">      resolve(stmt.value);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitReturnStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitReturnStmt</em>()</div>
 
 <p>We&rsquo;re <em>still</em> not done. We statically disallow returning a <em>value</em> from an
 initializer, but you can still use an empty early <code>return</code>.</p>
@@ -1458,13 +1458,13 @@ initializer, but you can still use an empty early <code>return</code>.</p>
 entirely. Instead, it should return <code>this</code> instead of <code>nil</code>. That&rsquo;s an easy fix
 over in LoxFunction.</p>
 <div class="codehilite"><pre class="insert-before">    } catch (Return returnValue) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
+</pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
 in <em>call</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">isInitializer</span>) <span class="k">return</span> <span class="i">closure</span>.<span class="i">getAt</span>(<span class="n">0</span>, <span class="s">&quot;this&quot;</span>);
 
 </pre><pre class="insert-after">      return returnValue.value;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, in <em>call</em>()</div>
+<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, in <em>call</em>()</div>
 
 <p>If we&rsquo;re in an initializer and execute a <code>return</code> statement, instead of
 returning the value (which will always be <code>nil</code>), we again return <code>this</code>.</p>

--- a/site/control-flow.html
+++ b/site/control-flow.html
@@ -220,13 +220,13 @@ if the condition is truthy. Optionally, it may also have an <code>else</code> ke
 statement to execute if the condition is falsey. The <span name="if-ast">syntax
 tree node</span> has fields for each of those three pieces.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Expression : Expr expression&quot;,
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;If         : Expr condition, Stmt thenBranch,&quot;</span> +
                   <span class="s">&quot; Stmt elseBranch&quot;</span>,
 </pre><pre class="insert-after">      &quot;Print      : Expr expression&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="if-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#if-statement">Appendix II</a>.</p>
@@ -234,15 +234,15 @@ in <em>main</em>()</div>
 <p>Like other statements, the parser recognizes an <code>if</code> statement by the leading
 <code>if</code> keyword.</p>
 <div class="codehilite"><pre class="insert-before">  private Stmt statement() {
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">match</span>(<span class="i">IF</span>)) <span class="k">return</span> <span class="i">ifStatement</span>();
 </pre><pre class="insert-after">    if (match(PRINT)) return printStatement();
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>statement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>statement</em>()</div>
 
 <p>When it finds one, it calls this new method to parse the rest:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>statement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">ifStatement</span>() {
     <span class="i">consume</span>(<span class="i">LEFT_PAREN</span>, <span class="s">&quot;Expect &#39;(&#39; after &#39;if&#39;.&quot;</span>);
@@ -258,7 +258,7 @@ add after <em>statement</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">If</span>(<span class="i">condition</span>, <span class="i">thenBranch</span>, <span class="i">elseBranch</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>statement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>statement</em>()</div>
 
 <aside name="parens">
 <p>The parentheses around the condition are only half useful. You need some kind of
@@ -312,7 +312,7 @@ precedes it.</p>
 for an <code>else</code> before returning, the innermost call to a nested series will claim
 the else clause for itself before returning to the outer <code>if</code> statements.</p>
 <p>Syntax in hand, we are ready to interpret.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitExpressionStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitIfStmt</span>(<span class="t">Stmt</span>.<span class="t">If</span> <span class="i">stmt</span>) {
@@ -324,7 +324,7 @@ add after <em>visitExpressionStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitExpressionStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitExpressionStmt</em>()</div>
 
 <p>The interpreter implementation is a thin wrapper around the self-same Java code.
 It evaluates the condition. If truthy, it executes the then branch. Otherwise,
@@ -378,12 +378,12 @@ code path to handle the short circuiting. I think it&rsquo;s cleaner to define a
 name="logical-ast">new class</span> for these operators so that they get their
 own visit method.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Literal  : Object value&quot;,
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Logical  : Expr left, Token operator, Expr right&quot;</span>,
 </pre><pre class="insert-after">      &quot;Unary    : Token operator, Expr right&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="logical-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#logical-expression">Appendix II</a>.</p>
@@ -391,7 +391,7 @@ in <em>main</em>()</div>
 <p>To weave the new expressions into the parser, we first change the parsing code
 for assignment to call <code>or()</code>.</p>
 <div class="codehilite"><pre class="insert-before">  private Expr assignment() {
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>assignment</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">or</span>();
@@ -399,10 +399,10 @@ replace 1 line</div>
 
     if (match(EQUAL)) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>assignment</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>assignment</em>(), replace 1 line</div>
 
 <p>The code to parse a series of <code>or</code> expressions mirrors other binary operators.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>assignment</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">or</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">and</span>();
@@ -416,10 +416,10 @@ add after <em>assignment</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>assignment</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>assignment</em>()</div>
 
 <p>Its operands are the next higher level of precedence, the new <code>and</code> expression.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>or</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">and</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">equality</span>();
@@ -433,11 +433,11 @@ add after <em>or</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>or</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>or</em>()</div>
 
 <p>That calls <code>equality()</code> for its operands, and with that, the expression parser
 is all tied back together again. We&rsquo;re ready to interpret.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitLiteralExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitLogicalExpr</span>(<span class="t">Expr</span>.<span class="t">Logical</span> <span class="i">expr</span>) {
@@ -452,7 +452,7 @@ add after <em>visitLiteralExpr</em>()</div>
     <span class="k">return</span> <span class="i">evaluate</span>(<span class="i">expr</span>.<span class="i">right</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitLiteralExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitLiteralExpr</em>()</div>
 
 <p>If you compare this to the <a href="evaluating-expressions.html">earlier chapter&rsquo;s</a> <code>visitBinaryExpr()</code>
 method, you can see the difference. Here, we evaluate the left operand first. We
@@ -491,13 +491,13 @@ expression, then a statement for the body. That new grammar rule gets a <span
 name="while-ast">syntax tree node</span>.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Print      : Expr expression&quot;,
 </pre><pre class="insert-before">      <span class="s">&quot;Var        : Token name, Expr initializer&quot;</span><span class="insert-comma">,</span>
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()<br>
 add <em>&ldquo;,&rdquo;</em> to previous line</div>
 <pre class="insert">      <span class="s">&quot;While      : Expr condition, Stmt body&quot;</span>
 </pre><pre class="insert-after">    ));
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>(), add <em>&ldquo;,&rdquo;</em> to previous line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>(), add <em>&ldquo;,&rdquo;</em> to previous line</div>
 
 <aside name="while-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#while-statement">Appendix II</a>.</p>
@@ -509,15 +509,15 @@ make it clear that the condition is an expression and the body is a statement.</
 First, we add another case in <code>statement()</code> to detect and match the leading
 keyword.</p>
 <div class="codehilite"><pre class="insert-before">    if (match(PRINT)) return printStatement();
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">match</span>(<span class="i">WHILE</span>)) <span class="k">return</span> <span class="i">whileStatement</span>();
 </pre><pre class="insert-after">    if (match(LEFT_BRACE)) return new Stmt.Block(block());
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>statement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>statement</em>()</div>
 
 <p>That delegates the real work to this method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>varDeclaration</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">whileStatement</span>() {
     <span class="i">consume</span>(<span class="i">LEFT_PAREN</span>, <span class="s">&quot;Expect &#39;(&#39; after &#39;while&#39;.&quot;</span>);
@@ -528,11 +528,11 @@ add after <em>varDeclaration</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">While</span>(<span class="i">condition</span>, <span class="i">body</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>varDeclaration</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>varDeclaration</em>()</div>
 
 <p>The grammar is dead simple and this is a straight translation of it to Java.
 Speaking of translating straight to Java, here&rsquo;s how we execute the new syntax:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitVarStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitWhileStmt</span>(<span class="t">Stmt</span>.<span class="t">While</span> <span class="i">stmt</span>) {
@@ -542,7 +542,7 @@ add after <em>visitVarStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitVarStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitVarStmt</em>()</div>
 
 <p>Like the visit method for <code>if</code>, this visitor uses the corresponding Java
 feature. This method isn&rsquo;t complex, but it makes Lox much more powerful. We can
@@ -642,25 +642,25 @@ doesn&rsquo;t save us much work, but it does give me an excuse to introduce you 
 technique. So, unlike the previous statements, we <em>won&rsquo;t</em> add a new syntax tree
 node. Instead, we go straight to parsing. First, add an import we&rsquo;ll need soon.</p>
 <div class="codehilite"><pre class="insert-before">import java.util.ArrayList;
-</pre><div class="source-file"><em>lox/Parser.java</em></div>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em></div>
 <pre class="insert"><span class="k">import</span> <span class="i">java.util.Arrays</span>;
 </pre><pre class="insert-after">import java.util.List;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em></div>
 
 <p>Like every statement, we start parsing a <code>for</code> loop by matching its keyword.</p>
 <div class="codehilite"><pre class="insert-before">  private Stmt statement() {
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">match</span>(<span class="i">FOR</span>)) <span class="k">return</span> <span class="i">forStatement</span>();
 </pre><pre class="insert-after">    if (match(IF)) return ifStatement();
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>statement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>statement</em>()</div>
 
 <p>Here is where it gets interesting. The desugaring is going to happen here, so
 we&rsquo;ll build this method a piece at a time, starting with the opening parenthesis
 before the clauses.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>statement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">forStatement</span>() {
     <span class="i">consume</span>(<span class="i">LEFT_PAREN</span>, <span class="s">&quot;Expect &#39;(&#39; after &#39;for&#39;.&quot;</span>);
@@ -668,12 +668,12 @@ add after <em>statement</em>()</div>
     <span class="c">// More here...</span>
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>statement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>statement</em>()</div>
 
 <p>The first clause following that is the initializer.</p>
 <div class="codehilite"><pre class="insert-before">    consume(LEFT_PAREN, &quot;Expect '(' after 'for'.&quot;);
 
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>forStatement</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">Stmt</span> <span class="i">initializer</span>;
@@ -686,7 +686,7 @@ replace 1 line</div>
     }
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>forStatement</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>forStatement</em>(), replace 1 line</div>
 
 <p>If the token following the <code>(</code> is a semicolon then the initializer has been
 omitted. Otherwise, we check for a <code>var</code> keyword to see if it&rsquo;s a <span
@@ -702,7 +702,7 @@ true, I guess.</p>
 <p>Next up is the condition.</p>
 <div class="codehilite"><pre class="insert-before">      initializer = expressionStatement();
     }
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">
 
@@ -713,12 +713,12 @@ in <em>forStatement</em>()</div>
     <span class="i">consume</span>(<span class="i">SEMICOLON</span>, <span class="s">&quot;Expect &#39;;&#39; after loop condition.&quot;</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>forStatement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>forStatement</em>()</div>
 
 <p>Again, we look for a semicolon to see if the clause has been omitted. The last
 clause is the increment.</p>
 <div class="codehilite"><pre class="insert-before">    consume(SEMICOLON, &quot;Expect ';' after loop condition.&quot;);
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">
 
@@ -729,7 +729,7 @@ in <em>forStatement</em>()</div>
     <span class="i">consume</span>(<span class="i">RIGHT_PAREN</span>, <span class="s">&quot;Expect &#39;)&#39; after for clauses.&quot;</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>forStatement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>forStatement</em>()</div>
 
 <p>It&rsquo;s similar to the condition clause except this one is terminated by the
 closing parenthesis. All that remains is the <span name="body">body</span>.</p>
@@ -737,14 +737,14 @@ closing parenthesis. All that remains is the <span name="body">body</span>.</p>
 <p>Is it just me or does that sound morbid? &ldquo;All that remained<span class="ellipse">&thinsp;.&thinsp;.&thinsp;.&nbsp;</span>was the <em>body</em>&rdquo;.</p>
 </aside>
 <div class="codehilite"><pre class="insert-before">    consume(RIGHT_PAREN, &quot;Expect ')' after for clauses.&quot;);
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">    <span class="t">Stmt</span> <span class="i">body</span> = <span class="i">statement</span>();
 
     <span class="k">return</span> <span class="i">body</span>;
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>forStatement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>forStatement</em>()</div>
 
 <p>We&rsquo;ve parsed all of the various pieces of the <code>for</code> loop and the resulting AST
 nodes are sitting in a handful of Java local variables. This is where the
@@ -755,7 +755,7 @@ showed you earlier.</p>
 clause.</p>
 <div class="codehilite"><pre class="insert-before">    Stmt body = statement();
 
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">increment</span> != <span class="k">null</span>) {
       <span class="i">body</span> = <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Block</span>(
@@ -766,28 +766,28 @@ in <em>forStatement</em>()</div>
 
 </pre><pre class="insert-after">    return body;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>forStatement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>forStatement</em>()</div>
 
 <p>The increment, if there is one, executes after the body in each iteration of the
 loop. We do that by replacing the body with a little block that contains the
 original body followed by an expression statement that evaluates the increment.</p>
 <div class="codehilite"><pre class="insert-before">    }
 
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">condition</span> == <span class="k">null</span>) <span class="i">condition</span> = <span class="k">new</span> <span class="t">Expr</span>.<span class="t">Literal</span>(<span class="k">true</span>);
     <span class="i">body</span> = <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">While</span>(<span class="i">condition</span>, <span class="i">body</span>);
 
 </pre><pre class="insert-after">    return body;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>forStatement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>forStatement</em>()</div>
 
 <p>Next, we take the condition and the body and build the loop using a primitive
 <code>while</code> loop. If the condition is omitted, we jam in <code>true</code> to make an infinite
 loop.</p>
 <div class="codehilite"><pre class="insert-before">    body = new Stmt.While(condition, body);
 
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">initializer</span> != <span class="k">null</span>) {
       <span class="i">body</span> = <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Block</span>(<span class="t">Arrays</span>.<span class="i">asList</span>(<span class="i">initializer</span>, <span class="i">body</span>));
@@ -795,7 +795,7 @@ in <em>forStatement</em>()</div>
 
 </pre><pre class="insert-after">    return body;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>forStatement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>forStatement</em>()</div>
 
 <p>Finally, if there is an initializer, it runs once before the entire loop. We do
 that by, again, replacing the whole statement with a block that runs the

--- a/site/control-flow.html
+++ b/site/control-flow.html
@@ -220,13 +220,13 @@ if the condition is truthy. Optionally, it may also have an <code>else</code> ke
 statement to execute if the condition is falsey. The <span name="if-ast">syntax
 tree node</span> has fields for each of those three pieces.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Expression : Expr expression&quot;,
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;If         : Expr condition, Stmt thenBranch,&quot;</span> +
                   <span class="s">&quot; Stmt elseBranch&quot;</span>,
 </pre><pre class="insert-after">      &quot;Print      : Expr expression&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="if-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#if-statement">Appendix II</a>.</p>
@@ -234,15 +234,15 @@ in <em>main</em>()</div>
 <p>Like other statements, the parser recognizes an <code>if</code> statement by the leading
 <code>if</code> keyword.</p>
 <div class="codehilite"><pre class="insert-before">  private Stmt statement() {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">match</span>(<span class="i">IF</span>)) <span class="k">return</span> <span class="i">ifStatement</span>();
 </pre><pre class="insert-after">    if (match(PRINT)) return printStatement();
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>statement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>statement</em>()</div>
 
 <p>When it finds one, it calls this new method to parse the rest:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>statement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">ifStatement</span>() {
     <span class="i">consume</span>(<span class="i">LEFT_PAREN</span>, <span class="s">&quot;Expect &#39;(&#39; after &#39;if&#39;.&quot;</span>);
@@ -258,7 +258,7 @@ add after <em>statement</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">If</span>(<span class="i">condition</span>, <span class="i">thenBranch</span>, <span class="i">elseBranch</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>statement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>statement</em>()</div>
 
 <aside name="parens">
 <p>The parentheses around the condition are only half useful. You need some kind of
@@ -312,7 +312,7 @@ precedes it.</p>
 for an <code>else</code> before returning, the innermost call to a nested series will claim
 the else clause for itself before returning to the outer <code>if</code> statements.</p>
 <p>Syntax in hand, we are ready to interpret.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitExpressionStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitIfStmt</span>(<span class="t">Stmt</span>.<span class="t">If</span> <span class="i">stmt</span>) {
@@ -324,7 +324,7 @@ add after <em>visitExpressionStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitExpressionStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitExpressionStmt</em>()</div>
 
 <p>The interpreter implementation is a thin wrapper around the self-same Java code.
 It evaluates the condition. If truthy, it executes the then branch. Otherwise,
@@ -378,12 +378,12 @@ code path to handle the short circuiting. I think it&rsquo;s cleaner to define a
 name="logical-ast">new class</span> for these operators so that they get their
 own visit method.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Literal  : Object value&quot;,
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Logical  : Expr left, Token operator, Expr right&quot;</span>,
 </pre><pre class="insert-after">      &quot;Unary    : Token operator, Expr right&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="logical-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#logical-expression">Appendix II</a>.</p>
@@ -391,7 +391,7 @@ in <em>main</em>()</div>
 <p>To weave the new expressions into the parser, we first change the parsing code
 for assignment to call <code>or()</code>.</p>
 <div class="codehilite"><pre class="insert-before">  private Expr assignment() {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>assignment</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">or</span>();
@@ -399,10 +399,10 @@ replace 1 line</div>
 
     if (match(EQUAL)) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>assignment</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>assignment</em>(), replace 1 line</div>
 
 <p>The code to parse a series of <code>or</code> expressions mirrors other binary operators.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>assignment</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">or</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">and</span>();
@@ -416,10 +416,10 @@ add after <em>assignment</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>assignment</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>assignment</em>()</div>
 
 <p>Its operands are the next higher level of precedence, the new <code>and</code> expression.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>or</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">and</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">equality</span>();
@@ -433,11 +433,11 @@ add after <em>or</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>or</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>or</em>()</div>
 
 <p>That calls <code>equality()</code> for its operands, and with that, the expression parser
 is all tied back together again. We&rsquo;re ready to interpret.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitLiteralExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitLogicalExpr</span>(<span class="t">Expr</span>.<span class="t">Logical</span> <span class="i">expr</span>) {
@@ -452,7 +452,7 @@ add after <em>visitLiteralExpr</em>()</div>
     <span class="k">return</span> <span class="i">evaluate</span>(<span class="i">expr</span>.<span class="i">right</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitLiteralExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitLiteralExpr</em>()</div>
 
 <p>If you compare this to the <a href="evaluating-expressions.html">earlier chapter&rsquo;s</a> <code>visitBinaryExpr()</code>
 method, you can see the difference. Here, we evaluate the left operand first. We
@@ -491,13 +491,13 @@ expression, then a statement for the body. That new grammar rule gets a <span
 name="while-ast">syntax tree node</span>.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Print      : Expr expression&quot;,
 </pre><pre class="insert-before">      <span class="s">&quot;Var        : Token name, Expr initializer&quot;</span><span class="insert-comma">,</span>
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()<br>
 add <em>&ldquo;,&rdquo;</em> to previous line</div>
 <pre class="insert">      <span class="s">&quot;While      : Expr condition, Stmt body&quot;</span>
 </pre><pre class="insert-after">    ));
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>(), add <em>&ldquo;,&rdquo;</em> to previous line</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>(), add <em>&ldquo;,&rdquo;</em> to previous line</div>
 
 <aside name="while-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#while-statement">Appendix II</a>.</p>
@@ -509,15 +509,15 @@ make it clear that the condition is an expression and the body is a statement.</
 First, we add another case in <code>statement()</code> to detect and match the leading
 keyword.</p>
 <div class="codehilite"><pre class="insert-before">    if (match(PRINT)) return printStatement();
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">match</span>(<span class="i">WHILE</span>)) <span class="k">return</span> <span class="i">whileStatement</span>();
 </pre><pre class="insert-after">    if (match(LEFT_BRACE)) return new Stmt.Block(block());
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>statement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>statement</em>()</div>
 
 <p>That delegates the real work to this method:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>varDeclaration</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">whileStatement</span>() {
     <span class="i">consume</span>(<span class="i">LEFT_PAREN</span>, <span class="s">&quot;Expect &#39;(&#39; after &#39;while&#39;.&quot;</span>);
@@ -528,11 +528,11 @@ add after <em>varDeclaration</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">While</span>(<span class="i">condition</span>, <span class="i">body</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>varDeclaration</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>varDeclaration</em>()</div>
 
 <p>The grammar is dead simple and this is a straight translation of it to Java.
 Speaking of translating straight to Java, here&rsquo;s how we execute the new syntax:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitVarStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitWhileStmt</span>(<span class="t">Stmt</span>.<span class="t">While</span> <span class="i">stmt</span>) {
@@ -542,7 +542,7 @@ add after <em>visitVarStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitVarStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitVarStmt</em>()</div>
 
 <p>Like the visit method for <code>if</code>, this visitor uses the corresponding Java
 feature. This method isn&rsquo;t complex, but it makes Lox much more powerful. We can
@@ -642,25 +642,25 @@ doesn&rsquo;t save us much work, but it does give me an excuse to introduce you 
 technique. So, unlike the previous statements, we <em>won&rsquo;t</em> add a new syntax tree
 node. Instead, we go straight to parsing. First, add an import we&rsquo;ll need soon.</p>
 <div class="codehilite"><pre class="insert-before">import java.util.ArrayList;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em></div>
+</pre><div class="source-file"><em>lox/Parser.java</em></div>
 <pre class="insert"><span class="k">import</span> <span class="i">java.util.Arrays</span>;
 </pre><pre class="insert-after">import java.util.List;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em></div>
+<div class="source-file-narrow"><em>lox/Parser.java</em></div>
 
 <p>Like every statement, we start parsing a <code>for</code> loop by matching its keyword.</p>
 <div class="codehilite"><pre class="insert-before">  private Stmt statement() {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">match</span>(<span class="i">FOR</span>)) <span class="k">return</span> <span class="i">forStatement</span>();
 </pre><pre class="insert-after">    if (match(IF)) return ifStatement();
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>statement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>statement</em>()</div>
 
 <p>Here is where it gets interesting. The desugaring is going to happen here, so
 we&rsquo;ll build this method a piece at a time, starting with the opening parenthesis
 before the clauses.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>statement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">forStatement</span>() {
     <span class="i">consume</span>(<span class="i">LEFT_PAREN</span>, <span class="s">&quot;Expect &#39;(&#39; after &#39;for&#39;.&quot;</span>);
@@ -668,12 +668,12 @@ add after <em>statement</em>()</div>
     <span class="c">// More here...</span>
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>statement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>statement</em>()</div>
 
 <p>The first clause following that is the initializer.</p>
 <div class="codehilite"><pre class="insert-before">    consume(LEFT_PAREN, &quot;Expect '(' after 'for'.&quot;);
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>forStatement</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">Stmt</span> <span class="i">initializer</span>;
@@ -686,7 +686,7 @@ replace 1 line</div>
     }
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>forStatement</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>forStatement</em>(), replace 1 line</div>
 
 <p>If the token following the <code>(</code> is a semicolon then the initializer has been
 omitted. Otherwise, we check for a <code>var</code> keyword to see if it&rsquo;s a <span
@@ -702,7 +702,7 @@ true, I guess.</p>
 <p>Next up is the condition.</p>
 <div class="codehilite"><pre class="insert-before">      initializer = expressionStatement();
     }
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">
 
@@ -713,12 +713,12 @@ in <em>forStatement</em>()</div>
     <span class="i">consume</span>(<span class="i">SEMICOLON</span>, <span class="s">&quot;Expect &#39;;&#39; after loop condition.&quot;</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>forStatement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>forStatement</em>()</div>
 
 <p>Again, we look for a semicolon to see if the clause has been omitted. The last
 clause is the increment.</p>
 <div class="codehilite"><pre class="insert-before">    consume(SEMICOLON, &quot;Expect ';' after loop condition.&quot;);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">
 
@@ -729,7 +729,7 @@ in <em>forStatement</em>()</div>
     <span class="i">consume</span>(<span class="i">RIGHT_PAREN</span>, <span class="s">&quot;Expect &#39;)&#39; after for clauses.&quot;</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>forStatement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>forStatement</em>()</div>
 
 <p>It&rsquo;s similar to the condition clause except this one is terminated by the
 closing parenthesis. All that remains is the <span name="body">body</span>.</p>
@@ -737,14 +737,14 @@ closing parenthesis. All that remains is the <span name="body">body</span>.</p>
 <p>Is it just me or does that sound morbid? &ldquo;All that remained<span class="ellipse">&thinsp;.&thinsp;.&thinsp;.&nbsp;</span>was the <em>body</em>&rdquo;.</p>
 </aside>
 <div class="codehilite"><pre class="insert-before">    consume(RIGHT_PAREN, &quot;Expect ')' after for clauses.&quot;);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">    <span class="t">Stmt</span> <span class="i">body</span> = <span class="i">statement</span>();
 
     <span class="k">return</span> <span class="i">body</span>;
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>forStatement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>forStatement</em>()</div>
 
 <p>We&rsquo;ve parsed all of the various pieces of the <code>for</code> loop and the resulting AST
 nodes are sitting in a handful of Java local variables. This is where the
@@ -755,7 +755,7 @@ showed you earlier.</p>
 clause.</p>
 <div class="codehilite"><pre class="insert-before">    Stmt body = statement();
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">increment</span> != <span class="k">null</span>) {
       <span class="i">body</span> = <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Block</span>(
@@ -766,28 +766,28 @@ in <em>forStatement</em>()</div>
 
 </pre><pre class="insert-after">    return body;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>forStatement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>forStatement</em>()</div>
 
 <p>The increment, if there is one, executes after the body in each iteration of the
 loop. We do that by replacing the body with a little block that contains the
 original body followed by an expression statement that evaluates the increment.</p>
 <div class="codehilite"><pre class="insert-before">    }
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">condition</span> == <span class="k">null</span>) <span class="i">condition</span> = <span class="k">new</span> <span class="t">Expr</span>.<span class="t">Literal</span>(<span class="k">true</span>);
     <span class="i">body</span> = <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">While</span>(<span class="i">condition</span>, <span class="i">body</span>);
 
 </pre><pre class="insert-after">    return body;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>forStatement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>forStatement</em>()</div>
 
 <p>Next, we take the condition and the body and build the loop using a primitive
 <code>while</code> loop. If the condition is omitted, we jam in <code>true</code> to make an infinite
 loop.</p>
 <div class="codehilite"><pre class="insert-before">    body = new Stmt.While(condition, body);
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>forStatement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">initializer</span> != <span class="k">null</span>) {
       <span class="i">body</span> = <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Block</span>(<span class="t">Arrays</span>.<span class="i">asList</span>(<span class="i">initializer</span>, <span class="i">body</span>));
@@ -795,7 +795,7 @@ in <em>forStatement</em>()</div>
 
 </pre><pre class="insert-after">    return body;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>forStatement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>forStatement</em>()</div>
 
 <p>Finally, if there is an initializer, it runs once before the entire loop. We do
 that by, again, replacing the whole statement with a block that runs the

--- a/site/evaluating-expressions.html
+++ b/site/evaluating-expressions.html
@@ -201,14 +201,14 @@ recursively traversed it, building up a string which it ultimately returned.
 That&rsquo;s almost exactly what a real interpreter does, except instead of
 concatenating strings, it computes values.</p>
 <p>We start with a new class.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
 <span class="k">class</span> <span class="t">Interpreter</span> <span class="k">implements</span> <span class="t">Expr</span>.<span class="t">Visitor</span>&lt;<span class="t">Object</span>&gt; {
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, create new file</div>
 
 <p>The class declares that it&rsquo;s a visitor. The return type of the visit methods
 will be Object, the root class that we use to refer to a Lox value in our Java
@@ -230,14 +230,14 @@ expressions, which are also leaf nodes.</p>
 <p>So, much like we converted a literal <em>token</em> into a literal <em>syntax tree node</em>
 in the parser, now we convert the literal tree node into a runtime value. That
 turns out to be trivial.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitLiteralExpr</span>(<span class="t">Expr</span>.<span class="t">Literal</span> <span class="i">expr</span>) {
     <span class="k">return</span> <span class="i">expr</span>.<span class="i">value</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em></div>
 
 <p>We eagerly produced the runtime value way back during scanning and stuffed it in
 the token. The parser took that value and stuck it in the literal tree node,
@@ -245,14 +245,14 @@ so to evaluate a literal, we simply pull it back out.</p>
 <h3><a href="#evaluating-parentheses" id="evaluating-parentheses"><small>7&#8202;.&#8202;2&#8202;.&#8202;2</small>Evaluating parentheses</a></h3>
 <p>The next simplest node to evaluate is grouping<span class="em">&mdash;</span>the node you get as a result
 of using explicit parentheses in an expression.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitGroupingExpr</span>(<span class="t">Expr</span>.<span class="t">Grouping</span> <span class="i">expr</span>) {
     <span class="k">return</span> <span class="i">evaluate</span>(<span class="i">expr</span>.<span class="i">expression</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em></div>
 
 <p>A <span name="grouping">grouping</span> node has a reference to an inner node
 for the expression contained inside the parentheses. To evaluate the grouping
@@ -265,19 +265,19 @@ parenthesized expression, they simply return the node for the inner expression.
 We do create a node for parentheses in Lox because we&rsquo;ll need it later to
 correctly handle the left-hand sides of assignment expressions.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre>  <span class="k">private</span> <span class="t">Object</span> <span class="i">evaluate</span>(<span class="t">Expr</span> <span class="i">expr</span>) {
     <span class="k">return</span> <span class="i">expr</span>.<span class="i">accept</span>(<span class="k">this</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em></div>
 
 <h3><a href="#evaluating-unary-expressions" id="evaluating-unary-expressions"><small>7&#8202;.&#8202;2&#8202;.&#8202;3</small>Evaluating unary expressions</a></h3>
 <p>Like grouping, unary expressions have a single subexpression that we must
 evaluate first. The difference is that the unary expression itself does a little
 work afterwards.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitLiteralExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitUnaryExpr</span>(<span class="t">Expr</span>.<span class="t">Unary</span> <span class="i">expr</span>) {
@@ -292,7 +292,7 @@ add after <em>visitLiteralExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitLiteralExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitLiteralExpr</em>()</div>
 
 <p>First, we evaluate the operand expression. Then we apply the unary operator
 itself to the result of that. There are two different unary expressions,
@@ -311,13 +311,13 @@ evaluate the unary operator itself until after we evaluate its operand
 subexpression. That means our interpreter is doing a <strong>post-order traversal</strong><span class="em">&mdash;</span>each node evaluates its children before doing its own work.</p>
 <p>The other unary operator is logical not.</p>
 <div class="codehilite"><pre class="insert-before">    switch (expr.operator.type) {
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitUnaryExpr</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="i">BANG</span>:
         <span class="k">return</span> !<span class="i">isTruthy</span>(<span class="i">right</span>);
 </pre><pre class="insert-after">      case MINUS:
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitUnaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitUnaryExpr</em>()</div>
 
 <p>The implementation is simple, but what is this &ldquo;truthy&rdquo; thing about? We need to
 make a little side trip to one of the great questions of Western philosophy:
@@ -345,7 +345,7 @@ non-empty strings are truthy.</p>
 </aside>
 <p>Lox follows Ruby&rsquo;s simple rule: <code>false</code> and <code>nil</code> are falsey, and everything else
 is truthy. We implement that like so:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitUnaryExpr</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isTruthy</span>(<span class="t">Object</span> <span class="i">object</span>) {
     <span class="k">if</span> (<span class="i">object</span> == <span class="k">null</span>) <span class="k">return</span> <span class="k">false</span>;
@@ -353,12 +353,12 @@ add after <em>visitUnaryExpr</em>()</div>
     <span class="k">return</span> <span class="k">true</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitUnaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitUnaryExpr</em>()</div>
 
 <h3><a href="#evaluating-binary-operators" id="evaluating-binary-operators"><small>7&#8202;.&#8202;2&#8202;.&#8202;5</small>Evaluating binary operators</a></h3>
 <p>On to the last expression tree class, binary operators. There&rsquo;s a handful of
 them, and we&rsquo;ll start with the arithmetic ones.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>evaluate</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitBinaryExpr</span>(<span class="t">Expr</span>.<span class="t">Binary</span> <span class="i">expr</span>) {
@@ -378,7 +378,7 @@ add after <em>evaluate</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>evaluate</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>evaluate</em>()</div>
 
 <aside name="left">
 <p>Did you notice we pinned down a subtle corner of the language semantics here?
@@ -394,7 +394,7 @@ unary negation operator is that we have two operands to evaluate.</p>
 <div class="codehilite"><pre class="insert-before">    switch (expr.operator.type) {
       case MINUS:
         return (double)left - (double)right;
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="i">PLUS</span>:
         <span class="k">if</span> (<span class="i">left</span> <span class="k">instanceof</span> <span class="t">Double</span> &amp;&amp; <span class="i">right</span> <span class="k">instanceof</span> <span class="t">Double</span>) {
@@ -408,7 +408,7 @@ in <em>visitBinaryExpr</em>()</div>
         <span class="k">break</span>;
 </pre><pre class="insert-after">      case SLASH:
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>The <code>+</code> operator can also be used to concatenate two strings. To handle that, we
 don&rsquo;t just assume the operands are a certain type and <em>cast</em> them, we
@@ -425,7 +425,7 @@ adding both integers and floating-point numbers.</p>
 </aside>
 <p>Next up are the comparison operators.</p>
 <div class="codehilite"><pre class="insert-before">    switch (expr.operator.type) {
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="i">GREATER</span>:
         <span class="k">return</span> (<span class="t">double</span>)<span class="i">left</span> &gt; (<span class="t">double</span>)<span class="i">right</span>;
@@ -437,18 +437,18 @@ in <em>visitBinaryExpr</em>()</div>
         <span class="k">return</span> (<span class="t">double</span>)<span class="i">left</span> &lt;= (<span class="t">double</span>)<span class="i">right</span>;
 </pre><pre class="insert-after">      case MINUS:
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>They are basically the same as arithmetic. The only difference is that where the
 arithmetic operators produce a value whose type is the same as the operands
 (numbers or strings), the comparison operators always produce a Boolean.</p>
 <p>The last pair of operators are equality.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre>      <span class="k">case</span> <span class="i">BANG_EQUAL</span>: <span class="k">return</span> !<span class="i">isEqual</span>(<span class="i">left</span>, <span class="i">right</span>);
       <span class="k">case</span> <span class="i">EQUAL_EQUAL</span>: <span class="k">return</span> <span class="i">isEqual</span>(<span class="i">left</span>, <span class="i">right</span>);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Unlike the comparison operators which require numbers, the equality operators
 support operands of any type, even mixed ones. You can&rsquo;t ask Lox if 3 is <em>less</em>
@@ -458,7 +458,7 @@ it.</p>
 <p>Spoiler alert: it&rsquo;s not.</p>
 </aside>
 <p>Like truthiness, the equality logic is hoisted out into a separate method.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>isTruthy</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isEqual</span>(<span class="t">Object</span> <span class="i">a</span>, <span class="t">Object</span> <span class="i">b</span>) {
     <span class="k">if</span> (<span class="i">a</span> == <span class="k">null</span> &amp;&amp; <span class="i">b</span> == <span class="k">null</span>) <span class="k">return</span> <span class="k">true</span>;
@@ -467,7 +467,7 @@ add after <em>isTruthy</em>()</div>
     <span class="k">return</span> <span class="i">a</span>.<span class="i">equals</span>(<span class="i">b</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>isTruthy</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>isTruthy</em>()</div>
 
 <p>This is one of those corners where the details of how we represent Lox objects
 in terms of Java matter. We need to correctly implement <em>Lox&rsquo;s</em> notion of
@@ -549,25 +549,25 @@ failure, we&rsquo;ll define a Lox-specific one so that we can handle it how we w
 <p>Before we do the cast, we check the object&rsquo;s type ourselves. So, for unary <code>-</code>,
 we add:</p>
 <div class="codehilite"><pre class="insert-before">      case MINUS:
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitUnaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperand</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return -(double)right;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitUnaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitUnaryExpr</em>()</div>
 
 <p>The code to check the operand is:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitUnaryExpr</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">checkNumberOperand</span>(<span class="t">Token</span> <span class="i">operator</span>, <span class="t">Object</span> <span class="i">operand</span>) {
     <span class="k">if</span> (<span class="i">operand</span> <span class="k">instanceof</span> <span class="t">Double</span>) <span class="k">return</span>;
     <span class="k">throw</span> <span class="k">new</span> <span class="t">RuntimeError</span>(<span class="i">operator</span>, <span class="s">&quot;Operand must be a number.&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitUnaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitUnaryExpr</em>()</div>
 
 <p>When the check fails, it throws one of these:</p>
-<div class="codehilite"><div class="source-file"><em>lox/RuntimeError.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\RuntimeError.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -580,7 +580,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/RuntimeError.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\RuntimeError.java</em>, create new file</div>
 
 <p>Unlike the Java cast exception, our <span name="class">class</span> tracks the
 token that identifies where in the user&rsquo;s code the runtime error came from. As
@@ -596,70 +596,70 @@ single line of code needed to implement the interpreters, I&rsquo;ll run through
 all.</p>
 <p>Greater than:</p>
 <div class="codehilite"><pre class="insert-before">      case GREATER:
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return (double)left &gt; (double)right;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Greater than or equal to:</p>
 <div class="codehilite"><pre class="insert-before">      case GREATER_EQUAL:
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return (double)left &gt;= (double)right;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Less than:</p>
 <div class="codehilite"><pre class="insert-before">      case LESS:
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return (double)left &lt; (double)right;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Less than or equal to:</p>
 <div class="codehilite"><pre class="insert-before">      case LESS_EQUAL:
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return (double)left &lt;= (double)right;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Subtraction:</p>
 <div class="codehilite"><pre class="insert-before">      case MINUS:
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return (double)left - (double)right;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Division:</p>
 <div class="codehilite"><pre class="insert-before">      case SLASH:
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return (double)left / (double)right;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Multiplication:</p>
 <div class="codehilite"><pre class="insert-before">      case STAR:
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return (double)left * (double)right;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>All of those rely on this validator, which is virtually the same as the unary
 one:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>checkNumberOperand</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">checkNumberOperands</span>(<span class="t">Token</span> <span class="i">operator</span>,
                                    <span class="t">Object</span> <span class="i">left</span>, <span class="t">Object</span> <span class="i">right</span>) {
@@ -668,7 +668,7 @@ add after <em>checkNumberOperand</em>()</div>
     <span class="k">throw</span> <span class="k">new</span> <span class="t">RuntimeError</span>(<span class="i">operator</span>, <span class="s">&quot;Operands must be numbers.&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>checkNumberOperand</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>checkNumberOperand</em>()</div>
 
 <aside name="operand">
 <p>Another subtle semantic choice: We evaluate <em>both</em> operands before checking the
@@ -686,14 +686,14 @@ we need to do is fail if neither of the two success cases match.</p>
 <div class="codehilite"><pre class="insert-before">          return (String)left + (String)right;
         }
 
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()<br>
 replace 1 line</div>
 <pre class="insert">        <span class="k">throw</span> <span class="k">new</span> <span class="t">RuntimeError</span>(<span class="i">expr</span>.<span class="i">operator</span>,
             <span class="s">&quot;Operands must be two numbers or two strings.&quot;</span>);
 </pre><pre class="insert-after">      case SLASH:
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>(), replace 1 line</div>
 
 <p>That gets us detecting runtime errors deep in the innards of the evaluator. The
 errors are getting thrown. The next step is to write the code that catches them.
@@ -703,7 +703,7 @@ drives it.</p>
 <p>The visit methods are sort of the guts of the Interpreter class, where the real
 work happens. We need to wrap a skin around them to interface with the rest of
 the program. The Interpreter&rsquo;s public API is simply one method.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre>  <span class="t">void</span> <span class="i">interpret</span>(<span class="t">Expr</span> <span class="i">expression</span>) {<span name="void"> </span>
     <span class="k">try</span> {
@@ -714,13 +714,13 @@ in class <em>Interpreter</em></div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em></div>
 
 <p>This takes in a syntax tree for an expression and evaluates it. If that
 succeeds, <code>evaluate()</code> returns an object for the result value. <code>interpret()</code>
 converts that to a string and shows it to the user. To convert a Lox value to a
 string, we rely on:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>isEqual</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">String</span> <span class="i">stringify</span>(<span class="t">Object</span> <span class="i">object</span>) {
     <span class="k">if</span> (<span class="i">object</span> == <span class="k">null</span>) <span class="k">return</span> <span class="s">&quot;nil&quot;</span>;
@@ -736,7 +736,7 @@ add after <em>isEqual</em>()</div>
     <span class="k">return</span> <span class="i">object</span>.<span class="i">toString</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>isEqual</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>isEqual</em>()</div>
 
 <p>This is another of those pieces of code like <code>isTruthy()</code> that crosses the
 membrane between the user&rsquo;s view of Lox objects and their internal
@@ -762,7 +762,7 @@ on different interpreters.</p>
 catches it. This lets us report the error to the user and then gracefully
 continue. All of our existing error reporting code lives in the Lox class, so we
 put this method there too:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 add after <em>error</em>()</div>
 <pre>  <span class="k">static</span> <span class="t">void</span> <span class="i">runtimeError</span>(<span class="t">RuntimeError</span> <span class="i">error</span>) {
     <span class="t">System</span>.<span class="i">err</span>.<span class="i">println</span>(<span class="i">error</span>.<span class="i">getMessage</span>() +
@@ -770,7 +770,7 @@ add after <em>error</em>()</div>
     <span class="i">hadRuntimeError</span> = <span class="k">true</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, add after <em>error</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, add after <em>error</em>()</div>
 
 <p>We use the token associated with the RuntimeError to tell the user what line of
 code was executing when the error occurred. Even better would be to give the
@@ -778,25 +778,25 @@ user an entire call stack to show how they <em>got</em> to be executing that cod
 we don&rsquo;t have function calls yet, so I guess we don&rsquo;t have to worry about it.</p>
 <p>After showing the error, <code>runtimeError()</code> sets this field:</p>
 <div class="codehilite"><pre class="insert-before">  static boolean hadError = false;
-</pre><div class="source-file"><em>lox/Lox.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 in class <em>Lox</em></div>
 <pre class="insert">  <span class="k">static</span> <span class="t">boolean</span> <span class="i">hadRuntimeError</span> = <span class="k">false</span>;
 
 </pre><pre class="insert-after">  public static void main(String[] args) throws IOException {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, in class <em>Lox</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in class <em>Lox</em></div>
 
 <p>That field plays a small but important role.</p>
 <div class="codehilite"><pre class="insert-before">    run(new String(bytes, Charset.defaultCharset()));
 
     // Indicate an error in the exit code.
     if (hadError) System.exit(65);
-</pre><div class="source-file"><em>lox/Lox.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 in <em>runFile</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">hadRuntimeError</span>) <span class="t">System</span>.<span class="i">exit</span>(<span class="n">70</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>runFile</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>runFile</em>()</div>
 
 <p>If the user is running a Lox <span name="repl">script from a file</span> and a
 runtime error occurs, we set an exit code when the process quits to let the
@@ -809,12 +809,12 @@ keep going.</p>
 <h3><a href="#running-the-interpreter" id="running-the-interpreter"><small>7&#8202;.&#8202;4&#8202;.&#8202;2</small>Running the interpreter</a></h3>
 <p>Now that we have an interpreter, the Lox class can start using it.</p>
 <div class="codehilite"><pre class="insert-before">public class Lox {
-</pre><div class="source-file"><em>lox/Lox.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 in class <em>Lox</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">static</span> <span class="k">final</span> <span class="t">Interpreter</span> <span class="i">interpreter</span> = <span class="k">new</span> <span class="t">Interpreter</span>();
 </pre><pre class="insert-after">  static boolean hadError = false;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, in class <em>Lox</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in class <em>Lox</em></div>
 
 <p>We make the field static so that successive calls to <code>run()</code> inside a REPL
 session reuse the same interpreter. That doesn&rsquo;t make a difference now, but it
@@ -825,13 +825,13 @@ printing the syntax tree and replace it with this:</p>
 <div class="codehilite"><pre class="insert-before">    // Stop if there was a syntax error.
     if (hadError) return;
 
-</pre><div class="source-file"><em>lox/Lox.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 in <em>run</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="i">interpreter</span>.<span class="i">interpret</span>(<span class="i">expression</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>run</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>run</em>(), replace 1 line</div>
 
 <p>We have an entire language pipeline now: scanning, parsing, and
 execution. Congratulations, you now have your very own arithmetic calculator.</p>

--- a/site/evaluating-expressions.html
+++ b/site/evaluating-expressions.html
@@ -201,14 +201,14 @@ recursively traversed it, building up a string which it ultimately returned.
 That&rsquo;s almost exactly what a real interpreter does, except instead of
 concatenating strings, it computes values.</p>
 <p>We start with a new class.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
 <span class="k">class</span> <span class="t">Interpreter</span> <span class="k">implements</span> <span class="t">Expr</span>.<span class="t">Visitor</span>&lt;<span class="t">Object</span>&gt; {
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, create new file</div>
 
 <p>The class declares that it&rsquo;s a visitor. The return type of the visit methods
 will be Object, the root class that we use to refer to a Lox value in our Java
@@ -230,14 +230,14 @@ expressions, which are also leaf nodes.</p>
 <p>So, much like we converted a literal <em>token</em> into a literal <em>syntax tree node</em>
 in the parser, now we convert the literal tree node into a runtime value. That
 turns out to be trivial.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitLiteralExpr</span>(<span class="t">Expr</span>.<span class="t">Literal</span> <span class="i">expr</span>) {
     <span class="k">return</span> <span class="i">expr</span>.<span class="i">value</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em></div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em></div>
 
 <p>We eagerly produced the runtime value way back during scanning and stuffed it in
 the token. The parser took that value and stuck it in the literal tree node,
@@ -245,14 +245,14 @@ so to evaluate a literal, we simply pull it back out.</p>
 <h3><a href="#evaluating-parentheses" id="evaluating-parentheses"><small>7&#8202;.&#8202;2&#8202;.&#8202;2</small>Evaluating parentheses</a></h3>
 <p>The next simplest node to evaluate is grouping<span class="em">&mdash;</span>the node you get as a result
 of using explicit parentheses in an expression.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitGroupingExpr</span>(<span class="t">Expr</span>.<span class="t">Grouping</span> <span class="i">expr</span>) {
     <span class="k">return</span> <span class="i">evaluate</span>(<span class="i">expr</span>.<span class="i">expression</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em></div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em></div>
 
 <p>A <span name="grouping">grouping</span> node has a reference to an inner node
 for the expression contained inside the parentheses. To evaluate the grouping
@@ -265,19 +265,19 @@ parenthesized expression, they simply return the node for the inner expression.
 We do create a node for parentheses in Lox because we&rsquo;ll need it later to
 correctly handle the left-hand sides of assignment expressions.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre>  <span class="k">private</span> <span class="t">Object</span> <span class="i">evaluate</span>(<span class="t">Expr</span> <span class="i">expr</span>) {
     <span class="k">return</span> <span class="i">expr</span>.<span class="i">accept</span>(<span class="k">this</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em></div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em></div>
 
 <h3><a href="#evaluating-unary-expressions" id="evaluating-unary-expressions"><small>7&#8202;.&#8202;2&#8202;.&#8202;3</small>Evaluating unary expressions</a></h3>
 <p>Like grouping, unary expressions have a single subexpression that we must
 evaluate first. The difference is that the unary expression itself does a little
 work afterwards.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitLiteralExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitUnaryExpr</span>(<span class="t">Expr</span>.<span class="t">Unary</span> <span class="i">expr</span>) {
@@ -292,7 +292,7 @@ add after <em>visitLiteralExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitLiteralExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitLiteralExpr</em>()</div>
 
 <p>First, we evaluate the operand expression. Then we apply the unary operator
 itself to the result of that. There are two different unary expressions,
@@ -311,13 +311,13 @@ evaluate the unary operator itself until after we evaluate its operand
 subexpression. That means our interpreter is doing a <strong>post-order traversal</strong><span class="em">&mdash;</span>each node evaluates its children before doing its own work.</p>
 <p>The other unary operator is logical not.</p>
 <div class="codehilite"><pre class="insert-before">    switch (expr.operator.type) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitUnaryExpr</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="i">BANG</span>:
         <span class="k">return</span> !<span class="i">isTruthy</span>(<span class="i">right</span>);
 </pre><pre class="insert-after">      case MINUS:
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitUnaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitUnaryExpr</em>()</div>
 
 <p>The implementation is simple, but what is this &ldquo;truthy&rdquo; thing about? We need to
 make a little side trip to one of the great questions of Western philosophy:
@@ -345,7 +345,7 @@ non-empty strings are truthy.</p>
 </aside>
 <p>Lox follows Ruby&rsquo;s simple rule: <code>false</code> and <code>nil</code> are falsey, and everything else
 is truthy. We implement that like so:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitUnaryExpr</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isTruthy</span>(<span class="t">Object</span> <span class="i">object</span>) {
     <span class="k">if</span> (<span class="i">object</span> == <span class="k">null</span>) <span class="k">return</span> <span class="k">false</span>;
@@ -353,12 +353,12 @@ add after <em>visitUnaryExpr</em>()</div>
     <span class="k">return</span> <span class="k">true</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitUnaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitUnaryExpr</em>()</div>
 
 <h3><a href="#evaluating-binary-operators" id="evaluating-binary-operators"><small>7&#8202;.&#8202;2&#8202;.&#8202;5</small>Evaluating binary operators</a></h3>
 <p>On to the last expression tree class, binary operators. There&rsquo;s a handful of
 them, and we&rsquo;ll start with the arithmetic ones.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>evaluate</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitBinaryExpr</span>(<span class="t">Expr</span>.<span class="t">Binary</span> <span class="i">expr</span>) {
@@ -378,7 +378,7 @@ add after <em>evaluate</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>evaluate</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>evaluate</em>()</div>
 
 <aside name="left">
 <p>Did you notice we pinned down a subtle corner of the language semantics here?
@@ -394,7 +394,7 @@ unary negation operator is that we have two operands to evaluate.</p>
 <div class="codehilite"><pre class="insert-before">    switch (expr.operator.type) {
       case MINUS:
         return (double)left - (double)right;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="i">PLUS</span>:
         <span class="k">if</span> (<span class="i">left</span> <span class="k">instanceof</span> <span class="t">Double</span> &amp;&amp; <span class="i">right</span> <span class="k">instanceof</span> <span class="t">Double</span>) {
@@ -408,7 +408,7 @@ in <em>visitBinaryExpr</em>()</div>
         <span class="k">break</span>;
 </pre><pre class="insert-after">      case SLASH:
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>The <code>+</code> operator can also be used to concatenate two strings. To handle that, we
 don&rsquo;t just assume the operands are a certain type and <em>cast</em> them, we
@@ -425,7 +425,7 @@ adding both integers and floating-point numbers.</p>
 </aside>
 <p>Next up are the comparison operators.</p>
 <div class="codehilite"><pre class="insert-before">    switch (expr.operator.type) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="i">GREATER</span>:
         <span class="k">return</span> (<span class="t">double</span>)<span class="i">left</span> &gt; (<span class="t">double</span>)<span class="i">right</span>;
@@ -437,18 +437,18 @@ in <em>visitBinaryExpr</em>()</div>
         <span class="k">return</span> (<span class="t">double</span>)<span class="i">left</span> &lt;= (<span class="t">double</span>)<span class="i">right</span>;
 </pre><pre class="insert-after">      case MINUS:
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>They are basically the same as arithmetic. The only difference is that where the
 arithmetic operators produce a value whose type is the same as the operands
 (numbers or strings), the comparison operators always produce a Boolean.</p>
 <p>The last pair of operators are equality.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre>      <span class="k">case</span> <span class="i">BANG_EQUAL</span>: <span class="k">return</span> !<span class="i">isEqual</span>(<span class="i">left</span>, <span class="i">right</span>);
       <span class="k">case</span> <span class="i">EQUAL_EQUAL</span>: <span class="k">return</span> <span class="i">isEqual</span>(<span class="i">left</span>, <span class="i">right</span>);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Unlike the comparison operators which require numbers, the equality operators
 support operands of any type, even mixed ones. You can&rsquo;t ask Lox if 3 is <em>less</em>
@@ -458,7 +458,7 @@ it.</p>
 <p>Spoiler alert: it&rsquo;s not.</p>
 </aside>
 <p>Like truthiness, the equality logic is hoisted out into a separate method.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>isTruthy</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isEqual</span>(<span class="t">Object</span> <span class="i">a</span>, <span class="t">Object</span> <span class="i">b</span>) {
     <span class="k">if</span> (<span class="i">a</span> == <span class="k">null</span> &amp;&amp; <span class="i">b</span> == <span class="k">null</span>) <span class="k">return</span> <span class="k">true</span>;
@@ -467,7 +467,7 @@ add after <em>isTruthy</em>()</div>
     <span class="k">return</span> <span class="i">a</span>.<span class="i">equals</span>(<span class="i">b</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>isTruthy</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>isTruthy</em>()</div>
 
 <p>This is one of those corners where the details of how we represent Lox objects
 in terms of Java matter. We need to correctly implement <em>Lox&rsquo;s</em> notion of
@@ -549,25 +549,25 @@ failure, we&rsquo;ll define a Lox-specific one so that we can handle it how we w
 <p>Before we do the cast, we check the object&rsquo;s type ourselves. So, for unary <code>-</code>,
 we add:</p>
 <div class="codehilite"><pre class="insert-before">      case MINUS:
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitUnaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperand</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return -(double)right;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitUnaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitUnaryExpr</em>()</div>
 
 <p>The code to check the operand is:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitUnaryExpr</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">checkNumberOperand</span>(<span class="t">Token</span> <span class="i">operator</span>, <span class="t">Object</span> <span class="i">operand</span>) {
     <span class="k">if</span> (<span class="i">operand</span> <span class="k">instanceof</span> <span class="t">Double</span>) <span class="k">return</span>;
     <span class="k">throw</span> <span class="k">new</span> <span class="t">RuntimeError</span>(<span class="i">operator</span>, <span class="s">&quot;Operand must be a number.&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitUnaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitUnaryExpr</em>()</div>
 
 <p>When the check fails, it throws one of these:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\RuntimeError.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/RuntimeError.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -580,7 +580,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\RuntimeError.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/RuntimeError.java</em>, create new file</div>
 
 <p>Unlike the Java cast exception, our <span name="class">class</span> tracks the
 token that identifies where in the user&rsquo;s code the runtime error came from. As
@@ -596,70 +596,70 @@ single line of code needed to implement the interpreters, I&rsquo;ll run through
 all.</p>
 <p>Greater than:</p>
 <div class="codehilite"><pre class="insert-before">      case GREATER:
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return (double)left &gt; (double)right;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Greater than or equal to:</p>
 <div class="codehilite"><pre class="insert-before">      case GREATER_EQUAL:
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return (double)left &gt;= (double)right;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Less than:</p>
 <div class="codehilite"><pre class="insert-before">      case LESS:
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return (double)left &lt; (double)right;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Less than or equal to:</p>
 <div class="codehilite"><pre class="insert-before">      case LESS_EQUAL:
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return (double)left &lt;= (double)right;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Subtraction:</p>
 <div class="codehilite"><pre class="insert-before">      case MINUS:
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return (double)left - (double)right;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Division:</p>
 <div class="codehilite"><pre class="insert-before">      case SLASH:
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return (double)left / (double)right;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>Multiplication:</p>
 <div class="codehilite"><pre class="insert-before">      case STAR:
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()</div>
 <pre class="insert">        <span class="i">checkNumberOperands</span>(<span class="i">expr</span>.<span class="i">operator</span>, <span class="i">left</span>, <span class="i">right</span>);
 </pre><pre class="insert-after">        return (double)left * (double)right;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>()</div>
 
 <p>All of those rely on this validator, which is virtually the same as the unary
 one:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>checkNumberOperand</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">checkNumberOperands</span>(<span class="t">Token</span> <span class="i">operator</span>,
                                    <span class="t">Object</span> <span class="i">left</span>, <span class="t">Object</span> <span class="i">right</span>) {
@@ -668,7 +668,7 @@ add after <em>checkNumberOperand</em>()</div>
     <span class="k">throw</span> <span class="k">new</span> <span class="t">RuntimeError</span>(<span class="i">operator</span>, <span class="s">&quot;Operands must be numbers.&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>checkNumberOperand</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>checkNumberOperand</em>()</div>
 
 <aside name="operand">
 <p>Another subtle semantic choice: We evaluate <em>both</em> operands before checking the
@@ -686,14 +686,14 @@ we need to do is fail if neither of the two success cases match.</p>
 <div class="codehilite"><pre class="insert-before">          return (String)left + (String)right;
         }
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitBinaryExpr</em>()<br>
 replace 1 line</div>
 <pre class="insert">        <span class="k">throw</span> <span class="k">new</span> <span class="t">RuntimeError</span>(<span class="i">expr</span>.<span class="i">operator</span>,
             <span class="s">&quot;Operands must be two numbers or two strings.&quot;</span>);
 </pre><pre class="insert-after">      case SLASH:
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitBinaryExpr</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitBinaryExpr</em>(), replace 1 line</div>
 
 <p>That gets us detecting runtime errors deep in the innards of the evaluator. The
 errors are getting thrown. The next step is to write the code that catches them.
@@ -703,7 +703,7 @@ drives it.</p>
 <p>The visit methods are sort of the guts of the Interpreter class, where the real
 work happens. We need to wrap a skin around them to interface with the rest of
 the program. The Interpreter&rsquo;s public API is simply one method.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre>  <span class="t">void</span> <span class="i">interpret</span>(<span class="t">Expr</span> <span class="i">expression</span>) {<span name="void"> </span>
     <span class="k">try</span> {
@@ -714,13 +714,13 @@ in class <em>Interpreter</em></div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em></div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em></div>
 
 <p>This takes in a syntax tree for an expression and evaluates it. If that
 succeeds, <code>evaluate()</code> returns an object for the result value. <code>interpret()</code>
 converts that to a string and shows it to the user. To convert a Lox value to a
 string, we rely on:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>isEqual</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">String</span> <span class="i">stringify</span>(<span class="t">Object</span> <span class="i">object</span>) {
     <span class="k">if</span> (<span class="i">object</span> == <span class="k">null</span>) <span class="k">return</span> <span class="s">&quot;nil&quot;</span>;
@@ -736,7 +736,7 @@ add after <em>isEqual</em>()</div>
     <span class="k">return</span> <span class="i">object</span>.<span class="i">toString</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>isEqual</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>isEqual</em>()</div>
 
 <p>This is another of those pieces of code like <code>isTruthy()</code> that crosses the
 membrane between the user&rsquo;s view of Lox objects and their internal
@@ -762,7 +762,7 @@ on different interpreters.</p>
 catches it. This lets us report the error to the user and then gracefully
 continue. All of our existing error reporting code lives in the Lox class, so we
 put this method there too:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
 add after <em>error</em>()</div>
 <pre>  <span class="k">static</span> <span class="t">void</span> <span class="i">runtimeError</span>(<span class="t">RuntimeError</span> <span class="i">error</span>) {
     <span class="t">System</span>.<span class="i">err</span>.<span class="i">println</span>(<span class="i">error</span>.<span class="i">getMessage</span>() +
@@ -770,7 +770,7 @@ add after <em>error</em>()</div>
     <span class="i">hadRuntimeError</span> = <span class="k">true</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, add after <em>error</em>()</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, add after <em>error</em>()</div>
 
 <p>We use the token associated with the RuntimeError to tell the user what line of
 code was executing when the error occurred. Even better would be to give the
@@ -778,25 +778,25 @@ user an entire call stack to show how they <em>got</em> to be executing that cod
 we don&rsquo;t have function calls yet, so I guess we don&rsquo;t have to worry about it.</p>
 <p>After showing the error, <code>runtimeError()</code> sets this field:</p>
 <div class="codehilite"><pre class="insert-before">  static boolean hadError = false;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+</pre><div class="source-file"><em>lox/Lox.java</em><br>
 in class <em>Lox</em></div>
 <pre class="insert">  <span class="k">static</span> <span class="t">boolean</span> <span class="i">hadRuntimeError</span> = <span class="k">false</span>;
 
 </pre><pre class="insert-after">  public static void main(String[] args) throws IOException {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in class <em>Lox</em></div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, in class <em>Lox</em></div>
 
 <p>That field plays a small but important role.</p>
 <div class="codehilite"><pre class="insert-before">    run(new String(bytes, Charset.defaultCharset()));
 
     // Indicate an error in the exit code.
     if (hadError) System.exit(65);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+</pre><div class="source-file"><em>lox/Lox.java</em><br>
 in <em>runFile</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">hadRuntimeError</span>) <span class="t">System</span>.<span class="i">exit</span>(<span class="n">70</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>runFile</em>()</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>runFile</em>()</div>
 
 <p>If the user is running a Lox <span name="repl">script from a file</span> and a
 runtime error occurs, we set an exit code when the process quits to let the
@@ -809,12 +809,12 @@ keep going.</p>
 <h3><a href="#running-the-interpreter" id="running-the-interpreter"><small>7&#8202;.&#8202;4&#8202;.&#8202;2</small>Running the interpreter</a></h3>
 <p>Now that we have an interpreter, the Lox class can start using it.</p>
 <div class="codehilite"><pre class="insert-before">public class Lox {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+</pre><div class="source-file"><em>lox/Lox.java</em><br>
 in class <em>Lox</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">static</span> <span class="k">final</span> <span class="t">Interpreter</span> <span class="i">interpreter</span> = <span class="k">new</span> <span class="t">Interpreter</span>();
 </pre><pre class="insert-after">  static boolean hadError = false;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in class <em>Lox</em></div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, in class <em>Lox</em></div>
 
 <p>We make the field static so that successive calls to <code>run()</code> inside a REPL
 session reuse the same interpreter. That doesn&rsquo;t make a difference now, but it
@@ -825,13 +825,13 @@ printing the syntax tree and replace it with this:</p>
 <div class="codehilite"><pre class="insert-before">    // Stop if there was a syntax error.
     if (hadError) return;
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+</pre><div class="source-file"><em>lox/Lox.java</em><br>
 in <em>run</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="i">interpreter</span>.<span class="i">interpret</span>(<span class="i">expression</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>run</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>run</em>(), replace 1 line</div>
 
 <p>We have an entire language pipeline now: scanning, parsing, and
 execution. Congratulations, you now have your very own arithmetic calculator.</p>

--- a/site/functions.html
+++ b/site/functions.html
@@ -164,12 +164,12 @@ language specs I&rsquo;ve seen, it is this cumbersome.</p>
 <p>Over in our syntax tree generator, we add a <span name="call-ast">new
 node</span>.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Binary   : Expr left, Token operator, Expr right&quot;,
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Call     : Expr callee, Token paren, List&lt;Expr&gt; arguments&quot;</span>,
 </pre><pre class="insert-after">      &quot;Grouping : Expr expression&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="call-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#call-expression">Appendix II</a>.</p>
@@ -182,16 +182,16 @@ change it to call, well, <code>call()</code>.</p>
 <div class="codehilite"><pre class="insert-before">      return new Expr.Unary(operator, right);
     }
 
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>unary</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="k">return</span> <span class="i">call</span>();
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>unary</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>unary</em>(), replace 1 line</div>
 
 <p>Its definition is:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>unary</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">call</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">primary</span>();
@@ -207,7 +207,7 @@ add after <em>unary</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>unary</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>unary</em>()</div>
 
 <p>The code here doesn&rsquo;t quite line up with the grammar rules. I moved a few things
 around to make the code cleaner<span class="em">&mdash;</span>one of the luxuries we have with a
@@ -222,7 +222,7 @@ new <code>expr</code> and we loop to see if the result is itself called.</p>
 parser later to handle properties on objects.</p>
 </aside>
 <p>The code to parse the argument list is in this helper:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>unary</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">finishCall</span>(<span class="t">Expr</span> <span class="i">callee</span>) {
     <span class="t">List</span>&lt;<span class="t">Expr</span>&gt; <span class="i">arguments</span> = <span class="k">new</span> <span class="t">ArrayList</span>&lt;&gt;();
@@ -238,7 +238,7 @@ add after <em>unary</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Expr</span>.<span class="t">Call</span>(<span class="i">callee</span>, <span class="i">paren</span>, <span class="i">arguments</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>unary</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>unary</em>()</div>
 
 <p>This is more or less the <code>arguments</code> grammar rule translated to code, except
 that we also handle the zero-argument case. We check for that case first by
@@ -266,14 +266,14 @@ number of arguments will simplify our bytecode interpreter in <a href="a-bytecod
 want our two interpreters to be compatible with each other, even in weird corner
 cases like this, so we&rsquo;ll add the same limit to jlox.</p>
 <div class="codehilite"><pre class="insert-before">      do {
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>finishCall</em>()</div>
 <pre class="insert">        <span class="k">if</span> (<span class="i">arguments</span>.<span class="i">size</span>() &gt;= <span class="n">255</span>) {
           <span class="i">error</span>(<span class="i">peek</span>(), <span class="s">&quot;Can&#39;t have more than 255 arguments.&quot;</span>);
         }
 </pre><pre class="insert-after">        arguments.add(expression());
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>finishCall</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>finishCall</em>()</div>
 
 <p>Note that the code here <em>reports</em> an error if it encounters too many arguments,
 but it doesn&rsquo;t <em>throw</em> the error. Throwing is how we kick into panic mode which
@@ -285,15 +285,15 @@ keepin&rsquo; on.</p>
 <p>We don&rsquo;t have any functions we can call, so it seems weird to start implementing
 calls first, but we&rsquo;ll worry about that when we get there. First, our
 interpreter needs a new import.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em></div>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
 <pre class="insert"><span class="k">import</span> <span class="i">java.util.ArrayList</span>;
 </pre><pre class="insert-after">import java.util.List;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
 
 <p>As always, interpretation starts with a new visit method for our new call
 expression node.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitBinaryExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitCallExpr</span>(<span class="t">Expr</span>.<span class="t">Call</span> <span class="i">expr</span>) {
@@ -308,7 +308,7 @@ add after <em>visitBinaryExpr</em>()</div>
     <span class="k">return</span> <span class="i">function</span>.<span class="i">call</span>(<span class="k">this</span>, <span class="i">arguments</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitBinaryExpr</em>()</div>
 
 <p>First, we evaluate the expression for the callee. Typically, this expression is
 just an identifier that looks up the function by its name, but it could be
@@ -333,7 +333,7 @@ We&rsquo;ll also use it for one more purpose shortly.</p>
 own Callable interface. Alas, all the good simple names are already taken.</p>
 </aside>
 <p>There isn&rsquo;t too much to this new interface.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxCallable.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxCallable.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -343,7 +343,7 @@ create new file</div>
   <span class="t">Object</span> <span class="i">call</span>(<span class="t">Interpreter</span> <span class="i">interpreter</span>, <span class="t">List</span>&lt;<span class="t">Object</span>&gt; <span class="i">arguments</span>);
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxCallable.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxCallable.java</em>, create new file</div>
 
 <p>We pass in the interpreter in case the class implementing <code>call()</code> needs it. We
 also give it the list of evaluated argument values. The implementer&rsquo;s job is
@@ -361,7 +361,7 @@ ClassCastException. We don&rsquo;t want our interpreter to vomit out some nasty 
 stack trace and die. Instead, we need to check the type ourselves first.</p>
 <div class="codehilite"><pre class="insert-before">    }
 
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitCallExpr</em>()</div>
 <pre class="insert">    <span class="k">if</span> (!(<span class="i">callee</span> <span class="k">instanceof</span> <span class="t">LoxCallable</span>)) {
       <span class="k">throw</span> <span class="k">new</span> <span class="t">RuntimeError</span>(<span class="i">expr</span>.<span class="i">paren</span>,
@@ -370,7 +370,7 @@ in <em>visitCallExpr</em>()</div>
 
 </pre><pre class="insert-after">    LoxCallable function = (LoxCallable)callee;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitCallExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitCallExpr</em>()</div>
 
 <p>We still throw an exception, but now we&rsquo;re throwing our own exception type, one
 that the interpreter knows to catch and report gracefully.</p>
@@ -401,7 +401,7 @@ the sooner the implementation draws my attention to it, the better. So for Lox,
 we&rsquo;ll take Python&rsquo;s approach. Before invoking the callable, we check to see if
 the argument list&rsquo;s length matches the callable&rsquo;s arity.</p>
 <div class="codehilite"><pre class="insert-before">    LoxCallable function = (LoxCallable)callee;
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitCallExpr</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">arguments</span>.<span class="i">size</span>() != <span class="i">function</span>.<span class="i">arity</span>()) {
       <span class="k">throw</span> <span class="k">new</span> <span class="t">RuntimeError</span>(<span class="i">expr</span>.<span class="i">paren</span>, <span class="s">&quot;Expected &quot;</span> +
@@ -411,16 +411,16 @@ in <em>visitCallExpr</em>()</div>
 
 </pre><pre class="insert-after">    return function.call(this, arguments);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitCallExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitCallExpr</em>()</div>
 
 <p>That requires a new method on the LoxCallable interface to ask it its arity.</p>
 <div class="codehilite"><pre class="insert-before">interface LoxCallable {
-</pre><div class="source-file"><em>lox/LoxCallable.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxCallable.java</em><br>
 in interface <em>LoxCallable</em></div>
 <pre class="insert">  <span class="t">int</span> <span class="i">arity</span>();
 </pre><pre class="insert-after">  Object call(Interpreter interpreter, List&lt;Object&gt; arguments);
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxCallable.java</em>, in interface <em>LoxCallable</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxCallable.java</em>, in interface <em>LoxCallable</em></div>
 
 <p>We <em>could</em> push the arity checking into the concrete implementation of <code>call()</code>.
 But, since we&rsquo;ll have multiple classes implementing LoxCallable, that would end
@@ -495,7 +495,7 @@ This function is defined in the global scope, so let&rsquo;s ensure the interpre
 has access to that.</p>
 <div class="codehilite"><pre class="insert-before">class Interpreter implements Expr.Visitor&lt;Object&gt;,
                              Stmt.Visitor&lt;Void&gt; {
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in class <em>Interpreter</em><br>
 replace 1 line</div>
 <pre class="insert">  <span class="k">final</span> <span class="t">Environment</span> <span class="i">globals</span> = <span class="k">new</span> <span class="t">Environment</span>();
@@ -504,7 +504,7 @@ replace 1 line</div>
 
   void interpret(List&lt;Stmt&gt; statements) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em>, replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em>, replace 1 line</div>
 
 <p>The <code>environment</code> field in the interpreter changes as we enter and exit local
 scopes. It tracks the <em>current</em> environment. This new <code>globals</code> field holds a
@@ -513,7 +513,7 @@ fixed reference to the outermost global environment.</p>
 scope.</p>
 <div class="codehilite"><pre class="insert-before">  private Environment environment = globals;
 
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre class="insert">  <span class="t">Interpreter</span>() {
     <span class="i">globals</span>.<span class="i">define</span>(<span class="s">&quot;clock&quot;</span>, <span class="k">new</span> <span class="t">LoxCallable</span>() {
@@ -533,7 +533,7 @@ in class <em>Interpreter</em></div>
 
 </pre><pre class="insert-after">  void interpret(List&lt;Stmt&gt; statements) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em></div>
 
 <p>This defines a <span name="lisp-1">variable</span> named &ldquo;clock&rdquo;. Its value is a
 Java anonymous class that implements LoxCallable. The <code>clock()</code> function takes
@@ -598,13 +598,13 @@ block statements use. The parameter list uses this rule:</p>
 identifier, not an expression. That&rsquo;s a lot of new syntax for the parser to chew
 through, but the resulting AST <span name="fun-ast">node</span> isn&rsquo;t too bad.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Expression : Expr expression&quot;,
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Function   : Token name, List&lt;Token&gt; params,&quot;</span> +
                   <span class="s">&quot; List&lt;Stmt&gt; body&quot;</span>,
 </pre><pre class="insert-after">      &quot;If         : Expr condition, Stmt thenBranch,&quot; +
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="fun-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#function-statement">Appendix II</a>.</p>
@@ -614,24 +614,24 @@ body. We store the body as the list of statements contained inside the curly
 braces.</p>
 <p>Over in the parser, we weave in the new declaration.</p>
 <div class="codehilite"><pre class="insert-before">    try {
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>declaration</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">match</span>(<span class="i">FUN</span>)) <span class="k">return</span> <span class="i">function</span>(<span class="s">&quot;function&quot;</span>);
 </pre><pre class="insert-after">      if (match(VAR)) return varDeclaration();
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>declaration</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>declaration</em>()</div>
 
 <p>Like other statements, a function is recognized by the leading keyword. When we
 encounter <code>fun</code>, we call <code>function</code>. That corresponds to the <code>function</code> grammar
 rule since we already matched and consumed the <code>fun</code> keyword. We&rsquo;ll build the
 method up a piece at a time, starting with this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>expressionStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span>.<span class="t">Function</span> <span class="i">function</span>(<span class="t">String</span> <span class="i">kind</span>) {
     <span class="t">Token</span> <span class="i">name</span> = <span class="i">consume</span>(<span class="i">IDENTIFIER</span>, <span class="s">&quot;Expect &quot;</span> + <span class="i">kind</span> + <span class="s">&quot; name.&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>expressionStatement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>expressionStatement</em>()</div>
 
 <p>Right now, it only consumes the identifier token for the function&rsquo;s name. You
 might be wondering about that funny little <code>kind</code> parameter. Just like we reuse
@@ -640,7 +640,7 @@ inside classes. When we do that, we&rsquo;ll pass in &ldquo;method&rdquo; for <c
 error messages are specific to the kind of declaration being parsed.</p>
 <p>Next, we parse the parameter list and the pair of parentheses wrapped around it.</p>
 <div class="codehilite"><pre class="insert-before">    Token name = consume(IDENTIFIER, &quot;Expect &quot; + kind + &quot; name.&quot;);
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>function</em>()</div>
 <pre class="insert">    <span class="i">consume</span>(<span class="i">LEFT_PAREN</span>, <span class="s">&quot;Expect &#39;(&#39; after &quot;</span> + <span class="i">kind</span> + <span class="s">&quot; name.&quot;</span>);
     <span class="t">List</span>&lt;<span class="t">Token</span>&gt; <span class="i">parameters</span> = <span class="k">new</span> <span class="t">ArrayList</span>&lt;&gt;();
@@ -657,7 +657,7 @@ in <em>function</em>()</div>
     <span class="i">consume</span>(<span class="i">RIGHT_PAREN</span>, <span class="s">&quot;Expect &#39;)&#39; after parameters.&quot;</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>function</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>function</em>()</div>
 
 <p>This is like the code for handling arguments in a call, except not split out
 into a helper method. The outer <code>if</code> statement handles the zero parameter case,
@@ -668,7 +668,7 @@ that you don&rsquo;t exceed the maximum number of parameters a function is allow
 have.</p>
 <p>Finally, we parse the body and wrap it all up in a function node.</p>
 <div class="codehilite"><pre class="insert-before">    consume(RIGHT_PAREN, &quot;Expect ')' after parameters.&quot;);
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>function</em>()</div>
 <pre class="insert">
 
@@ -677,7 +677,7 @@ in <em>function</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Function</span>(<span class="i">name</span>, <span class="i">parameters</span>, <span class="i">body</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>function</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>function</em>()</div>
 
 <p>Note that we consume the <code>{</code> at the beginning of the body here before calling
 <code>block()</code>. That&rsquo;s because <code>block()</code> assumes the brace token has already been
@@ -694,7 +694,7 @@ Almost, but not quite. We also need a class that implements LoxCallable so that
 we can call it. We don&rsquo;t want the runtime phase of the interpreter to bleed into
 the front end&rsquo;s syntax classes so we don&rsquo;t want Stmt.Function itself to
 implement that. Instead, we wrap it in a new class.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -707,10 +707,10 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, create new file</div>
 
 <p>We implement the <code>call()</code> of LoxCallable like so:</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
 add after <em>LoxFunction</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">call</span>(<span class="t">Interpreter</span> <span class="i">interpreter</span>,
@@ -725,7 +725,7 @@ add after <em>LoxFunction</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
 
 <p>This handful of lines of code is one of the most fundamental, powerful pieces of
 our interpreter. As we saw in <a href="statements-and-state.html">the chapter on statements and <span
@@ -789,25 +789,25 @@ it if you&rsquo;re so inclined.</p>
 lists have the same length. This is safe because <code>visitCallExpr()</code> checks the
 arity before calling <code>call()</code>. It relies on the function reporting its arity to
 do that.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
 add after <em>LoxFunction</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">int</span> <span class="i">arity</span>() {
     <span class="k">return</span> <span class="i">declaration</span>.<span class="i">params</span>.<span class="i">size</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
 
 <p>That&rsquo;s most of our object representation. While we&rsquo;re in here, we may as well
 implement <code>toString()</code>.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
 add after <em>LoxFunction</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">String</span> <span class="i">toString</span>() {
     <span class="k">return</span> <span class="s">&quot;&lt;fn &quot;</span> + <span class="i">declaration</span>.<span class="i">name</span>.<span class="i">lexeme</span> + <span class="s">&quot;&gt;&quot;</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
 
 <p>This gives nicer output if a user decides to print a function value.</p>
 <div class="codehilite"><pre><span class="k">fun</span> <span class="i">add</span>(<span class="i">a</span>, <span class="i">b</span>) {
@@ -819,7 +819,7 @@ add after <em>LoxFunction</em>()</div>
 <h3><a href="#interpreting-function-declarations" id="interpreting-function-declarations"><small>10&#8202;.&#8202;4&#8202;.&#8202;1</small>Interpreting function declarations</a></h3>
 <p>We&rsquo;ll come back and refine LoxFunction soon, but that&rsquo;s enough to get started.
 Now we can visit a function declaration.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitExpressionStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitFunctionStmt</span>(<span class="t">Stmt</span>.<span class="t">Function</span> <span class="i">stmt</span>) {
@@ -828,7 +828,7 @@ add after <em>visitExpressionStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitExpressionStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitExpressionStmt</em>()</div>
 
 <p>This is similar to how we interpret other literal expressions. We take a
 function <em>syntax node</em><span class="em">&mdash;</span>a compile-time representation of the function<span class="em">&mdash;</span>and
@@ -893,12 +893,12 @@ omit the value in a <code>return</code> statement, we simply treat it as equival
 </pre></div>
 <p>Over in our AST generator, we add a <span name="return-ast">new node</span>.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Print      : Expr expression&quot;,
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Return     : Token keyword, Expr value&quot;</span>,
 </pre><pre class="insert-after">      &quot;Var        : Token name, Expr initializer&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="return-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#return-statement">Appendix II</a>.</p>
@@ -907,15 +907,15 @@ in <em>main</em>()</div>
 reporting, and the value being returned, if any. We parse it like other
 statements, first by recognizing the initial keyword.</p>
 <div class="codehilite"><pre class="insert-before">    if (match(PRINT)) return printStatement();
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">match</span>(<span class="i">RETURN</span>)) <span class="k">return</span> <span class="i">returnStatement</span>();
 </pre><pre class="insert-after">    if (match(WHILE)) return whileStatement();
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>statement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>statement</em>()</div>
 
 <p>That branches out to:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>printStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">returnStatement</span>() {
     <span class="t">Token</span> <span class="i">keyword</span> = <span class="i">previous</span>();
@@ -928,7 +928,7 @@ add after <em>printStatement</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Return</span>(<span class="i">keyword</span>, <span class="i">value</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>printStatement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>printStatement</em>()</div>
 
 <p>After snagging the previously consumed <code>return</code> keyword, we look for a value
 expression. Since many different tokens can potentially start an expression,
@@ -969,7 +969,7 @@ know about you, but to me that sounds like exceptions. When we execute a
 visit methods of all of the containing statements back to the code that began
 executing the body.</p>
 <p>The visit method for our new AST node looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitPrintStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitReturnStmt</span>(<span class="t">Stmt</span>.<span class="t">Return</span> <span class="i">stmt</span>) {
@@ -979,11 +979,11 @@ add after <em>visitPrintStmt</em>()</div>
     <span class="k">throw</span> <span class="k">new</span> <span class="t">Return</span>(<span class="i">value</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitPrintStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitPrintStmt</em>()</div>
 
 <p>If we have a return value, we evaluate it, otherwise, we use <code>nil</code>. Then we take
 that value and wrap it in a custom exception class and throw it.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Return.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Return.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -996,7 +996,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Return.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Return.java</em>, create new file</div>
 
 <p>This class wraps the return value with the accoutrements Java requires for a
 runtime exception class. The weird super constructor call with those <code>null</code> and
@@ -1015,7 +1015,7 @@ exceptions are a handy tool for that.</p>
 <div class="codehilite"><pre class="insert-before">          arguments.get(i));
     }
 
-</pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
 in <em>call</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="k">try</span> {
@@ -1025,7 +1025,7 @@ replace 1 line</div>
     }
 </pre><pre class="insert-after">    return null;
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, in <em>call</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, in <em>call</em>(), replace 1 line</div>
 
 <p>We wrap the call to <code>executeBlock()</code> in a try-catch block. When it catches a
 return exception, it pulls out the value and makes that the return value from
@@ -1118,46 +1118,46 @@ along that computer scientists communicated with each other using only primitive
 grunts and pawing hand gestures.</p>
 </aside>
 <div class="codehilite"><pre class="insert-before">  private final Stmt.Function declaration;
-</pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
 in class <em>LoxFunction</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">Environment</span> <span class="i">closure</span>;
 
 </pre><pre class="insert-after">  LoxFunction(Stmt.Function declaration) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, in class <em>LoxFunction</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, in class <em>LoxFunction</em></div>
 
 <p>We initialize that in the constructor.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
 constructor <em>LoxFunction</em>()<br>
 replace 1 line</div>
 <pre class="insert">  <span class="t">LoxFunction</span>(<span class="t">Stmt</span>.<span class="t">Function</span> <span class="i">declaration</span>, <span class="t">Environment</span> <span class="i">closure</span>) {
     <span class="k">this</span>.<span class="i">closure</span> = <span class="i">closure</span>;
 </pre><pre class="insert-after">    this.declaration = declaration;
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, constructor <em>LoxFunction</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, constructor <em>LoxFunction</em>(), replace 1 line</div>
 
 <p>When we create a LoxFunction, we capture the current environment.</p>
 <div class="codehilite"><pre class="insert-before">  public Void visitFunctionStmt(Stmt.Function stmt) {
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitFunctionStmt</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">LoxFunction</span> <span class="i">function</span> = <span class="k">new</span> <span class="t">LoxFunction</span>(<span class="i">stmt</span>, <span class="i">environment</span>);
 </pre><pre class="insert-after">    environment.define(stmt.name.lexeme, function);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitFunctionStmt</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitFunctionStmt</em>(), replace 1 line</div>
 
 <p>This is the environment that is active when the function is <em>declared</em> not when
 it&rsquo;s <em>called</em>, which is what we want. It represents the lexical scope
 surrounding the function declaration. Finally, when we call the function, we use
 that environment as the call&rsquo;s parent instead of going straight to <code>globals</code>.</p>
 <div class="codehilite"><pre class="insert-before">                     List&lt;Object&gt; arguments) {
-</pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
 in <em>call</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">Environment</span> <span class="i">environment</span> = <span class="k">new</span> <span class="t">Environment</span>(<span class="i">closure</span>);
 </pre><pre class="insert-after">    for (int i = 0; i &lt; declaration.params.size(); i++) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, in <em>call</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, in <em>call</em>(), replace 1 line</div>
 
 <p>This creates an environment chain that goes from the function&rsquo;s body out through
 the environments where the function is declared, all the way out to the global

--- a/site/functions.html
+++ b/site/functions.html
@@ -164,12 +164,12 @@ language specs I&rsquo;ve seen, it is this cumbersome.</p>
 <p>Over in our syntax tree generator, we add a <span name="call-ast">new
 node</span>.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Binary   : Expr left, Token operator, Expr right&quot;,
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Call     : Expr callee, Token paren, List&lt;Expr&gt; arguments&quot;</span>,
 </pre><pre class="insert-after">      &quot;Grouping : Expr expression&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="call-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#call-expression">Appendix II</a>.</p>
@@ -182,16 +182,16 @@ change it to call, well, <code>call()</code>.</p>
 <div class="codehilite"><pre class="insert-before">      return new Expr.Unary(operator, right);
     }
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>unary</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="k">return</span> <span class="i">call</span>();
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>unary</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>unary</em>(), replace 1 line</div>
 
 <p>Its definition is:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>unary</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">call</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">primary</span>();
@@ -207,7 +207,7 @@ add after <em>unary</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>unary</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>unary</em>()</div>
 
 <p>The code here doesn&rsquo;t quite line up with the grammar rules. I moved a few things
 around to make the code cleaner<span class="em">&mdash;</span>one of the luxuries we have with a
@@ -222,7 +222,7 @@ new <code>expr</code> and we loop to see if the result is itself called.</p>
 parser later to handle properties on objects.</p>
 </aside>
 <p>The code to parse the argument list is in this helper:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>unary</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">finishCall</span>(<span class="t">Expr</span> <span class="i">callee</span>) {
     <span class="t">List</span>&lt;<span class="t">Expr</span>&gt; <span class="i">arguments</span> = <span class="k">new</span> <span class="t">ArrayList</span>&lt;&gt;();
@@ -238,7 +238,7 @@ add after <em>unary</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Expr</span>.<span class="t">Call</span>(<span class="i">callee</span>, <span class="i">paren</span>, <span class="i">arguments</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>unary</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>unary</em>()</div>
 
 <p>This is more or less the <code>arguments</code> grammar rule translated to code, except
 that we also handle the zero-argument case. We check for that case first by
@@ -266,14 +266,14 @@ number of arguments will simplify our bytecode interpreter in <a href="a-bytecod
 want our two interpreters to be compatible with each other, even in weird corner
 cases like this, so we&rsquo;ll add the same limit to jlox.</p>
 <div class="codehilite"><pre class="insert-before">      do {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>finishCall</em>()</div>
 <pre class="insert">        <span class="k">if</span> (<span class="i">arguments</span>.<span class="i">size</span>() &gt;= <span class="n">255</span>) {
           <span class="i">error</span>(<span class="i">peek</span>(), <span class="s">&quot;Can&#39;t have more than 255 arguments.&quot;</span>);
         }
 </pre><pre class="insert-after">        arguments.add(expression());
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>finishCall</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>finishCall</em>()</div>
 
 <p>Note that the code here <em>reports</em> an error if it encounters too many arguments,
 but it doesn&rsquo;t <em>throw</em> the error. Throwing is how we kick into panic mode which
@@ -285,15 +285,15 @@ keepin&rsquo; on.</p>
 <p>We don&rsquo;t have any functions we can call, so it seems weird to start implementing
 calls first, but we&rsquo;ll worry about that when we get there. First, our
 interpreter needs a new import.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em></div>
 <pre class="insert"><span class="k">import</span> <span class="i">java.util.ArrayList</span>;
 </pre><pre class="insert-after">import java.util.List;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em></div>
 
 <p>As always, interpretation starts with a new visit method for our new call
 expression node.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitBinaryExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitCallExpr</span>(<span class="t">Expr</span>.<span class="t">Call</span> <span class="i">expr</span>) {
@@ -308,7 +308,7 @@ add after <em>visitBinaryExpr</em>()</div>
     <span class="k">return</span> <span class="i">function</span>.<span class="i">call</span>(<span class="k">this</span>, <span class="i">arguments</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitBinaryExpr</em>()</div>
 
 <p>First, we evaluate the expression for the callee. Typically, this expression is
 just an identifier that looks up the function by its name, but it could be
@@ -333,7 +333,7 @@ We&rsquo;ll also use it for one more purpose shortly.</p>
 own Callable interface. Alas, all the good simple names are already taken.</p>
 </aside>
 <p>There isn&rsquo;t too much to this new interface.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxCallable.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/LoxCallable.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -343,7 +343,7 @@ create new file</div>
   <span class="t">Object</span> <span class="i">call</span>(<span class="t">Interpreter</span> <span class="i">interpreter</span>, <span class="t">List</span>&lt;<span class="t">Object</span>&gt; <span class="i">arguments</span>);
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxCallable.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/LoxCallable.java</em>, create new file</div>
 
 <p>We pass in the interpreter in case the class implementing <code>call()</code> needs it. We
 also give it the list of evaluated argument values. The implementer&rsquo;s job is
@@ -361,7 +361,7 @@ ClassCastException. We don&rsquo;t want our interpreter to vomit out some nasty 
 stack trace and die. Instead, we need to check the type ourselves first.</p>
 <div class="codehilite"><pre class="insert-before">    }
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitCallExpr</em>()</div>
 <pre class="insert">    <span class="k">if</span> (!(<span class="i">callee</span> <span class="k">instanceof</span> <span class="t">LoxCallable</span>)) {
       <span class="k">throw</span> <span class="k">new</span> <span class="t">RuntimeError</span>(<span class="i">expr</span>.<span class="i">paren</span>,
@@ -370,7 +370,7 @@ in <em>visitCallExpr</em>()</div>
 
 </pre><pre class="insert-after">    LoxCallable function = (LoxCallable)callee;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitCallExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitCallExpr</em>()</div>
 
 <p>We still throw an exception, but now we&rsquo;re throwing our own exception type, one
 that the interpreter knows to catch and report gracefully.</p>
@@ -401,7 +401,7 @@ the sooner the implementation draws my attention to it, the better. So for Lox,
 we&rsquo;ll take Python&rsquo;s approach. Before invoking the callable, we check to see if
 the argument list&rsquo;s length matches the callable&rsquo;s arity.</p>
 <div class="codehilite"><pre class="insert-before">    LoxCallable function = (LoxCallable)callee;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitCallExpr</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">arguments</span>.<span class="i">size</span>() != <span class="i">function</span>.<span class="i">arity</span>()) {
       <span class="k">throw</span> <span class="k">new</span> <span class="t">RuntimeError</span>(<span class="i">expr</span>.<span class="i">paren</span>, <span class="s">&quot;Expected &quot;</span> +
@@ -411,16 +411,16 @@ in <em>visitCallExpr</em>()</div>
 
 </pre><pre class="insert-after">    return function.call(this, arguments);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitCallExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitCallExpr</em>()</div>
 
 <p>That requires a new method on the LoxCallable interface to ask it its arity.</p>
 <div class="codehilite"><pre class="insert-before">interface LoxCallable {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxCallable.java</em><br>
+</pre><div class="source-file"><em>lox/LoxCallable.java</em><br>
 in interface <em>LoxCallable</em></div>
 <pre class="insert">  <span class="t">int</span> <span class="i">arity</span>();
 </pre><pre class="insert-after">  Object call(Interpreter interpreter, List&lt;Object&gt; arguments);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxCallable.java</em>, in interface <em>LoxCallable</em></div>
+<div class="source-file-narrow"><em>lox/LoxCallable.java</em>, in interface <em>LoxCallable</em></div>
 
 <p>We <em>could</em> push the arity checking into the concrete implementation of <code>call()</code>.
 But, since we&rsquo;ll have multiple classes implementing LoxCallable, that would end
@@ -495,7 +495,7 @@ This function is defined in the global scope, so let&rsquo;s ensure the interpre
 has access to that.</p>
 <div class="codehilite"><pre class="insert-before">class Interpreter implements Expr.Visitor&lt;Object&gt;,
                              Stmt.Visitor&lt;Void&gt; {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em><br>
 replace 1 line</div>
 <pre class="insert">  <span class="k">final</span> <span class="t">Environment</span> <span class="i">globals</span> = <span class="k">new</span> <span class="t">Environment</span>();
@@ -504,7 +504,7 @@ replace 1 line</div>
 
   void interpret(List&lt;Stmt&gt; statements) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em>, replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em>, replace 1 line</div>
 
 <p>The <code>environment</code> field in the interpreter changes as we enter and exit local
 scopes. It tracks the <em>current</em> environment. This new <code>globals</code> field holds a
@@ -513,7 +513,7 @@ fixed reference to the outermost global environment.</p>
 scope.</p>
 <div class="codehilite"><pre class="insert-before">  private Environment environment = globals;
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre class="insert">  <span class="t">Interpreter</span>() {
     <span class="i">globals</span>.<span class="i">define</span>(<span class="s">&quot;clock&quot;</span>, <span class="k">new</span> <span class="t">LoxCallable</span>() {
@@ -533,7 +533,7 @@ in class <em>Interpreter</em></div>
 
 </pre><pre class="insert-after">  void interpret(List&lt;Stmt&gt; statements) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em></div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em></div>
 
 <p>This defines a <span name="lisp-1">variable</span> named &ldquo;clock&rdquo;. Its value is a
 Java anonymous class that implements LoxCallable. The <code>clock()</code> function takes
@@ -598,13 +598,13 @@ block statements use. The parameter list uses this rule:</p>
 identifier, not an expression. That&rsquo;s a lot of new syntax for the parser to chew
 through, but the resulting AST <span name="fun-ast">node</span> isn&rsquo;t too bad.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Expression : Expr expression&quot;,
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Function   : Token name, List&lt;Token&gt; params,&quot;</span> +
                   <span class="s">&quot; List&lt;Stmt&gt; body&quot;</span>,
 </pre><pre class="insert-after">      &quot;If         : Expr condition, Stmt thenBranch,&quot; +
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="fun-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#function-statement">Appendix II</a>.</p>
@@ -614,24 +614,24 @@ body. We store the body as the list of statements contained inside the curly
 braces.</p>
 <p>Over in the parser, we weave in the new declaration.</p>
 <div class="codehilite"><pre class="insert-before">    try {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>declaration</em>()</div>
 <pre class="insert">      <span class="k">if</span> (<span class="i">match</span>(<span class="i">FUN</span>)) <span class="k">return</span> <span class="i">function</span>(<span class="s">&quot;function&quot;</span>);
 </pre><pre class="insert-after">      if (match(VAR)) return varDeclaration();
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>declaration</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>declaration</em>()</div>
 
 <p>Like other statements, a function is recognized by the leading keyword. When we
 encounter <code>fun</code>, we call <code>function</code>. That corresponds to the <code>function</code> grammar
 rule since we already matched and consumed the <code>fun</code> keyword. We&rsquo;ll build the
 method up a piece at a time, starting with this:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>expressionStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span>.<span class="t">Function</span> <span class="i">function</span>(<span class="t">String</span> <span class="i">kind</span>) {
     <span class="t">Token</span> <span class="i">name</span> = <span class="i">consume</span>(<span class="i">IDENTIFIER</span>, <span class="s">&quot;Expect &quot;</span> + <span class="i">kind</span> + <span class="s">&quot; name.&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>expressionStatement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>expressionStatement</em>()</div>
 
 <p>Right now, it only consumes the identifier token for the function&rsquo;s name. You
 might be wondering about that funny little <code>kind</code> parameter. Just like we reuse
@@ -640,7 +640,7 @@ inside classes. When we do that, we&rsquo;ll pass in &ldquo;method&rdquo; for <c
 error messages are specific to the kind of declaration being parsed.</p>
 <p>Next, we parse the parameter list and the pair of parentheses wrapped around it.</p>
 <div class="codehilite"><pre class="insert-before">    Token name = consume(IDENTIFIER, &quot;Expect &quot; + kind + &quot; name.&quot;);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>function</em>()</div>
 <pre class="insert">    <span class="i">consume</span>(<span class="i">LEFT_PAREN</span>, <span class="s">&quot;Expect &#39;(&#39; after &quot;</span> + <span class="i">kind</span> + <span class="s">&quot; name.&quot;</span>);
     <span class="t">List</span>&lt;<span class="t">Token</span>&gt; <span class="i">parameters</span> = <span class="k">new</span> <span class="t">ArrayList</span>&lt;&gt;();
@@ -657,7 +657,7 @@ in <em>function</em>()</div>
     <span class="i">consume</span>(<span class="i">RIGHT_PAREN</span>, <span class="s">&quot;Expect &#39;)&#39; after parameters.&quot;</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>function</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>function</em>()</div>
 
 <p>This is like the code for handling arguments in a call, except not split out
 into a helper method. The outer <code>if</code> statement handles the zero parameter case,
@@ -668,7 +668,7 @@ that you don&rsquo;t exceed the maximum number of parameters a function is allow
 have.</p>
 <p>Finally, we parse the body and wrap it all up in a function node.</p>
 <div class="codehilite"><pre class="insert-before">    consume(RIGHT_PAREN, &quot;Expect ')' after parameters.&quot;);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>function</em>()</div>
 <pre class="insert">
 
@@ -677,7 +677,7 @@ in <em>function</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Function</span>(<span class="i">name</span>, <span class="i">parameters</span>, <span class="i">body</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>function</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>function</em>()</div>
 
 <p>Note that we consume the <code>{</code> at the beginning of the body here before calling
 <code>block()</code>. That&rsquo;s because <code>block()</code> assumes the brace token has already been
@@ -694,7 +694,7 @@ Almost, but not quite. We also need a class that implements LoxCallable so that
 we can call it. We don&rsquo;t want the runtime phase of the interpreter to bleed into
 the front end&rsquo;s syntax classes so we don&rsquo;t want Stmt.Function itself to
 implement that. Instead, we wrap it in a new class.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -707,10 +707,10 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, create new file</div>
 
 <p>We implement the <code>call()</code> of LoxCallable like so:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
 add after <em>LoxFunction</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">call</span>(<span class="t">Interpreter</span> <span class="i">interpreter</span>,
@@ -725,7 +725,7 @@ add after <em>LoxFunction</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
+<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
 
 <p>This handful of lines of code is one of the most fundamental, powerful pieces of
 our interpreter. As we saw in <a href="statements-and-state.html">the chapter on statements and <span
@@ -789,25 +789,25 @@ it if you&rsquo;re so inclined.</p>
 lists have the same length. This is safe because <code>visitCallExpr()</code> checks the
 arity before calling <code>call()</code>. It relies on the function reporting its arity to
 do that.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
 add after <em>LoxFunction</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">int</span> <span class="i">arity</span>() {
     <span class="k">return</span> <span class="i">declaration</span>.<span class="i">params</span>.<span class="i">size</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
+<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
 
 <p>That&rsquo;s most of our object representation. While we&rsquo;re in here, we may as well
 implement <code>toString()</code>.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
 add after <em>LoxFunction</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">String</span> <span class="i">toString</span>() {
     <span class="k">return</span> <span class="s">&quot;&lt;fn &quot;</span> + <span class="i">declaration</span>.<span class="i">name</span>.<span class="i">lexeme</span> + <span class="s">&quot;&gt;&quot;</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
+<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, add after <em>LoxFunction</em>()</div>
 
 <p>This gives nicer output if a user decides to print a function value.</p>
 <div class="codehilite"><pre><span class="k">fun</span> <span class="i">add</span>(<span class="i">a</span>, <span class="i">b</span>) {
@@ -819,7 +819,7 @@ add after <em>LoxFunction</em>()</div>
 <h3><a href="#interpreting-function-declarations" id="interpreting-function-declarations"><small>10&#8202;.&#8202;4&#8202;.&#8202;1</small>Interpreting function declarations</a></h3>
 <p>We&rsquo;ll come back and refine LoxFunction soon, but that&rsquo;s enough to get started.
 Now we can visit a function declaration.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitExpressionStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitFunctionStmt</span>(<span class="t">Stmt</span>.<span class="t">Function</span> <span class="i">stmt</span>) {
@@ -828,7 +828,7 @@ add after <em>visitExpressionStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitExpressionStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitExpressionStmt</em>()</div>
 
 <p>This is similar to how we interpret other literal expressions. We take a
 function <em>syntax node</em><span class="em">&mdash;</span>a compile-time representation of the function<span class="em">&mdash;</span>and
@@ -893,12 +893,12 @@ omit the value in a <code>return</code> statement, we simply treat it as equival
 </pre></div>
 <p>Over in our AST generator, we add a <span name="return-ast">new node</span>.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Print      : Expr expression&quot;,
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Return     : Token keyword, Expr value&quot;</span>,
 </pre><pre class="insert-after">      &quot;Var        : Token name, Expr initializer&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="return-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#return-statement">Appendix II</a>.</p>
@@ -907,15 +907,15 @@ in <em>main</em>()</div>
 reporting, and the value being returned, if any. We parse it like other
 statements, first by recognizing the initial keyword.</p>
 <div class="codehilite"><pre class="insert-before">    if (match(PRINT)) return printStatement();
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">match</span>(<span class="i">RETURN</span>)) <span class="k">return</span> <span class="i">returnStatement</span>();
 </pre><pre class="insert-after">    if (match(WHILE)) return whileStatement();
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>statement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>statement</em>()</div>
 
 <p>That branches out to:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>printStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">returnStatement</span>() {
     <span class="t">Token</span> <span class="i">keyword</span> = <span class="i">previous</span>();
@@ -928,7 +928,7 @@ add after <em>printStatement</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Return</span>(<span class="i">keyword</span>, <span class="i">value</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>printStatement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>printStatement</em>()</div>
 
 <p>After snagging the previously consumed <code>return</code> keyword, we look for a value
 expression. Since many different tokens can potentially start an expression,
@@ -969,7 +969,7 @@ know about you, but to me that sounds like exceptions. When we execute a
 visit methods of all of the containing statements back to the code that began
 executing the body.</p>
 <p>The visit method for our new AST node looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitPrintStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitReturnStmt</span>(<span class="t">Stmt</span>.<span class="t">Return</span> <span class="i">stmt</span>) {
@@ -979,11 +979,11 @@ add after <em>visitPrintStmt</em>()</div>
     <span class="k">throw</span> <span class="k">new</span> <span class="t">Return</span>(<span class="i">value</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitPrintStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitPrintStmt</em>()</div>
 
 <p>If we have a return value, we evaluate it, otherwise, we use <code>nil</code>. Then we take
 that value and wrap it in a custom exception class and throw it.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Return.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Return.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -996,7 +996,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Return.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/Return.java</em>, create new file</div>
 
 <p>This class wraps the return value with the accoutrements Java requires for a
 runtime exception class. The weird super constructor call with those <code>null</code> and
@@ -1015,7 +1015,7 @@ exceptions are a handy tool for that.</p>
 <div class="codehilite"><pre class="insert-before">          arguments.get(i));
     }
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
+</pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
 in <em>call</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="k">try</span> {
@@ -1025,7 +1025,7 @@ replace 1 line</div>
     }
 </pre><pre class="insert-after">    return null;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, in <em>call</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, in <em>call</em>(), replace 1 line</div>
 
 <p>We wrap the call to <code>executeBlock()</code> in a try-catch block. When it catches a
 return exception, it pulls out the value and makes that the return value from
@@ -1118,46 +1118,46 @@ along that computer scientists communicated with each other using only primitive
 grunts and pawing hand gestures.</p>
 </aside>
 <div class="codehilite"><pre class="insert-before">  private final Stmt.Function declaration;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
+</pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
 in class <em>LoxFunction</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">Environment</span> <span class="i">closure</span>;
 
 </pre><pre class="insert-after">  LoxFunction(Stmt.Function declaration) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, in class <em>LoxFunction</em></div>
+<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, in class <em>LoxFunction</em></div>
 
 <p>We initialize that in the constructor.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/LoxFunction.java</em><br>
 constructor <em>LoxFunction</em>()<br>
 replace 1 line</div>
 <pre class="insert">  <span class="t">LoxFunction</span>(<span class="t">Stmt</span>.<span class="t">Function</span> <span class="i">declaration</span>, <span class="t">Environment</span> <span class="i">closure</span>) {
     <span class="k">this</span>.<span class="i">closure</span> = <span class="i">closure</span>;
 </pre><pre class="insert-after">    this.declaration = declaration;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, constructor <em>LoxFunction</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, constructor <em>LoxFunction</em>(), replace 1 line</div>
 
 <p>When we create a LoxFunction, we capture the current environment.</p>
 <div class="codehilite"><pre class="insert-before">  public Void visitFunctionStmt(Stmt.Function stmt) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitFunctionStmt</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">LoxFunction</span> <span class="i">function</span> = <span class="k">new</span> <span class="t">LoxFunction</span>(<span class="i">stmt</span>, <span class="i">environment</span>);
 </pre><pre class="insert-after">    environment.define(stmt.name.lexeme, function);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitFunctionStmt</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitFunctionStmt</em>(), replace 1 line</div>
 
 <p>This is the environment that is active when the function is <em>declared</em> not when
 it&rsquo;s <em>called</em>, which is what we want. It represents the lexical scope
 surrounding the function declaration. Finally, when we call the function, we use
 that environment as the call&rsquo;s parent instead of going straight to <code>globals</code>.</p>
 <div class="codehilite"><pre class="insert-before">                     List&lt;Object&gt; arguments) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxFunction.java</em><br>
+</pre><div class="source-file"><em>lox/LoxFunction.java</em><br>
 in <em>call</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">Environment</span> <span class="i">environment</span> = <span class="k">new</span> <span class="t">Environment</span>(<span class="i">closure</span>);
 </pre><pre class="insert-after">    for (int i = 0; i &lt; declaration.params.size(); i++) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxFunction.java</em>, in <em>call</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/LoxFunction.java</em>, in <em>call</em>(), replace 1 line</div>
 
 <p>This creates an environment chain that goes from the function&rsquo;s body out through
 the environments where the function is declared, all the way out to the global

--- a/site/inheritance.html
+++ b/site/inheritance.html
@@ -171,14 +171,14 @@ class that everything inherits from, so when you omit the superclass clause, the
 class has <em>no</em> superclass, not even an implicit one.</p>
 <p>We want to capture this new syntax in the class declaration&rsquo;s AST node.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Block      : List&lt;Stmt&gt; statements&quot;,
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()<br>
 replace 1 line</div>
 <pre class="insert">      <span class="s">&quot;Class      : Token name, Expr.Variable superclass,&quot;</span> +
                   <span class="s">&quot; List&lt;Stmt.Function&gt; methods&quot;</span>,
 </pre><pre class="insert-after">      &quot;Expression : Expr expression&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>(), replace 1 line</div>
 
 <p>You might be surprised that we store the superclass name as an Expr.Variable,
 not a Token. The grammar restricts the superclass clause to a single identifier,
@@ -187,7 +187,7 @@ name in an Expr.Variable early on in the parser gives us an object that the
 resolver can hang the resolution information off of.</p>
 <p>The new parser code follows the grammar directly.</p>
 <div class="codehilite"><pre class="insert-before">    Token name = consume(IDENTIFIER, &quot;Expect class name.&quot;);
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>classDeclaration</em>()</div>
 <pre class="insert">
 
@@ -199,24 +199,24 @@ in <em>classDeclaration</em>()</div>
 
 </pre><pre class="insert-after">    consume(LEFT_BRACE, &quot;Expect '{' before class body.&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>classDeclaration</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>classDeclaration</em>()</div>
 
 <p>Once we&rsquo;ve (possibly) parsed a superclass declaration, we store it in the AST.</p>
 <div class="codehilite"><pre class="insert-before">    consume(RIGHT_BRACE, &quot;Expect '}' after class body.&quot;);
 
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>classDeclaration</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Class</span>(<span class="i">name</span>, <span class="i">superclass</span>, <span class="i">methods</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>classDeclaration</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>classDeclaration</em>(), replace 1 line</div>
 
 <p>If we didn&rsquo;t parse a superclass clause, the superclass expression will be
 <code>null</code>. We&rsquo;ll have to make sure the later passes check for that. The first of
 those is the resolver.</p>
 <div class="codehilite"><pre class="insert-before">    define(stmt.name);
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">
 
@@ -227,7 +227,7 @@ in <em>visitClassStmt</em>()</div>
 
     beginScope();
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>The class declaration AST node has a new subexpression, so we traverse into and
 resolve that. Since classes are usually declared at the top level, the
@@ -245,7 +245,7 @@ being cycles in the inheritance chain. The safest thing is to detect this case
 statically and report it as an error.</p>
 <div class="codehilite"><pre class="insert-before">    define(stmt.name);
 
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">stmt</span>.<span class="i">superclass</span> != <span class="k">null</span> &amp;&amp;
         <span class="i">stmt</span>.<span class="i">name</span>.<span class="i">lexeme</span>.<span class="i">equals</span>(<span class="i">stmt</span>.<span class="i">superclass</span>.<span class="i">name</span>.<span class="i">lexeme</span>)) {
@@ -255,11 +255,11 @@ in <em>visitClassStmt</em>()</div>
 
 </pre><pre class="insert-after">    if (stmt.superclass != null) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>Assuming the code resolves without error, the AST travels to the interpreter.</p>
 <div class="codehilite"><pre class="insert-before">  public Void visitClassStmt(Stmt.Class stmt) {
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="t">Object</span> <span class="i">superclass</span> = <span class="k">null</span>;
     <span class="k">if</span> (<span class="i">stmt</span>.<span class="i">superclass</span> != <span class="k">null</span>) {
@@ -272,7 +272,7 @@ in <em>visitClassStmt</em>()</div>
 
 </pre><pre class="insert-after">    environment.define(stmt.name.lexeme, null);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>If the class has a superclass expression, we evaluate it. Since that could
 potentially evaluate to some other kind of object, we have to check at runtime
@@ -289,7 +289,7 @@ that too. We pass the superclass to the constructor.</p>
 <div class="codehilite"><pre class="insert-before">      methods.put(method.name.lexeme, function);
     }
 
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitClassStmt</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">LoxClass</span> <span class="i">klass</span> = <span class="k">new</span> <span class="t">LoxClass</span>(<span class="i">stmt</span>.<span class="i">name</span>.<span class="i">lexeme</span>,
@@ -297,10 +297,10 @@ replace 1 line</div>
 
 </pre><pre class="insert-after">    environment.assign(stmt.name, klass);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitClassStmt</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitClassStmt</em>(), replace 1 line</div>
 
 <p>The constructor stores it in a field.</p>
-<div class="codehilite"><div class="source-file"><em>lox/LoxClass.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
 constructor <em>LoxClass</em>()<br>
 replace 1 line</div>
 <pre class="insert">  <span class="t">LoxClass</span>(<span class="t">String</span> <span class="i">name</span>, <span class="t">LoxClass</span> <span class="i">superclass</span>,
@@ -308,16 +308,16 @@ replace 1 line</div>
     <span class="k">this</span>.<span class="i">superclass</span> = <span class="i">superclass</span>;
 </pre><pre class="insert-after">    this.name = name;
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxClass.java</em>, constructor <em>LoxClass</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, constructor <em>LoxClass</em>(), replace 1 line</div>
 
 <p>Which we declare here:</p>
 <div class="codehilite"><pre class="insert-before">  final String name;
-</pre><div class="source-file"><em>lox/LoxClass.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
 in class <em>LoxClass</em></div>
 <pre class="insert">  <span class="k">final</span> <span class="t">LoxClass</span> <span class="i">superclass</span>;
 </pre><pre class="insert-after">  private final Map&lt;String, LoxFunction&gt; methods;
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxClass.java</em>, in class <em>LoxClass</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, in class <em>LoxClass</em></div>
 
 <p>With that, we can define classes that are subclasses of other classes. Now, what
 does having a superclass actually <em>do?</em></p>
@@ -343,7 +343,7 @@ astonishingly easy.</p>
 <div class="codehilite"><pre class="insert-before">      return methods.get(name);
     }
 
-</pre><div class="source-file"><em>lox/LoxClass.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
 in <em>findMethod</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">superclass</span> != <span class="k">null</span>) {
       <span class="k">return</span> <span class="i">superclass</span>.<span class="i">findMethod</span>(<span class="i">name</span>);
@@ -351,7 +351,7 @@ in <em>findMethod</em>()</div>
 
 </pre><pre class="insert-after">    return null;
 </pre></div>
-<div class="source-file-narrow"><em>lox/LoxClass.java</em>, in <em>findMethod</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, in <em>findMethod</em>()</div>
 
 <p>That&rsquo;s literally all there is to it. When we are looking up a method on an
 instance, if we don&rsquo;t find it on the instance&rsquo;s class, we recurse up through the
@@ -428,12 +428,12 @@ you can get a handle to a superclass method and invoke it separately.</p>
 and the name of the method being looked up. The corresponding <span
 name="super-ast">syntax tree node</span> is thus:</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Set      : Expr object, Token name, Expr value&quot;,
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Super    : Token keyword, Token method&quot;</span>,
 </pre><pre class="insert-after">      &quot;This     : Token keyword&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="super-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#super-expression">Appendix II</a>.</p>
@@ -442,7 +442,7 @@ in <em>main</em>()</div>
 method.</p>
 <div class="codehilite"><pre class="insert-before">      return new Expr.Literal(previous().literal);
     }
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>primary</em>()</div>
 <pre class="insert">
 
@@ -457,7 +457,7 @@ in <em>primary</em>()</div>
 
     if (match(THIS)) return new Expr.This(previous());
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>primary</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>primary</em>()</div>
 
 <p>A leading <code>super</code> keyword tells us we&rsquo;ve hit a <code>super</code> expression. After that we
 consume the expected <code>.</code> and method name.</p>
@@ -546,7 +546,7 @@ can get to creating the environment at runtime, we need to handle the
 corresponding scope chain in the resolver.</p>
 <div class="codehilite"><pre class="insert-before">      resolve(stmt.superclass);
     }
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">
 
@@ -558,27 +558,27 @@ in <em>visitClassStmt</em>()</div>
 
     beginScope();
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>If the class declaration has a superclass, then we create a new scope
 surrounding all of its methods. In that scope, we define the name &ldquo;super&rdquo;. Once
 we&rsquo;re done resolving the class&rsquo;s methods, we discard that scope.</p>
 <div class="codehilite"><pre class="insert-before">    endScope();
 
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">stmt</span>.<span class="i">superclass</span> != <span class="k">null</span>) <span class="i">endScope</span>();
 
 </pre><pre class="insert-after">    currentClass = enclosingClass;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>It&rsquo;s a minor optimization, but we only create the superclass environment if the
 class actually <em>has</em> a superclass. There&rsquo;s no point creating it when there isn&rsquo;t
 a superclass since there&rsquo;d be no superclass to store in it anyway.</p>
 <p>With &ldquo;super&rdquo; defined in a scope chain, we are able to resolve the <code>super</code>
 expression itself.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitSetExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitSuperExpr</span>(<span class="t">Expr</span>.<span class="t">Super</span> <span class="i">expr</span>) {
@@ -586,7 +586,7 @@ add after <em>visitSetExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitSetExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitSetExpr</em>()</div>
 
 <p>We resolve the <code>super</code> token exactly as if it were a variable. The resolution
 stores the number of hops along the environment chain that the interpreter needs
@@ -599,7 +599,7 @@ definition, we create a new environment.</p>
     }
 
     environment.define(stmt.name.lexeme, null);
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">
 
@@ -611,7 +611,7 @@ in <em>visitClassStmt</em>()</div>
 
     Map&lt;String, LoxFunction&gt; methods = new HashMap&lt;&gt;();
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>Inside that environment, we store a reference to the superclass<span class="em">&mdash;</span>the actual
 LoxClass object for the superclass which we have now that we are in the runtime.
@@ -620,7 +620,7 @@ environment<span class="em">&mdash;</span>the one where we just bound &ldquo;sup
 on to the superclass like we need. Once that&rsquo;s done, we pop the environment.</p>
 <div class="codehilite"><pre class="insert-before">    LoxClass klass = new LoxClass(stmt.name.lexeme,
         (LoxClass)superclass, methods);
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">
 
@@ -631,11 +631,11 @@ in <em>visitClassStmt</em>()</div>
 
     environment.assign(stmt.name, klass);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>We&rsquo;re ready to interpret <code>super</code> expressions themselves. There are a few moving
 parts, so we&rsquo;ll build this method up in pieces.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitSetExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitSuperExpr</span>(<span class="t">Expr</span>.<span class="t">Super</span> <span class="i">expr</span>) {
@@ -644,7 +644,7 @@ add after <em>visitSetExpr</em>()</div>
         <span class="i">distance</span>, <span class="s">&quot;super&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitSetExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitSetExpr</em>()</div>
 
 <p>First, the work we&rsquo;ve been leading up to. We look up the surrounding class&rsquo;s
 superclass by looking up &ldquo;super&rdquo; in the proper environment.</p>
@@ -660,7 +660,7 @@ control the layout of the environment chains. The environment where &ldquo;this&
 bound is always right inside the environment where we store &ldquo;super&rdquo;.</p>
 <div class="codehilite"><pre class="insert-before">    LoxClass superclass = (LoxClass)environment.getAt(
         distance, &quot;super&quot;);
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitSuperExpr</em>()</div>
 <pre class="insert">
 
@@ -668,7 +668,7 @@ in <em>visitSuperExpr</em>()</div>
         <span class="i">distance</span> - <span class="n">1</span>, <span class="s">&quot;this&quot;</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitSuperExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitSuperExpr</em>()</div>
 
 <p>Offsetting the distance by one looks up &ldquo;this&rdquo; in that inner environment. I
 admit this isn&rsquo;t the most <span name="elegant">elegant</span> code, but it
@@ -680,7 +680,7 @@ can&rsquo;t hide the hacks by leaving them as an &ldquo;exercise for the reader&
 <p>Now we&rsquo;re ready to look up and bind the method, starting at the superclass.</p>
 <div class="codehilite"><pre class="insert-before">    LoxInstance object = (LoxInstance)environment.getAt(
         distance - 1, &quot;this&quot;);
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitSuperExpr</em>()</div>
 <pre class="insert">
 
@@ -688,7 +688,7 @@ in <em>visitSuperExpr</em>()</div>
     <span class="k">return</span> <span class="i">method</span>.<span class="i">bind</span>(<span class="i">object</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitSuperExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitSuperExpr</em>()</div>
 
 <p>This is almost exactly like the code for looking up a method of a get
 expression, except that we call <code>findMethod()</code> on the superclass instead of on
@@ -698,7 +698,7 @@ So we check for that too.</p>
 <div class="codehilite"><pre class="insert-before">
 
     LoxFunction method = superclass.findMethod(expr.method.lexeme);
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitSuperExpr</em>()</div>
 <pre class="insert">
 
@@ -710,7 +710,7 @@ in <em>visitSuperExpr</em>()</div>
 </pre><pre class="insert-after">    return method.bind(object);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitSuperExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitSuperExpr</em>()</div>
 
 <p>There you have it! Take that BostonCream example earlier and give it a try.
 Assuming you and I did everything right, it should fry it first, then stuff it
@@ -747,29 +747,29 @@ resolver.</p>
 is surrounding the current code being visited.</p>
 <div class="codehilite"><pre class="insert-before">    NONE,
 </pre><pre class="insert-before">    <span class="i">CLASS</span><span class="insert-comma">,</span>
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in enum <em>ClassType</em><br>
 add <em>&ldquo;,&rdquo;</em> to previous line</div>
 <pre class="insert">    <span class="i">SUBCLASS</span>
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in enum <em>ClassType</em>, add <em>&ldquo;,&rdquo;</em> to previous line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in enum <em>ClassType</em>, add <em>&ldquo;,&rdquo;</em> to previous line</div>
 
 <p>We&rsquo;ll use that to distinguish when we&rsquo;re inside a class that has a superclass
 versus one that doesn&rsquo;t. When we resolve a class declaration, we set that if the
 class is a subclass.</p>
 <div class="codehilite"><pre class="insert-before">    if (stmt.superclass != null) {
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">      <span class="i">currentClass</span> = <span class="t">ClassType</span>.<span class="i">SUBCLASS</span>;
 </pre><pre class="insert-after">      resolve(stmt.superclass);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>Then, when we resolve a <code>super</code> expression, we check to see that we are
 currently inside a scope where that&rsquo;s allowed.</p>
 <div class="codehilite"><pre class="insert-before">  public Void visitSuperExpr(Expr.Super expr) {
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitSuperExpr</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">currentClass</span> == <span class="t">ClassType</span>.<span class="i">NONE</span>) {
       <span class="t">Lox</span>.<span class="i">error</span>(<span class="i">expr</span>.<span class="i">keyword</span>,
@@ -781,7 +781,7 @@ in <em>visitSuperExpr</em>()</div>
 
 </pre><pre class="insert-after">    resolveLocal(expr, expr.keyword);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitSuperExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitSuperExpr</em>()</div>
 
 <p>If not<span class="em">&mdash;</span>oopsie!<span class="em">&mdash;</span>the user made a mistake.</p>
 <h2><a href="#conclusion" id="conclusion"><small>13&#8202;.&#8202;4</small>Conclusion</a></h2>

--- a/site/inheritance.html
+++ b/site/inheritance.html
@@ -171,14 +171,14 @@ class that everything inherits from, so when you omit the superclass clause, the
 class has <em>no</em> superclass, not even an implicit one.</p>
 <p>We want to capture this new syntax in the class declaration&rsquo;s AST node.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Block      : List&lt;Stmt&gt; statements&quot;,
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()<br>
 replace 1 line</div>
 <pre class="insert">      <span class="s">&quot;Class      : Token name, Expr.Variable superclass,&quot;</span> +
                   <span class="s">&quot; List&lt;Stmt.Function&gt; methods&quot;</span>,
 </pre><pre class="insert-after">      &quot;Expression : Expr expression&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>(), replace 1 line</div>
 
 <p>You might be surprised that we store the superclass name as an Expr.Variable,
 not a Token. The grammar restricts the superclass clause to a single identifier,
@@ -187,7 +187,7 @@ name in an Expr.Variable early on in the parser gives us an object that the
 resolver can hang the resolution information off of.</p>
 <p>The new parser code follows the grammar directly.</p>
 <div class="codehilite"><pre class="insert-before">    Token name = consume(IDENTIFIER, &quot;Expect class name.&quot;);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>classDeclaration</em>()</div>
 <pre class="insert">
 
@@ -199,24 +199,24 @@ in <em>classDeclaration</em>()</div>
 
 </pre><pre class="insert-after">    consume(LEFT_BRACE, &quot;Expect '{' before class body.&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>classDeclaration</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>classDeclaration</em>()</div>
 
 <p>Once we&rsquo;ve (possibly) parsed a superclass declaration, we store it in the AST.</p>
 <div class="codehilite"><pre class="insert-before">    consume(RIGHT_BRACE, &quot;Expect '}' after class body.&quot;);
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>classDeclaration</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Class</span>(<span class="i">name</span>, <span class="i">superclass</span>, <span class="i">methods</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>classDeclaration</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>classDeclaration</em>(), replace 1 line</div>
 
 <p>If we didn&rsquo;t parse a superclass clause, the superclass expression will be
 <code>null</code>. We&rsquo;ll have to make sure the later passes check for that. The first of
 those is the resolver.</p>
 <div class="codehilite"><pre class="insert-before">    define(stmt.name);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">
 
@@ -227,7 +227,7 @@ in <em>visitClassStmt</em>()</div>
 
     beginScope();
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>The class declaration AST node has a new subexpression, so we traverse into and
 resolve that. Since classes are usually declared at the top level, the
@@ -245,7 +245,7 @@ being cycles in the inheritance chain. The safest thing is to detect this case
 statically and report it as an error.</p>
 <div class="codehilite"><pre class="insert-before">    define(stmt.name);
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">stmt</span>.<span class="i">superclass</span> != <span class="k">null</span> &amp;&amp;
         <span class="i">stmt</span>.<span class="i">name</span>.<span class="i">lexeme</span>.<span class="i">equals</span>(<span class="i">stmt</span>.<span class="i">superclass</span>.<span class="i">name</span>.<span class="i">lexeme</span>)) {
@@ -255,11 +255,11 @@ in <em>visitClassStmt</em>()</div>
 
 </pre><pre class="insert-after">    if (stmt.superclass != null) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>Assuming the code resolves without error, the AST travels to the interpreter.</p>
 <div class="codehilite"><pre class="insert-before">  public Void visitClassStmt(Stmt.Class stmt) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="t">Object</span> <span class="i">superclass</span> = <span class="k">null</span>;
     <span class="k">if</span> (<span class="i">stmt</span>.<span class="i">superclass</span> != <span class="k">null</span>) {
@@ -272,7 +272,7 @@ in <em>visitClassStmt</em>()</div>
 
 </pre><pre class="insert-after">    environment.define(stmt.name.lexeme, null);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>If the class has a superclass expression, we evaluate it. Since that could
 potentially evaluate to some other kind of object, we have to check at runtime
@@ -289,7 +289,7 @@ that too. We pass the superclass to the constructor.</p>
 <div class="codehilite"><pre class="insert-before">      methods.put(method.name.lexeme, function);
     }
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitClassStmt</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">LoxClass</span> <span class="i">klass</span> = <span class="k">new</span> <span class="t">LoxClass</span>(<span class="i">stmt</span>.<span class="i">name</span>.<span class="i">lexeme</span>,
@@ -297,10 +297,10 @@ replace 1 line</div>
 
 </pre><pre class="insert-after">    environment.assign(stmt.name, klass);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitClassStmt</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitClassStmt</em>(), replace 1 line</div>
 
 <p>The constructor stores it in a field.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/LoxClass.java</em><br>
 constructor <em>LoxClass</em>()<br>
 replace 1 line</div>
 <pre class="insert">  <span class="t">LoxClass</span>(<span class="t">String</span> <span class="i">name</span>, <span class="t">LoxClass</span> <span class="i">superclass</span>,
@@ -308,16 +308,16 @@ replace 1 line</div>
     <span class="k">this</span>.<span class="i">superclass</span> = <span class="i">superclass</span>;
 </pre><pre class="insert-after">    this.name = name;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, constructor <em>LoxClass</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/LoxClass.java</em>, constructor <em>LoxClass</em>(), replace 1 line</div>
 
 <p>Which we declare here:</p>
 <div class="codehilite"><pre class="insert-before">  final String name;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
+</pre><div class="source-file"><em>lox/LoxClass.java</em><br>
 in class <em>LoxClass</em></div>
 <pre class="insert">  <span class="k">final</span> <span class="t">LoxClass</span> <span class="i">superclass</span>;
 </pre><pre class="insert-after">  private final Map&lt;String, LoxFunction&gt; methods;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, in class <em>LoxClass</em></div>
+<div class="source-file-narrow"><em>lox/LoxClass.java</em>, in class <em>LoxClass</em></div>
 
 <p>With that, we can define classes that are subclasses of other classes. Now, what
 does having a superclass actually <em>do?</em></p>
@@ -343,7 +343,7 @@ astonishingly easy.</p>
 <div class="codehilite"><pre class="insert-before">      return methods.get(name);
     }
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\LoxClass.java</em><br>
+</pre><div class="source-file"><em>lox/LoxClass.java</em><br>
 in <em>findMethod</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">superclass</span> != <span class="k">null</span>) {
       <span class="k">return</span> <span class="i">superclass</span>.<span class="i">findMethod</span>(<span class="i">name</span>);
@@ -351,7 +351,7 @@ in <em>findMethod</em>()</div>
 
 </pre><pre class="insert-after">    return null;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\LoxClass.java</em>, in <em>findMethod</em>()</div>
+<div class="source-file-narrow"><em>lox/LoxClass.java</em>, in <em>findMethod</em>()</div>
 
 <p>That&rsquo;s literally all there is to it. When we are looking up a method on an
 instance, if we don&rsquo;t find it on the instance&rsquo;s class, we recurse up through the
@@ -428,12 +428,12 @@ you can get a handle to a superclass method and invoke it separately.</p>
 and the name of the method being looked up. The corresponding <span
 name="super-ast">syntax tree node</span> is thus:</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Set      : Expr object, Token name, Expr value&quot;,
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Super    : Token keyword, Token method&quot;</span>,
 </pre><pre class="insert-after">      &quot;This     : Token keyword&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="super-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#super-expression">Appendix II</a>.</p>
@@ -442,7 +442,7 @@ in <em>main</em>()</div>
 method.</p>
 <div class="codehilite"><pre class="insert-before">      return new Expr.Literal(previous().literal);
     }
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>primary</em>()</div>
 <pre class="insert">
 
@@ -457,7 +457,7 @@ in <em>primary</em>()</div>
 
     if (match(THIS)) return new Expr.This(previous());
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>primary</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>primary</em>()</div>
 
 <p>A leading <code>super</code> keyword tells us we&rsquo;ve hit a <code>super</code> expression. After that we
 consume the expected <code>.</code> and method name.</p>
@@ -546,7 +546,7 @@ can get to creating the environment at runtime, we need to handle the
 corresponding scope chain in the resolver.</p>
 <div class="codehilite"><pre class="insert-before">      resolve(stmt.superclass);
     }
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">
 
@@ -558,27 +558,27 @@ in <em>visitClassStmt</em>()</div>
 
     beginScope();
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>If the class declaration has a superclass, then we create a new scope
 surrounding all of its methods. In that scope, we define the name &ldquo;super&rdquo;. Once
 we&rsquo;re done resolving the class&rsquo;s methods, we discard that scope.</p>
 <div class="codehilite"><pre class="insert-before">    endScope();
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">stmt</span>.<span class="i">superclass</span> != <span class="k">null</span>) <span class="i">endScope</span>();
 
 </pre><pre class="insert-after">    currentClass = enclosingClass;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>It&rsquo;s a minor optimization, but we only create the superclass environment if the
 class actually <em>has</em> a superclass. There&rsquo;s no point creating it when there isn&rsquo;t
 a superclass since there&rsquo;d be no superclass to store in it anyway.</p>
 <p>With &ldquo;super&rdquo; defined in a scope chain, we are able to resolve the <code>super</code>
 expression itself.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitSetExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitSuperExpr</span>(<span class="t">Expr</span>.<span class="t">Super</span> <span class="i">expr</span>) {
@@ -586,7 +586,7 @@ add after <em>visitSetExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitSetExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitSetExpr</em>()</div>
 
 <p>We resolve the <code>super</code> token exactly as if it were a variable. The resolution
 stores the number of hops along the environment chain that the interpreter needs
@@ -599,7 +599,7 @@ definition, we create a new environment.</p>
     }
 
     environment.define(stmt.name.lexeme, null);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">
 
@@ -611,7 +611,7 @@ in <em>visitClassStmt</em>()</div>
 
     Map&lt;String, LoxFunction&gt; methods = new HashMap&lt;&gt;();
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>Inside that environment, we store a reference to the superclass<span class="em">&mdash;</span>the actual
 LoxClass object for the superclass which we have now that we are in the runtime.
@@ -620,7 +620,7 @@ environment<span class="em">&mdash;</span>the one where we just bound &ldquo;sup
 on to the superclass like we need. Once that&rsquo;s done, we pop the environment.</p>
 <div class="codehilite"><pre class="insert-before">    LoxClass klass = new LoxClass(stmt.name.lexeme,
         (LoxClass)superclass, methods);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">
 
@@ -631,11 +631,11 @@ in <em>visitClassStmt</em>()</div>
 
     environment.assign(stmt.name, klass);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>We&rsquo;re ready to interpret <code>super</code> expressions themselves. There are a few moving
 parts, so we&rsquo;ll build this method up in pieces.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitSetExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitSuperExpr</span>(<span class="t">Expr</span>.<span class="t">Super</span> <span class="i">expr</span>) {
@@ -644,7 +644,7 @@ add after <em>visitSetExpr</em>()</div>
         <span class="i">distance</span>, <span class="s">&quot;super&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitSetExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitSetExpr</em>()</div>
 
 <p>First, the work we&rsquo;ve been leading up to. We look up the surrounding class&rsquo;s
 superclass by looking up &ldquo;super&rdquo; in the proper environment.</p>
@@ -660,7 +660,7 @@ control the layout of the environment chains. The environment where &ldquo;this&
 bound is always right inside the environment where we store &ldquo;super&rdquo;.</p>
 <div class="codehilite"><pre class="insert-before">    LoxClass superclass = (LoxClass)environment.getAt(
         distance, &quot;super&quot;);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitSuperExpr</em>()</div>
 <pre class="insert">
 
@@ -668,7 +668,7 @@ in <em>visitSuperExpr</em>()</div>
         <span class="i">distance</span> - <span class="n">1</span>, <span class="s">&quot;this&quot;</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitSuperExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitSuperExpr</em>()</div>
 
 <p>Offsetting the distance by one looks up &ldquo;this&rdquo; in that inner environment. I
 admit this isn&rsquo;t the most <span name="elegant">elegant</span> code, but it
@@ -680,7 +680,7 @@ can&rsquo;t hide the hacks by leaving them as an &ldquo;exercise for the reader&
 <p>Now we&rsquo;re ready to look up and bind the method, starting at the superclass.</p>
 <div class="codehilite"><pre class="insert-before">    LoxInstance object = (LoxInstance)environment.getAt(
         distance - 1, &quot;this&quot;);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitSuperExpr</em>()</div>
 <pre class="insert">
 
@@ -688,7 +688,7 @@ in <em>visitSuperExpr</em>()</div>
     <span class="k">return</span> <span class="i">method</span>.<span class="i">bind</span>(<span class="i">object</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitSuperExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitSuperExpr</em>()</div>
 
 <p>This is almost exactly like the code for looking up a method of a get
 expression, except that we call <code>findMethod()</code> on the superclass instead of on
@@ -698,7 +698,7 @@ So we check for that too.</p>
 <div class="codehilite"><pre class="insert-before">
 
     LoxFunction method = superclass.findMethod(expr.method.lexeme);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitSuperExpr</em>()</div>
 <pre class="insert">
 
@@ -710,7 +710,7 @@ in <em>visitSuperExpr</em>()</div>
 </pre><pre class="insert-after">    return method.bind(object);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitSuperExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitSuperExpr</em>()</div>
 
 <p>There you have it! Take that BostonCream example earlier and give it a try.
 Assuming you and I did everything right, it should fry it first, then stuff it
@@ -747,29 +747,29 @@ resolver.</p>
 is surrounding the current code being visited.</p>
 <div class="codehilite"><pre class="insert-before">    NONE,
 </pre><pre class="insert-before">    <span class="i">CLASS</span><span class="insert-comma">,</span>
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in enum <em>ClassType</em><br>
 add <em>&ldquo;,&rdquo;</em> to previous line</div>
 <pre class="insert">    <span class="i">SUBCLASS</span>
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in enum <em>ClassType</em>, add <em>&ldquo;,&rdquo;</em> to previous line</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in enum <em>ClassType</em>, add <em>&ldquo;,&rdquo;</em> to previous line</div>
 
 <p>We&rsquo;ll use that to distinguish when we&rsquo;re inside a class that has a superclass
 versus one that doesn&rsquo;t. When we resolve a class declaration, we set that if the
 class is a subclass.</p>
 <div class="codehilite"><pre class="insert-before">    if (stmt.superclass != null) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitClassStmt</em>()</div>
 <pre class="insert">      <span class="i">currentClass</span> = <span class="t">ClassType</span>.<span class="i">SUBCLASS</span>;
 </pre><pre class="insert-after">      resolve(stmt.superclass);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitClassStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitClassStmt</em>()</div>
 
 <p>Then, when we resolve a <code>super</code> expression, we check to see that we are
 currently inside a scope where that&rsquo;s allowed.</p>
 <div class="codehilite"><pre class="insert-before">  public Void visitSuperExpr(Expr.Super expr) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitSuperExpr</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">currentClass</span> == <span class="t">ClassType</span>.<span class="i">NONE</span>) {
       <span class="t">Lox</span>.<span class="i">error</span>(<span class="i">expr</span>.<span class="i">keyword</span>,
@@ -781,7 +781,7 @@ in <em>visitSuperExpr</em>()</div>
 
 </pre><pre class="insert-after">    resolveLocal(expr, expr.keyword);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitSuperExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitSuperExpr</em>()</div>
 
 <p>If not<span class="em">&mdash;</span>oopsie!<span class="em">&mdash;</span>the user made a mistake.</p>
 <h2><a href="#conclusion" id="conclusion"><small>13&#8202;.&#8202;4</small>Conclusion</a></h2>

--- a/site/parsing-expressions.html
+++ b/site/parsing-expressions.html
@@ -419,7 +419,7 @@ itself<span class="em">&mdash;</span>directly or indirectly<span class="em">&mda
 call.</p>
 <h3><a href="#the-parser-class" id="the-parser-class"><small>6&#8202;.&#8202;2&#8202;.&#8202;1</small>The parser class</a></h3>
 <p>Each grammar rule becomes a method inside this new class:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -436,7 +436,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, create new file</div>
 
 <p>Like the scanner, the parser consumes a flat input sequence, only now we&rsquo;re
 reading tokens instead of characters. We store the list of tokens and use
@@ -444,13 +444,13 @@ reading tokens instead of characters. We store the list of tokens and use
 <p>We&rsquo;re going to run straight through the expression grammar now and translate
 each rule to Java code. The first rule, <code>expression</code>, simply expands to the
 <code>equality</code> rule, so that&rsquo;s straightforward.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>Parser</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">expression</span>() {
     <span class="k">return</span> <span class="i">equality</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>Parser</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>Parser</em>()</div>
 
 <p>Each method for parsing a grammar rule produces a syntax tree for that rule and
 returns it to the caller. When the body of the rule contains a nonterminal<span class="em">&mdash;</span>a
@@ -465,7 +465,7 @@ and so on, until the parser hits a stack overflow and dies.</p>
 <div class="codehilite"><pre><span class="i">equality</span>       → <span class="i">comparison</span> ( ( <span class="s">&quot;!=&quot;</span> | <span class="s">&quot;==&quot;</span> ) <span class="i">comparison</span> )* ;
 </pre></div>
 <p>In Java, that becomes:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>expression</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">equality</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">comparison</span>();
@@ -479,7 +479,7 @@ add after <em>expression</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>expression</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>expression</em>()</div>
 
 <p>Let&rsquo;s step through it. The first <code>comparison</code> nonterminal in the body translates
 to the first call to <code>comparison()</code> in the method. We take that result and store
@@ -489,7 +489,7 @@ when to exit that loop. We can see that inside the rule, we must first find
 either a <code>!=</code> or <code>==</code> token. So, if we <em>don&rsquo;t</em> see one of those, we must be done
 with the sequence of equality operators. We express that check using a handy
 <code>match()</code> method.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>equality</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">match</span>(<span class="t">TokenType</span>... <span class="i">types</span>) {
     <span class="k">for</span> (<span class="t">TokenType</span> <span class="i">type</span> : <span class="i">types</span>) {
@@ -502,7 +502,7 @@ add after <em>equality</em>()</div>
     <span class="k">return</span> <span class="k">false</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>equality</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>equality</em>()</div>
 
 <p>This checks to see if the current token has any of the given types. If so, it
 consumes the token and returns <code>true</code>. Otherwise, it returns <code>false</code> and leaves
@@ -510,28 +510,28 @@ the current token alone. The <code>match()</code> method is defined in terms of 
 fundamental operations.</p>
 <p>The <code>check()</code> method returns <code>true</code> if the current token is of the given type.
 Unlike <code>match()</code>, it never consumes the token, it only looks at it.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>match</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">check</span>(<span class="t">TokenType</span> <span class="i">type</span>) {
     <span class="k">if</span> (<span class="i">isAtEnd</span>()) <span class="k">return</span> <span class="k">false</span>;
     <span class="k">return</span> <span class="i">peek</span>().<span class="i">type</span> == <span class="i">type</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>match</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>match</em>()</div>
 
 <p>The <code>advance()</code> method consumes the current token and returns it, similar to how
 our scanner&rsquo;s corresponding method crawled through characters.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>check</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Token</span> <span class="i">advance</span>() {
     <span class="k">if</span> (!<span class="i">isAtEnd</span>()) <span class="i">current</span>++;
     <span class="k">return</span> <span class="i">previous</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>check</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>check</em>()</div>
 
 <p>These methods bottom out on the last handful of primitive operations.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>advance</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isAtEnd</span>() {
     <span class="k">return</span> <span class="i">peek</span>().<span class="i">type</span> == <span class="i">EOF</span>;
@@ -545,7 +545,7 @@ add after <em>advance</em>()</div>
     <span class="k">return</span> <span class="i">tokens</span>.<span class="i">get</span>(<span class="i">current</span> - <span class="n">1</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>advance</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>advance</em>()</div>
 
 <p><code>isAtEnd()</code> checks if we&rsquo;ve run out of tokens to parse. <code>peek()</code> returns the
 current token we have yet to consume, and <code>previous()</code> returns the most recently
@@ -576,7 +576,7 @@ precedence</em>.</p>
 <div class="codehilite"><pre><span class="i">comparison</span>     → <span class="i">term</span> ( ( <span class="s">&quot;&gt;&quot;</span> | <span class="s">&quot;&gt;=&quot;</span> | <span class="s">&quot;&lt;&quot;</span> | <span class="s">&quot;&lt;=&quot;</span> ) <span class="i">term</span> )* ;
 </pre></div>
 <p>Translated to Java:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>equality</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">comparison</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">term</span>();
@@ -590,7 +590,7 @@ add after <em>equality</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>equality</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>equality</em>()</div>
 
 <p>The grammar rule is virtually <span name="handle">identical</span> to <code>equality</code>
 and so is the corresponding code. The only differences are the token types for
@@ -603,7 +603,7 @@ follow the same pattern.</p>
 parsing a left-associative series of binary operators given a list of token
 types, and an operand method handle to simplify this redundant code.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>comparison</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">term</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">factor</span>();
@@ -617,10 +617,10 @@ add after <em>comparison</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>comparison</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>comparison</em>()</div>
 
 <p>And finally, multiplication and division:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>term</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">factor</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">unary</span>();
@@ -634,7 +634,7 @@ add after <em>term</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>term</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>term</em>()</div>
 
 <p>That&rsquo;s all of the binary operators, parsed with the correct precedence and
 associativity. We&rsquo;re crawling up the precedence hierarchy and now we&rsquo;ve reached
@@ -643,7 +643,7 @@ the unary operators.</p>
                | <span class="i">primary</span> ;
 </pre></div>
 <p>The code for this is a little different.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>factor</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">unary</span>() {
     <span class="k">if</span> (<span class="i">match</span>(<span class="i">BANG</span>, <span class="i">MINUS</span>)) {
@@ -655,7 +655,7 @@ add after <em>factor</em>()</div>
     <span class="k">return</span> <span class="i">primary</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>factor</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>factor</em>()</div>
 
 <p>Again, we look at the <span name="current">current</span> token to see how to
 parse. If it&rsquo;s a <code>!</code> or <code>-</code>, we must have a unary expression. In that case, we
@@ -672,7 +672,7 @@ expressions.</p>
 </pre></div>
 <p>Most of the cases for the rule are single terminals, so parsing is
 straightforward.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>unary</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">primary</span>() {
     <span class="k">if</span> (<span class="i">match</span>(<span class="i">FALSE</span>)) <span class="k">return</span> <span class="k">new</span> <span class="t">Expr</span>.<span class="t">Literal</span>(<span class="k">false</span>);
@@ -690,7 +690,7 @@ add after <em>unary</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>unary</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>unary</em>()</div>
 
 <p>The interesting branch is the one for handling parentheses. After we match an
 opening <code>(</code> and parse the expression inside it, we <em>must</em> find a <code>)</code> token. If
@@ -805,7 +805,7 @@ we&rsquo;ll get the machinery in place for later.</p>
 code to parse a parenthesized expression. After parsing the expression, the
 parser looks for the closing <code>)</code> by calling <code>consume()</code>. Here, finally, is that
 method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>match</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Token</span> <span class="i">consume</span>(<span class="t">TokenType</span> <span class="i">type</span>, <span class="t">String</span> <span class="i">message</span>) {
     <span class="k">if</span> (<span class="i">check</span>(<span class="i">type</span>)) <span class="k">return</span> <span class="i">advance</span>();
@@ -813,22 +813,22 @@ add after <em>match</em>()</div>
     <span class="k">throw</span> <span class="i">error</span>(<span class="i">peek</span>(), <span class="i">message</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>match</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>match</em>()</div>
 
 <p>It&rsquo;s similar to <code>match()</code> in that it checks to see if the next token is of the
 expected type. If so, it consumes the token and everything is groovy. If some
 other token is there, then we&rsquo;ve hit an error. We report it by calling this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>previous</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">ParseError</span> <span class="i">error</span>(<span class="t">Token</span> <span class="i">token</span>, <span class="t">String</span> <span class="i">message</span>) {
     <span class="t">Lox</span>.<span class="i">error</span>(<span class="i">token</span>, <span class="i">message</span>);
     <span class="k">return</span> <span class="k">new</span> <span class="t">ParseError</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>previous</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>previous</em>()</div>
 
 <p>First, that shows the error to the user by calling:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 add after <em>report</em>()</div>
 <pre>  <span class="k">static</span> <span class="t">void</span> <span class="i">error</span>(<span class="t">Token</span> <span class="i">token</span>, <span class="t">String</span> <span class="i">message</span>) {
     <span class="k">if</span> (<span class="i">token</span>.<span class="i">type</span> == <span class="t">TokenType</span>.<span class="i">EOF</span>) {
@@ -838,7 +838,7 @@ add after <em>report</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, add after <em>report</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, add after <em>report</em>()</div>
 
 <p>This reports an error at a given token. It shows the token&rsquo;s location and the
 token itself. This will come in handy later since we use tokens throughout the
@@ -847,13 +847,13 @@ interpreter to track locations in code.</p>
 <em>parser</em> do next? Back in <code>error()</code>, we create and return a ParseError, an
 instance of this new class:</p>
 <div class="codehilite"><pre class="insert-before">class Parser {
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 nest inside class <em>Parser</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">static</span> <span class="k">class</span> <span class="t">ParseError</span> <span class="k">extends</span> <span class="t">RuntimeException</span> {}
 
 </pre><pre class="insert-after">  private final List&lt;Token&gt; tokens;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, nest inside class <em>Parser</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, nest inside class <em>Parser</em></div>
 
 <p>This is a simple sentinel class we use to unwind the parser. The <code>error()</code>
 method <em>returns</em> the error instead of <em>throwing</em> it because we want to let the
@@ -910,7 +910,7 @@ loop. Our synchronization isn&rsquo;t perfect, but that&rsquo;s OK. We&rsquo;ve 
 the first error precisely, so everything after that is kind of &ldquo;best effort&rdquo;.</p>
 </aside>
 <p>This method encapsulates that logic:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>error</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">synchronize</span>() {
     <span class="i">advance</span>();
@@ -934,7 +934,7 @@ add after <em>error</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>error</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>error</em>()</div>
 
 <p>It discards tokens until it thinks it has found a statement boundary. After
 catching a ParseError, we&rsquo;ll call this and then we are hopefully back in sync.
@@ -956,18 +956,18 @@ expression. We need to handle that error too.</p>
       consume(RIGHT_PAREN, &quot;Expect ')' after expression.&quot;);
       return new Expr.Grouping(expr);
     }
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>primary</em>()</div>
 <pre class="insert">
 
     <span class="k">throw</span> <span class="i">error</span>(<span class="i">peek</span>(), <span class="s">&quot;Expect expression.&quot;</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>primary</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>primary</em>()</div>
 
 <p>With that, all that remains in the parser is to define an initial method to kick
 it off. That method is called, naturally enough, <code>parse()</code>.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>Parser</em>()</div>
 <pre>  <span class="t">Expr</span> <span class="i">parse</span>() {
     <span class="k">try</span> {
@@ -977,7 +977,7 @@ add after <em>Parser</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>Parser</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>Parser</em>()</div>
 
 <p>We&rsquo;ll revisit this method later when we add statements to the language. For now,
 it parses a single expression and returns it. We also have some temporary code
@@ -993,7 +993,7 @@ tree and then use the AstPrinter class from the <a href="representing-code.html#
 display it.</p>
 <p>Delete the old code to print the scanned tokens and replace it with this:</p>
 <div class="codehilite"><pre class="insert-before">    List&lt;Token&gt; tokens = scanner.scanTokens();
-</pre><div class="source-file"><em>lox/Lox.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 in <em>run</em>()<br>
 replace 5 lines</div>
 <pre class="insert">    <span class="t">Parser</span> <span class="i">parser</span> = <span class="k">new</span> <span class="t">Parser</span>(<span class="i">tokens</span>);
@@ -1005,7 +1005,7 @@ replace 5 lines</div>
     <span class="t">System</span>.<span class="i">out</span>.<span class="i">println</span>(<span class="k">new</span> <span class="t">AstPrinter</span>().<span class="i">print</span>(<span class="i">expression</span>));
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>run</em>(), replace 5 lines</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>run</em>(), replace 5 lines</div>
 
 <p>Congratulations, you have crossed the <span name="harder">threshold</span>! That
 really is all there is to handwriting a parser. We&rsquo;ll extend the grammar in

--- a/site/parsing-expressions.html
+++ b/site/parsing-expressions.html
@@ -419,7 +419,7 @@ itself<span class="em">&mdash;</span>directly or indirectly<span class="em">&mda
 call.</p>
 <h3><a href="#the-parser-class" id="the-parser-class"><small>6&#8202;.&#8202;2&#8202;.&#8202;1</small>The parser class</a></h3>
 <p>Each grammar rule becomes a method inside this new class:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -436,7 +436,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, create new file</div>
 
 <p>Like the scanner, the parser consumes a flat input sequence, only now we&rsquo;re
 reading tokens instead of characters. We store the list of tokens and use
@@ -444,13 +444,13 @@ reading tokens instead of characters. We store the list of tokens and use
 <p>We&rsquo;re going to run straight through the expression grammar now and translate
 each rule to Java code. The first rule, <code>expression</code>, simply expands to the
 <code>equality</code> rule, so that&rsquo;s straightforward.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>Parser</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">expression</span>() {
     <span class="k">return</span> <span class="i">equality</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>Parser</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>Parser</em>()</div>
 
 <p>Each method for parsing a grammar rule produces a syntax tree for that rule and
 returns it to the caller. When the body of the rule contains a nonterminal<span class="em">&mdash;</span>a
@@ -465,7 +465,7 @@ and so on, until the parser hits a stack overflow and dies.</p>
 <div class="codehilite"><pre><span class="i">equality</span>       → <span class="i">comparison</span> ( ( <span class="s">&quot;!=&quot;</span> | <span class="s">&quot;==&quot;</span> ) <span class="i">comparison</span> )* ;
 </pre></div>
 <p>In Java, that becomes:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>expression</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">equality</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">comparison</span>();
@@ -479,7 +479,7 @@ add after <em>expression</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>expression</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>expression</em>()</div>
 
 <p>Let&rsquo;s step through it. The first <code>comparison</code> nonterminal in the body translates
 to the first call to <code>comparison()</code> in the method. We take that result and store
@@ -489,7 +489,7 @@ when to exit that loop. We can see that inside the rule, we must first find
 either a <code>!=</code> or <code>==</code> token. So, if we <em>don&rsquo;t</em> see one of those, we must be done
 with the sequence of equality operators. We express that check using a handy
 <code>match()</code> method.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>equality</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">match</span>(<span class="t">TokenType</span>... <span class="i">types</span>) {
     <span class="k">for</span> (<span class="t">TokenType</span> <span class="i">type</span> : <span class="i">types</span>) {
@@ -502,7 +502,7 @@ add after <em>equality</em>()</div>
     <span class="k">return</span> <span class="k">false</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>equality</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>equality</em>()</div>
 
 <p>This checks to see if the current token has any of the given types. If so, it
 consumes the token and returns <code>true</code>. Otherwise, it returns <code>false</code> and leaves
@@ -510,28 +510,28 @@ the current token alone. The <code>match()</code> method is defined in terms of 
 fundamental operations.</p>
 <p>The <code>check()</code> method returns <code>true</code> if the current token is of the given type.
 Unlike <code>match()</code>, it never consumes the token, it only looks at it.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>match</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">check</span>(<span class="t">TokenType</span> <span class="i">type</span>) {
     <span class="k">if</span> (<span class="i">isAtEnd</span>()) <span class="k">return</span> <span class="k">false</span>;
     <span class="k">return</span> <span class="i">peek</span>().<span class="i">type</span> == <span class="i">type</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>match</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>match</em>()</div>
 
 <p>The <code>advance()</code> method consumes the current token and returns it, similar to how
 our scanner&rsquo;s corresponding method crawled through characters.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>check</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Token</span> <span class="i">advance</span>() {
     <span class="k">if</span> (!<span class="i">isAtEnd</span>()) <span class="i">current</span>++;
     <span class="k">return</span> <span class="i">previous</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>check</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>check</em>()</div>
 
 <p>These methods bottom out on the last handful of primitive operations.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>advance</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isAtEnd</span>() {
     <span class="k">return</span> <span class="i">peek</span>().<span class="i">type</span> == <span class="i">EOF</span>;
@@ -545,7 +545,7 @@ add after <em>advance</em>()</div>
     <span class="k">return</span> <span class="i">tokens</span>.<span class="i">get</span>(<span class="i">current</span> - <span class="n">1</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>advance</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>advance</em>()</div>
 
 <p><code>isAtEnd()</code> checks if we&rsquo;ve run out of tokens to parse. <code>peek()</code> returns the
 current token we have yet to consume, and <code>previous()</code> returns the most recently
@@ -576,7 +576,7 @@ precedence</em>.</p>
 <div class="codehilite"><pre><span class="i">comparison</span>     → <span class="i">term</span> ( ( <span class="s">&quot;&gt;&quot;</span> | <span class="s">&quot;&gt;=&quot;</span> | <span class="s">&quot;&lt;&quot;</span> | <span class="s">&quot;&lt;=&quot;</span> ) <span class="i">term</span> )* ;
 </pre></div>
 <p>Translated to Java:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>equality</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">comparison</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">term</span>();
@@ -590,7 +590,7 @@ add after <em>equality</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>equality</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>equality</em>()</div>
 
 <p>The grammar rule is virtually <span name="handle">identical</span> to <code>equality</code>
 and so is the corresponding code. The only differences are the token types for
@@ -603,7 +603,7 @@ follow the same pattern.</p>
 parsing a left-associative series of binary operators given a list of token
 types, and an operand method handle to simplify this redundant code.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>comparison</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">term</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">factor</span>();
@@ -617,10 +617,10 @@ add after <em>comparison</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>comparison</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>comparison</em>()</div>
 
 <p>And finally, multiplication and division:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>term</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">factor</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">unary</span>();
@@ -634,7 +634,7 @@ add after <em>term</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>term</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>term</em>()</div>
 
 <p>That&rsquo;s all of the binary operators, parsed with the correct precedence and
 associativity. We&rsquo;re crawling up the precedence hierarchy and now we&rsquo;ve reached
@@ -643,7 +643,7 @@ the unary operators.</p>
                | <span class="i">primary</span> ;
 </pre></div>
 <p>The code for this is a little different.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>factor</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">unary</span>() {
     <span class="k">if</span> (<span class="i">match</span>(<span class="i">BANG</span>, <span class="i">MINUS</span>)) {
@@ -655,7 +655,7 @@ add after <em>factor</em>()</div>
     <span class="k">return</span> <span class="i">primary</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>factor</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>factor</em>()</div>
 
 <p>Again, we look at the <span name="current">current</span> token to see how to
 parse. If it&rsquo;s a <code>!</code> or <code>-</code>, we must have a unary expression. In that case, we
@@ -672,7 +672,7 @@ expressions.</p>
 </pre></div>
 <p>Most of the cases for the rule are single terminals, so parsing is
 straightforward.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>unary</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">primary</span>() {
     <span class="k">if</span> (<span class="i">match</span>(<span class="i">FALSE</span>)) <span class="k">return</span> <span class="k">new</span> <span class="t">Expr</span>.<span class="t">Literal</span>(<span class="k">false</span>);
@@ -690,7 +690,7 @@ add after <em>unary</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>unary</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>unary</em>()</div>
 
 <p>The interesting branch is the one for handling parentheses. After we match an
 opening <code>(</code> and parse the expression inside it, we <em>must</em> find a <code>)</code> token. If
@@ -805,7 +805,7 @@ we&rsquo;ll get the machinery in place for later.</p>
 code to parse a parenthesized expression. After parsing the expression, the
 parser looks for the closing <code>)</code> by calling <code>consume()</code>. Here, finally, is that
 method:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>match</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Token</span> <span class="i">consume</span>(<span class="t">TokenType</span> <span class="i">type</span>, <span class="t">String</span> <span class="i">message</span>) {
     <span class="k">if</span> (<span class="i">check</span>(<span class="i">type</span>)) <span class="k">return</span> <span class="i">advance</span>();
@@ -813,22 +813,22 @@ add after <em>match</em>()</div>
     <span class="k">throw</span> <span class="i">error</span>(<span class="i">peek</span>(), <span class="i">message</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>match</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>match</em>()</div>
 
 <p>It&rsquo;s similar to <code>match()</code> in that it checks to see if the next token is of the
 expected type. If so, it consumes the token and everything is groovy. If some
 other token is there, then we&rsquo;ve hit an error. We report it by calling this:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>previous</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">ParseError</span> <span class="i">error</span>(<span class="t">Token</span> <span class="i">token</span>, <span class="t">String</span> <span class="i">message</span>) {
     <span class="t">Lox</span>.<span class="i">error</span>(<span class="i">token</span>, <span class="i">message</span>);
     <span class="k">return</span> <span class="k">new</span> <span class="t">ParseError</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>previous</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>previous</em>()</div>
 
 <p>First, that shows the error to the user by calling:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
 add after <em>report</em>()</div>
 <pre>  <span class="k">static</span> <span class="t">void</span> <span class="i">error</span>(<span class="t">Token</span> <span class="i">token</span>, <span class="t">String</span> <span class="i">message</span>) {
     <span class="k">if</span> (<span class="i">token</span>.<span class="i">type</span> == <span class="t">TokenType</span>.<span class="i">EOF</span>) {
@@ -838,7 +838,7 @@ add after <em>report</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, add after <em>report</em>()</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, add after <em>report</em>()</div>
 
 <p>This reports an error at a given token. It shows the token&rsquo;s location and the
 token itself. This will come in handy later since we use tokens throughout the
@@ -847,13 +847,13 @@ interpreter to track locations in code.</p>
 <em>parser</em> do next? Back in <code>error()</code>, we create and return a ParseError, an
 instance of this new class:</p>
 <div class="codehilite"><pre class="insert-before">class Parser {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 nest inside class <em>Parser</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">static</span> <span class="k">class</span> <span class="t">ParseError</span> <span class="k">extends</span> <span class="t">RuntimeException</span> {}
 
 </pre><pre class="insert-after">  private final List&lt;Token&gt; tokens;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, nest inside class <em>Parser</em></div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, nest inside class <em>Parser</em></div>
 
 <p>This is a simple sentinel class we use to unwind the parser. The <code>error()</code>
 method <em>returns</em> the error instead of <em>throwing</em> it because we want to let the
@@ -910,7 +910,7 @@ loop. Our synchronization isn&rsquo;t perfect, but that&rsquo;s OK. We&rsquo;ve 
 the first error precisely, so everything after that is kind of &ldquo;best effort&rdquo;.</p>
 </aside>
 <p>This method encapsulates that logic:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>error</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">synchronize</span>() {
     <span class="i">advance</span>();
@@ -934,7 +934,7 @@ add after <em>error</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>error</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>error</em>()</div>
 
 <p>It discards tokens until it thinks it has found a statement boundary. After
 catching a ParseError, we&rsquo;ll call this and then we are hopefully back in sync.
@@ -956,18 +956,18 @@ expression. We need to handle that error too.</p>
       consume(RIGHT_PAREN, &quot;Expect ')' after expression.&quot;);
       return new Expr.Grouping(expr);
     }
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>primary</em>()</div>
 <pre class="insert">
 
     <span class="k">throw</span> <span class="i">error</span>(<span class="i">peek</span>(), <span class="s">&quot;Expect expression.&quot;</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>primary</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>primary</em>()</div>
 
 <p>With that, all that remains in the parser is to define an initial method to kick
 it off. That method is called, naturally enough, <code>parse()</code>.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>Parser</em>()</div>
 <pre>  <span class="t">Expr</span> <span class="i">parse</span>() {
     <span class="k">try</span> {
@@ -977,7 +977,7 @@ add after <em>Parser</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>Parser</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>Parser</em>()</div>
 
 <p>We&rsquo;ll revisit this method later when we add statements to the language. For now,
 it parses a single expression and returns it. We also have some temporary code
@@ -993,7 +993,7 @@ tree and then use the AstPrinter class from the <a href="representing-code.html#
 display it.</p>
 <p>Delete the old code to print the scanned tokens and replace it with this:</p>
 <div class="codehilite"><pre class="insert-before">    List&lt;Token&gt; tokens = scanner.scanTokens();
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+</pre><div class="source-file"><em>lox/Lox.java</em><br>
 in <em>run</em>()<br>
 replace 5 lines</div>
 <pre class="insert">    <span class="t">Parser</span> <span class="i">parser</span> = <span class="k">new</span> <span class="t">Parser</span>(<span class="i">tokens</span>);
@@ -1005,7 +1005,7 @@ replace 5 lines</div>
     <span class="t">System</span>.<span class="i">out</span>.<span class="i">println</span>(<span class="k">new</span> <span class="t">AstPrinter</span>().<span class="i">print</span>(<span class="i">expression</span>));
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>run</em>(), replace 5 lines</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>run</em>(), replace 5 lines</div>
 
 <p>Congratulations, you have crossed the <span name="harder">threshold</span>! That
 really is all there is to handwriting a parser. We&rsquo;ll extend the grammar in

--- a/site/representing-code.html
+++ b/site/representing-code.html
@@ -544,7 +544,7 @@ Jython and IronPython.</p>
 <p>An actual scripting language would be a better fit for this than Java, but I&rsquo;m
 trying not to throw too many languages at you.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>tool/GenerateAst.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.tool</span>;
 
@@ -563,7 +563,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, create new file</div>
 
 <p>Note that this file is in a different package, <code>.tool</code> instead of <code>.lox</code>. This
 script isn&rsquo;t part of the interpreter itself. It&rsquo;s a tool <em>we</em>, the people
@@ -573,7 +573,7 @@ We are merely automating how that file gets authored.</p>
 <p>To generate the classes, it needs to have some description of each type and its
 fields.</p>
 <div class="codehilite"><pre class="insert-before">    String outputDir = args[0];
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">    <span class="i">defineAst</span>(<span class="i">outputDir</span>, <span class="s">&quot;Expr&quot;</span>, <span class="t">Arrays</span>.<span class="i">asList</span>(
       <span class="s">&quot;Binary   : Expr left, Token operator, Expr right&quot;</span>,
@@ -583,13 +583,13 @@ in <em>main</em>()</div>
     ));
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
 
 <p>For brevity&rsquo;s sake, I jammed the descriptions of the expression types into
 strings. Each is the name of the class followed by <code>:</code> and the list of fields,
 separated by commas. Each field has a type and a name.</p>
 <p>The first thing <code>defineAst()</code> needs to do is output the base Expr class.</p>
-<div class="codehilite"><div class="source-file"><em>tool/GenerateAst.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 add after <em>main</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">defineAst</span>(
       <span class="t">String</span> <span class="i">outputDir</span>, <span class="t">String</span> <span class="i">baseName</span>, <span class="t">List</span>&lt;<span class="t">String</span>&gt; <span class="i">types</span>)
@@ -607,7 +607,7 @@ add after <em>main</em>()</div>
     <span class="i">writer</span>.<span class="i">close</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, add after <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, add after <em>main</em>()</div>
 
 <p>When we call this, <code>baseName</code> is &ldquo;Expr&rdquo;, which is both the name of the class and
 the name of the file it outputs. We pass this as an argument instead of
@@ -616,7 +616,7 @@ statements.</p>
 <p>Inside the base class, we define each subclass.</p>
 <div class="codehilite"><pre class="insert-before">    writer.println(&quot;abstract class &quot; + baseName + &quot; {&quot;);
 
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>defineAst</em>()</div>
 <pre class="insert">    <span class="c">// The AST classes.</span>
     <span class="k">for</span> (<span class="t">String</span> <span class="i">type</span> : <span class="i">types</span>) {
@@ -626,7 +626,7 @@ in <em>defineAst</em>()</div>
     }
 </pre><pre class="insert-after">    writer.println(&quot;}&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>defineAst</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>defineAst</em>()</div>
 
 <aside name="robust">
 <p>This isn&rsquo;t the world&rsquo;s most elegant string manipulation code, but that&rsquo;s fine.
@@ -634,7 +634,7 @@ It only runs on the exact set of class definitions we give it. Robustness ain&rs
 a priority.</p>
 </aside>
 <p>That code, in turn, calls:</p>
-<div class="codehilite"><div class="source-file"><em>tool/GenerateAst.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 add after <em>defineAst</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">defineType</span>(
       <span class="t">PrintWriter</span> <span class="i">writer</span>, <span class="t">String</span> <span class="i">baseName</span>,
@@ -663,7 +663,7 @@ add after <em>defineAst</em>()</div>
     <span class="i">writer</span>.<span class="i">println</span>(<span class="s">&quot;  }&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, add after <em>defineAst</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, add after <em>defineAst</em>()</div>
 
 <p>There we go. All of that glorious Java boilerplate is done. It declares each
 field in the class body. It defines a constructor for the class with parameters
@@ -876,16 +876,16 @@ book don&rsquo;t need that, so I omitted it.</p>
 so that we can keep everything in one file.</p>
 <div class="codehilite"><pre class="insert-before">    writer.println(&quot;abstract class &quot; + baseName + &quot; {&quot;);
 
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>defineAst</em>()</div>
 <pre class="insert">    <span class="i">defineVisitor</span>(<span class="i">writer</span>, <span class="i">baseName</span>, <span class="i">types</span>);
 
 </pre><pre class="insert-after">    // The AST classes.
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>defineAst</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>defineAst</em>()</div>
 
 <p>That function generates the visitor interface.</p>
-<div class="codehilite"><div class="source-file"><em>tool/GenerateAst.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 add after <em>defineAst</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">defineVisitor</span>(
       <span class="t">PrintWriter</span> <span class="i">writer</span>, <span class="t">String</span> <span class="i">baseName</span>, <span class="t">List</span>&lt;<span class="t">String</span>&gt; <span class="i">types</span>) {
@@ -900,7 +900,7 @@ add after <em>defineAst</em>()</div>
     <span class="i">writer</span>.<span class="i">println</span>(<span class="s">&quot;  }&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, add after <em>defineAst</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, add after <em>defineAst</em>()</div>
 
 <p>Here, we iterate through all of the subclasses and declare a visit method for
 each one. When we define new expression types later, this will automatically
@@ -908,7 +908,7 @@ include them.</p>
 <p>Inside the base class, we define the abstract <code>accept()</code> method.</p>
 <div class="codehilite"><pre class="insert-before">      defineType(writer, baseName, className, fields);
     }
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>defineAst</em>()</div>
 <pre class="insert">
 
@@ -918,12 +918,12 @@ in <em>defineAst</em>()</div>
 
 </pre><pre class="insert-after">    writer.println(&quot;}&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>defineAst</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>defineAst</em>()</div>
 
 <p>Finally, each subclass implements that and calls the right visit method for its
 own type.</p>
 <div class="codehilite"><pre class="insert-before">    writer.println(&quot;    }&quot;);
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>defineType</em>()</div>
 <pre class="insert">
 
@@ -938,7 +938,7 @@ in <em>defineType</em>()</div>
 
     // Fields.
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>defineType</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>defineType</em>()</div>
 
 <p>There we go. Now we can define operations on expressions without having to muck
 with the classes or our generator script. Compile and run this generator script
@@ -968,7 +968,7 @@ parenthesized, and all of its subexpressions and tokens are contained in that.</
 </pre></div>
 <p>Not exactly &ldquo;pretty&rdquo;, but it does show the nesting and grouping explicitly. To
 implement this, we define a new class.</p>
-<div class="codehilite"><div class="source-file"><em>lox/AstPrinter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\AstPrinter.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -978,13 +978,13 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/AstPrinter.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\AstPrinter.java</em>, create new file</div>
 
 <p>As you can see, it implements the visitor interface. That means we need visit
 methods for each of the expression types we have so far.</p>
 <div class="codehilite"><pre class="insert-before">    return expr.accept(this);
   }
-</pre><div class="source-file"><em>lox/AstPrinter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\AstPrinter.java</em><br>
 add after <em>print</em>()</div>
 <pre class="insert">
 
@@ -1011,12 +1011,12 @@ add after <em>print</em>()</div>
   }
 </pre><pre class="insert-after">}
 </pre></div>
-<div class="source-file-narrow"><em>lox/AstPrinter.java</em>, add after <em>print</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\AstPrinter.java</em>, add after <em>print</em>()</div>
 
 <p>Literal expressions are easy<span class="em">&mdash;</span>they convert the value to a string with a little
 check to handle Java&rsquo;s <code>null</code> standing in for Lox&rsquo;s <code>nil</code>. The other expressions
 have subexpressions, so they use this <code>parenthesize()</code> helper method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/AstPrinter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\AstPrinter.java</em><br>
 add after <em>visitUnaryExpr</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">String</span> <span class="i">parenthesize</span>(<span class="t">String</span> <span class="i">name</span>, <span class="t">Expr</span>... <span class="i">exprs</span>) {
     <span class="t">StringBuilder</span> <span class="i">builder</span> = <span class="k">new</span> <span class="t">StringBuilder</span>();
@@ -1031,7 +1031,7 @@ add after <em>visitUnaryExpr</em>()</div>
     <span class="k">return</span> <span class="i">builder</span>.<span class="i">toString</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/AstPrinter.java</em>, add after <em>visitUnaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\AstPrinter.java</em>, add after <em>visitUnaryExpr</em>()</div>
 
 <p>It takes a name and a list of subexpressions and wraps them all up in
 parentheses, yielding a string like:</p>
@@ -1047,7 +1047,7 @@ with trees.</p>
 <p>We don&rsquo;t have a parser yet, so it&rsquo;s hard to see this in action. For now, we&rsquo;ll
 hack together a little <code>main()</code> method that manually instantiates a tree and
 prints it.</p>
-<div class="codehilite"><div class="source-file"><em>lox/AstPrinter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\AstPrinter.java</em><br>
 add after <em>parenthesize</em>()</div>
 <pre>  <span class="k">public</span> <span class="k">static</span> <span class="t">void</span> <span class="i">main</span>(<span class="t">String</span>[] <span class="i">args</span>) {
     <span class="t">Expr</span> <span class="i">expression</span> = <span class="k">new</span> <span class="t">Expr</span>.<span class="t">Binary</span>(
@@ -1061,7 +1061,7 @@ add after <em>parenthesize</em>()</div>
     <span class="t">System</span>.<span class="i">out</span>.<span class="i">println</span>(<span class="k">new</span> <span class="t">AstPrinter</span>().<span class="i">print</span>(<span class="i">expression</span>));
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/AstPrinter.java</em>, add after <em>parenthesize</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\AstPrinter.java</em>, add after <em>parenthesize</em>()</div>
 
 <p>If we did everything right, it prints:</p>
 <div class="codehilite"><pre>(* (- 123) (group 45.67))

--- a/site/representing-code.html
+++ b/site/representing-code.html
@@ -544,7 +544,7 @@ Jython and IronPython.</p>
 <p>An actual scripting language would be a better fit for this than Java, but I&rsquo;m
 trying not to throw too many languages at you.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+<div class="codehilite"><div class="source-file"><em>tool/GenerateAst.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.tool</span>;
 
@@ -563,7 +563,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, create new file</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, create new file</div>
 
 <p>Note that this file is in a different package, <code>.tool</code> instead of <code>.lox</code>. This
 script isn&rsquo;t part of the interpreter itself. It&rsquo;s a tool <em>we</em>, the people
@@ -573,7 +573,7 @@ We are merely automating how that file gets authored.</p>
 <p>To generate the classes, it needs to have some description of each type and its
 fields.</p>
 <div class="codehilite"><pre class="insert-before">    String outputDir = args[0];
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">    <span class="i">defineAst</span>(<span class="i">outputDir</span>, <span class="s">&quot;Expr&quot;</span>, <span class="t">Arrays</span>.<span class="i">asList</span>(
       <span class="s">&quot;Binary   : Expr left, Token operator, Expr right&quot;</span>,
@@ -583,13 +583,13 @@ in <em>main</em>()</div>
     ));
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
 
 <p>For brevity&rsquo;s sake, I jammed the descriptions of the expression types into
 strings. Each is the name of the class followed by <code>:</code> and the list of fields,
 separated by commas. Each field has a type and a name.</p>
 <p>The first thing <code>defineAst()</code> needs to do is output the base Expr class.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+<div class="codehilite"><div class="source-file"><em>tool/GenerateAst.java</em><br>
 add after <em>main</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">defineAst</span>(
       <span class="t">String</span> <span class="i">outputDir</span>, <span class="t">String</span> <span class="i">baseName</span>, <span class="t">List</span>&lt;<span class="t">String</span>&gt; <span class="i">types</span>)
@@ -607,7 +607,7 @@ add after <em>main</em>()</div>
     <span class="i">writer</span>.<span class="i">close</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, add after <em>main</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, add after <em>main</em>()</div>
 
 <p>When we call this, <code>baseName</code> is &ldquo;Expr&rdquo;, which is both the name of the class and
 the name of the file it outputs. We pass this as an argument instead of
@@ -616,7 +616,7 @@ statements.</p>
 <p>Inside the base class, we define each subclass.</p>
 <div class="codehilite"><pre class="insert-before">    writer.println(&quot;abstract class &quot; + baseName + &quot; {&quot;);
 
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>defineAst</em>()</div>
 <pre class="insert">    <span class="c">// The AST classes.</span>
     <span class="k">for</span> (<span class="t">String</span> <span class="i">type</span> : <span class="i">types</span>) {
@@ -626,7 +626,7 @@ in <em>defineAst</em>()</div>
     }
 </pre><pre class="insert-after">    writer.println(&quot;}&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>defineAst</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>defineAst</em>()</div>
 
 <aside name="robust">
 <p>This isn&rsquo;t the world&rsquo;s most elegant string manipulation code, but that&rsquo;s fine.
@@ -634,7 +634,7 @@ It only runs on the exact set of class definitions we give it. Robustness ain&rs
 a priority.</p>
 </aside>
 <p>That code, in turn, calls:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+<div class="codehilite"><div class="source-file"><em>tool/GenerateAst.java</em><br>
 add after <em>defineAst</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">defineType</span>(
       <span class="t">PrintWriter</span> <span class="i">writer</span>, <span class="t">String</span> <span class="i">baseName</span>,
@@ -663,7 +663,7 @@ add after <em>defineAst</em>()</div>
     <span class="i">writer</span>.<span class="i">println</span>(<span class="s">&quot;  }&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, add after <em>defineAst</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, add after <em>defineAst</em>()</div>
 
 <p>There we go. All of that glorious Java boilerplate is done. It declares each
 field in the class body. It defines a constructor for the class with parameters
@@ -876,16 +876,16 @@ book don&rsquo;t need that, so I omitted it.</p>
 so that we can keep everything in one file.</p>
 <div class="codehilite"><pre class="insert-before">    writer.println(&quot;abstract class &quot; + baseName + &quot; {&quot;);
 
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>defineAst</em>()</div>
 <pre class="insert">    <span class="i">defineVisitor</span>(<span class="i">writer</span>, <span class="i">baseName</span>, <span class="i">types</span>);
 
 </pre><pre class="insert-after">    // The AST classes.
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>defineAst</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>defineAst</em>()</div>
 
 <p>That function generates the visitor interface.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+<div class="codehilite"><div class="source-file"><em>tool/GenerateAst.java</em><br>
 add after <em>defineAst</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">defineVisitor</span>(
       <span class="t">PrintWriter</span> <span class="i">writer</span>, <span class="t">String</span> <span class="i">baseName</span>, <span class="t">List</span>&lt;<span class="t">String</span>&gt; <span class="i">types</span>) {
@@ -900,7 +900,7 @@ add after <em>defineAst</em>()</div>
     <span class="i">writer</span>.<span class="i">println</span>(<span class="s">&quot;  }&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, add after <em>defineAst</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, add after <em>defineAst</em>()</div>
 
 <p>Here, we iterate through all of the subclasses and declare a visit method for
 each one. When we define new expression types later, this will automatically
@@ -908,7 +908,7 @@ include them.</p>
 <p>Inside the base class, we define the abstract <code>accept()</code> method.</p>
 <div class="codehilite"><pre class="insert-before">      defineType(writer, baseName, className, fields);
     }
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>defineAst</em>()</div>
 <pre class="insert">
 
@@ -918,12 +918,12 @@ in <em>defineAst</em>()</div>
 
 </pre><pre class="insert-after">    writer.println(&quot;}&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>defineAst</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>defineAst</em>()</div>
 
 <p>Finally, each subclass implements that and calls the right visit method for its
 own type.</p>
 <div class="codehilite"><pre class="insert-before">    writer.println(&quot;    }&quot;);
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>defineType</em>()</div>
 <pre class="insert">
 
@@ -938,7 +938,7 @@ in <em>defineType</em>()</div>
 
     // Fields.
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>defineType</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>defineType</em>()</div>
 
 <p>There we go. Now we can define operations on expressions without having to muck
 with the classes or our generator script. Compile and run this generator script
@@ -968,7 +968,7 @@ parenthesized, and all of its subexpressions and tokens are contained in that.</
 </pre></div>
 <p>Not exactly &ldquo;pretty&rdquo;, but it does show the nesting and grouping explicitly. To
 implement this, we define a new class.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\AstPrinter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/AstPrinter.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -978,13 +978,13 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\AstPrinter.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/AstPrinter.java</em>, create new file</div>
 
 <p>As you can see, it implements the visitor interface. That means we need visit
 methods for each of the expression types we have so far.</p>
 <div class="codehilite"><pre class="insert-before">    return expr.accept(this);
   }
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\AstPrinter.java</em><br>
+</pre><div class="source-file"><em>lox/AstPrinter.java</em><br>
 add after <em>print</em>()</div>
 <pre class="insert">
 
@@ -1011,12 +1011,12 @@ add after <em>print</em>()</div>
   }
 </pre><pre class="insert-after">}
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\AstPrinter.java</em>, add after <em>print</em>()</div>
+<div class="source-file-narrow"><em>lox/AstPrinter.java</em>, add after <em>print</em>()</div>
 
 <p>Literal expressions are easy<span class="em">&mdash;</span>they convert the value to a string with a little
 check to handle Java&rsquo;s <code>null</code> standing in for Lox&rsquo;s <code>nil</code>. The other expressions
 have subexpressions, so they use this <code>parenthesize()</code> helper method:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\AstPrinter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/AstPrinter.java</em><br>
 add after <em>visitUnaryExpr</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">String</span> <span class="i">parenthesize</span>(<span class="t">String</span> <span class="i">name</span>, <span class="t">Expr</span>... <span class="i">exprs</span>) {
     <span class="t">StringBuilder</span> <span class="i">builder</span> = <span class="k">new</span> <span class="t">StringBuilder</span>();
@@ -1031,7 +1031,7 @@ add after <em>visitUnaryExpr</em>()</div>
     <span class="k">return</span> <span class="i">builder</span>.<span class="i">toString</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\AstPrinter.java</em>, add after <em>visitUnaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/AstPrinter.java</em>, add after <em>visitUnaryExpr</em>()</div>
 
 <p>It takes a name and a list of subexpressions and wraps them all up in
 parentheses, yielding a string like:</p>
@@ -1047,7 +1047,7 @@ with trees.</p>
 <p>We don&rsquo;t have a parser yet, so it&rsquo;s hard to see this in action. For now, we&rsquo;ll
 hack together a little <code>main()</code> method that manually instantiates a tree and
 prints it.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\AstPrinter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/AstPrinter.java</em><br>
 add after <em>parenthesize</em>()</div>
 <pre>  <span class="k">public</span> <span class="k">static</span> <span class="t">void</span> <span class="i">main</span>(<span class="t">String</span>[] <span class="i">args</span>) {
     <span class="t">Expr</span> <span class="i">expression</span> = <span class="k">new</span> <span class="t">Expr</span>.<span class="t">Binary</span>(
@@ -1061,7 +1061,7 @@ add after <em>parenthesize</em>()</div>
     <span class="t">System</span>.<span class="i">out</span>.<span class="i">println</span>(<span class="k">new</span> <span class="t">AstPrinter</span>().<span class="i">print</span>(<span class="i">expression</span>));
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\AstPrinter.java</em>, add after <em>parenthesize</em>()</div>
+<div class="source-file-narrow"><em>lox/AstPrinter.java</em>, add after <em>parenthesize</em>()</div>
 
 <p>If we did everything right, it prints:</p>
 <div class="codehilite"><pre>(* (- 123) (group 45.67))

--- a/site/resolving-and-binding.html
+++ b/site/resolving-and-binding.html
@@ -394,7 +394,7 @@ the user&rsquo;s program grows.</p>
 </aside>
 <h2><a href="#a-resolver-class" id="a-resolver-class"><small>11&#8202;.&#8202;3</small>A Resolver Class</a></h2>
 <p>Like everything in Java, our variable resolution pass is embodied in a class.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -411,7 +411,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, create new file</div>
 
 <p>Since the resolver needs to visit every node in the syntax tree, it implements
 the visitor abstraction we already have in place. Only a few kinds of nodes are
@@ -438,7 +438,7 @@ operands might.</p>
 <h3><a href="#resolving-blocks" id="resolving-blocks"><small>11&#8202;.&#8202;3&#8202;.&#8202;1</small>Resolving blocks</a></h3>
 <p>We start with blocks since they create the local scopes where all the magic
 happens.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>Resolver</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitBlockStmt</span>(<span class="t">Stmt</span>.<span class="t">Block</span> <span class="i">stmt</span>) {
@@ -448,12 +448,12 @@ add after <em>Resolver</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>Resolver</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>Resolver</em>()</div>
 
 <p>This begins a new scope, traverses into the statements inside the block, and
 then discards the scope. The fun stuff lives in those helper methods. We start
 with the simple one.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>Resolver</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">resolve</span>(<span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span>) {
     <span class="k">for</span> (<span class="t">Stmt</span> <span class="i">statement</span> : <span class="i">statements</span>) {
@@ -461,52 +461,52 @@ add after <em>Resolver</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>Resolver</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>Resolver</em>()</div>
 
 <p>This walks a list of statements and resolves each one. It in turn calls:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">resolve</span>(<span class="t">Stmt</span> <span class="i">stmt</span>) {
     <span class="i">stmt</span>.<span class="i">accept</span>(<span class="k">this</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
 
 <p>While we&rsquo;re at it, let&rsquo;s add another overload that we&rsquo;ll need later for
 resolving an expression.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>resolve</em>(Stmt stmt)</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">resolve</span>(<span class="t">Expr</span> <span class="i">expr</span>) {
     <span class="i">expr</span>.<span class="i">accept</span>(<span class="k">this</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>resolve</em>(Stmt stmt)</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>resolve</em>(Stmt stmt)</div>
 
 <p>These methods are similar to the <code>evaluate()</code> and <code>execute()</code> methods in
 Interpreter<span class="em">&mdash;</span>they turn around and apply the Visitor pattern to the given
 syntax tree node.</p>
 <p>The real interesting behavior is around scopes. A new block scope is created
 like so:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>resolve</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">beginScope</span>() {
     <span class="i">scopes</span>.<span class="i">push</span>(<span class="k">new</span> <span class="t">HashMap</span>&lt;<span class="t">String</span>, <span class="t">Boolean</span>&gt;());
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>resolve</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>resolve</em>()</div>
 
 <p>Lexical scopes nest in both the interpreter and the resolver. They behave like a
 stack. The interpreter implements that stack using a linked list<span class="em">&mdash;</span>the chain of
 Environment objects. In the resolver, we use an actual Java Stack.</p>
 <div class="codehilite"><pre class="insert-before">  private final Interpreter interpreter;
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in class <em>Resolver</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">Stack</span>&lt;<span class="t">Map</span>&lt;<span class="t">String</span>, <span class="t">Boolean</span>&gt;&gt; <span class="i">scopes</span> = <span class="k">new</span> <span class="t">Stack</span>&lt;&gt;();
 </pre><pre class="insert-after">
 
   Resolver(Interpreter interpreter) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in class <em>Resolver</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in class <em>Resolver</em></div>
 
 <p>This field keeps track of the stack of scopes currently, uh, in scope. Each
 element in the stack is a Map representing a single block scope. Keys, as in
@@ -517,19 +517,19 @@ top level in the global scope are not tracked by the resolver since they are
 more dynamic in Lox. When resolving a variable, if we can&rsquo;t find it in the stack
 of local scopes, we assume it must be global.</p>
 <p>Since scopes are stored in an explicit stack, exiting one is straightforward.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>beginScope</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">endScope</span>() {
     <span class="i">scopes</span>.<span class="i">pop</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>beginScope</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>beginScope</em>()</div>
 
 <p>Now we can push and pop a stack of empty scopes. Let&rsquo;s put some things in them.</p>
 <h3><a href="#resolving-variable-declarations" id="resolving-variable-declarations"><small>11&#8202;.&#8202;3&#8202;.&#8202;2</small>Resolving variable declarations</a></h3>
 <p>Resolving a variable declaration adds a new entry to the current innermost
 scope&rsquo;s map. That seems simple, but there&rsquo;s a little dance we need to do.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitVarStmt</span>(<span class="t">Stmt</span>.<span class="t">Var</span> <span class="i">stmt</span>) {
@@ -541,7 +541,7 @@ add after <em>visitBlockStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
 
 <p>We split binding into two steps, declaring then defining, in order to handle
 funny edge cases like this:</p>
@@ -590,7 +590,7 @@ way, the user is alerted to the problem before any code is run.</p>
 <p>In order to do that, as we visit expressions, we need to know if we&rsquo;re inside
 the initializer for some variable. We do that by splitting binding into two
 steps. The first is <strong>declaring</strong> it.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>endScope</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">declare</span>(<span class="t">Token</span> <span class="i">name</span>) {
     <span class="k">if</span> (<span class="i">scopes</span>.<span class="i">isEmpty</span>()) <span class="k">return</span>;
@@ -599,7 +599,7 @@ add after <em>endScope</em>()</div>
     <span class="i">scope</span>.<span class="i">put</span>(<span class="i">name</span>.<span class="i">lexeme</span>, <span class="k">false</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>endScope</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>endScope</em>()</div>
 
 <p>Declaration adds the variable to the innermost scope so that it shadows any
 outer one and so that we know the variable exists. We mark it as &ldquo;not ready yet&rdquo;
@@ -610,21 +610,21 @@ variable&rsquo;s initializer.</p>
 scope where the new variable now exists but is unavailable. Once the initializer
 expression is done, the variable is ready for prime time. We do that by
 <strong>defining</strong> it.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>declare</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">define</span>(<span class="t">Token</span> <span class="i">name</span>) {
     <span class="k">if</span> (<span class="i">scopes</span>.<span class="i">isEmpty</span>()) <span class="k">return</span>;
     <span class="i">scopes</span>.<span class="i">peek</span>().<span class="i">put</span>(<span class="i">name</span>.<span class="i">lexeme</span>, <span class="k">true</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>declare</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>declare</em>()</div>
 
 <p>We set the variable&rsquo;s value in the scope map to <code>true</code> to mark it as fully
 initialized and available for use. It&rsquo;s alive! </p>
 <h3><a href="#resolving-variable-expressions" id="resolving-variable-expressions"><small>11&#8202;.&#8202;3&#8202;.&#8202;3</small>Resolving variable expressions</a></h3>
 <p>Variable declarations<span class="em">&mdash;</span>and function declarations, which we&rsquo;ll get to<span class="em">&mdash;</span>write
 to the scope maps. Those maps are read when we resolve variable expressions.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitVarStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitVariableExpr</span>(<span class="t">Expr</span>.<span class="t">Variable</span> <span class="i">expr</span>) {
@@ -638,14 +638,14 @@ add after <em>visitVarStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitVarStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitVarStmt</em>()</div>
 
 <p>First, we check to see if the variable is being accessed inside its own
 initializer. This is where the values in the scope map come into play. If the
 variable exists in the current scope but its value is <code>false</code>, that means we
 have declared it but not yet defined it. We report that error.</p>
 <p>After that check, we actually resolve the variable itself using this helper:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>define</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">resolveLocal</span>(<span class="t">Expr</span> <span class="i">expr</span>, <span class="t">Token</span> <span class="i">name</span>) {
     <span class="k">for</span> (<span class="t">int</span> <span class="i">i</span> = <span class="i">scopes</span>.<span class="i">size</span>() - <span class="n">1</span>; <span class="i">i</span> &gt;= <span class="n">0</span>; <span class="i">i</span>--) {
@@ -656,7 +656,7 @@ add after <em>define</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>define</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>define</em>()</div>
 
 <p>This looks, for good reason, a lot like the code in Environment for evaluating a
 variable. We start at the innermost scope and work outwards, looking in each map
@@ -671,7 +671,7 @@ other syntax nodes.</p>
 <h3><a href="#resolving-assignment-expressions" id="resolving-assignment-expressions"><small>11&#8202;.&#8202;3&#8202;.&#8202;4</small>Resolving assignment expressions</a></h3>
 <p>The other expression that references a variable is assignment. Resolving one
 looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitVarStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitAssignExpr</span>(<span class="t">Expr</span>.<span class="t">Assign</span> <span class="i">expr</span>) {
@@ -680,7 +680,7 @@ add after <em>visitVarStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitVarStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitVarStmt</em>()</div>
 
 <p>First, we resolve the expression for the assigned value in case it also contains
 references to other variables. Then we use our existing <code>resolveLocal()</code> method
@@ -690,7 +690,7 @@ to resolve the variable that&rsquo;s being assigned to.</p>
 the function itself is bound in the surrounding scope where the function is
 declared. When we step into the function&rsquo;s body, we also bind its parameters
 into that inner function scope.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitFunctionStmt</span>(<span class="t">Stmt</span>.<span class="t">Function</span> <span class="i">stmt</span>) {
@@ -701,14 +701,14 @@ add after <em>visitBlockStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
 
 <p>Similar to <code>visitVariableStmt()</code>, we declare and define the name of the function
 in the current scope. Unlike variables, though, we define the name eagerly,
 before resolving the function&rsquo;s body. This lets a function recursively refer to
 itself inside its own body.</p>
 <p>Then we resolve the function&rsquo;s body using this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>resolve</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">resolveFunction</span>(<span class="t">Stmt</span>.<span class="t">Function</span> <span class="i">function</span>) {
     <span class="i">beginScope</span>();
@@ -720,7 +720,7 @@ add after <em>resolve</em>()</div>
     <span class="i">endScope</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>resolve</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>resolve</em>()</div>
 
 <p>It&rsquo;s a separate method since we will also use it for resolving Lox methods when
 we add classes later. It creates a new scope for the body and then binds
@@ -742,7 +742,7 @@ boring, but bear with me. We&rsquo;ll go kind of &ldquo;top down&rdquo; and star
 I didn&rsquo;t say they&rsquo;d all be exciting.</p>
 </aside>
 <p>An expression statement contains a single expression to traverse.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitExpressionStmt</span>(<span class="t">Stmt</span>.<span class="t">Expression</span> <span class="i">stmt</span>) {
@@ -750,11 +750,11 @@ add after <em>visitBlockStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
 
 <p>An if statement has an expression for its condition and one or two statements
 for the branches.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitFunctionStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitIfStmt</span>(<span class="t">Stmt</span>.<span class="t">If</span> <span class="i">stmt</span>) {
@@ -764,7 +764,7 @@ add after <em>visitFunctionStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitFunctionStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitFunctionStmt</em>()</div>
 
 <p>Here, we see how resolution is different from interpretation. When we resolve an
 <code>if</code> statement, there is no control flow. We resolve the condition and <em>both</em>
@@ -772,7 +772,7 @@ branches. Where a dynamic execution steps only into the branch that <em>is</em> 
 static analysis is conservative<span class="em">&mdash;</span>it analyzes any branch that <em>could</em> be run.
 Since either one could be reached at runtime, we resolve both.</p>
 <p>Like expression statements, a <code>print</code> statement contains a single subexpression.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitIfStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitPrintStmt</span>(<span class="t">Stmt</span>.<span class="t">Print</span> <span class="i">stmt</span>) {
@@ -780,10 +780,10 @@ add after <em>visitIfStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitIfStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitIfStmt</em>()</div>
 
 <p>Same deal for return.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitPrintStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitReturnStmt</span>(<span class="t">Stmt</span>.<span class="t">Return</span> <span class="i">stmt</span>) {
@@ -794,11 +794,11 @@ add after <em>visitPrintStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitPrintStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitPrintStmt</em>()</div>
 
 <p>As in <code>if</code> statements, with a <code>while</code> statement, we resolve its condition and
 resolve the body exactly once.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitVarStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitWhileStmt</span>(<span class="t">Stmt</span>.<span class="t">While</span> <span class="i">stmt</span>) {
@@ -807,12 +807,12 @@ add after <em>visitVarStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitVarStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitVarStmt</em>()</div>
 
 <p>That covers all the statements. On to expressions<span class="ellipse">&thinsp;.&thinsp;.&thinsp;.&nbsp;</span></p>
 <p>Our old friend the binary expression. We traverse into and resolve both
 operands.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitAssignExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitBinaryExpr</span>(<span class="t">Expr</span>.<span class="t">Binary</span> <span class="i">expr</span>) {
@@ -821,12 +821,12 @@ add after <em>visitAssignExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitAssignExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitAssignExpr</em>()</div>
 
 <p>Calls are similar<span class="em">&mdash;</span>we walk the argument list and resolve them all. The thing
 being called is also an expression (usually a variable expression), so that gets
 resolved too.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitBinaryExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitCallExpr</span>(<span class="t">Expr</span>.<span class="t">Call</span> <span class="i">expr</span>) {
@@ -839,10 +839,10 @@ add after <em>visitBinaryExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitBinaryExpr</em>()</div>
 
 <p>Parentheses are easy.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitCallExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitGroupingExpr</span>(<span class="t">Expr</span>.<span class="t">Grouping</span> <span class="i">expr</span>) {
@@ -850,23 +850,23 @@ add after <em>visitCallExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitCallExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitCallExpr</em>()</div>
 
 <p>Literals are easiest of all.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitGroupingExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitLiteralExpr</span>(<span class="t">Expr</span>.<span class="t">Literal</span> <span class="i">expr</span>) {
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitGroupingExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitGroupingExpr</em>()</div>
 
 <p>A literal expression doesn&rsquo;t mention any variables and doesn&rsquo;t contain any
 subexpressions so there is no work to do.</p>
 <p>Since a static analysis does no control flow or short-circuiting, logical
 expressions are exactly the same as other binary operators.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitLiteralExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitLogicalExpr</span>(<span class="t">Expr</span>.<span class="t">Logical</span> <span class="i">expr</span>) {
@@ -875,10 +875,10 @@ add after <em>visitLiteralExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitLiteralExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitLiteralExpr</em>()</div>
 
 <p>And, finally, the last node. We resolve its one operand.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>visitLogicalExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitUnaryExpr</span>(<span class="t">Expr</span>.<span class="t">Unary</span> <span class="i">expr</span>) {
@@ -886,7 +886,7 @@ add after <em>visitLogicalExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitLogicalExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitLogicalExpr</em>()</div>
 
 <p>With all of these visit methods, the Java compiler should be satisfied that
 Resolver fully implements Stmt.Visitor and Expr.Visitor. Now is a good time to
@@ -898,13 +898,13 @@ the scope where the variable is defined. At runtime, this corresponds exactly to
 the number of <em>environments</em> between the current one and the enclosing one where
 the interpreter can find the variable&rsquo;s value. The resolver hands that number to
 the interpreter by calling this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>execute</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">resolve</span>(<span class="t">Expr</span> <span class="i">expr</span>, <span class="t">int</span> <span class="i">depth</span>) {
     <span class="i">locals</span>.<span class="i">put</span>(<span class="i">expr</span>, <span class="i">depth</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>execute</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>execute</em>()</div>
 
 <p>We want to store the resolution information somewhere so we can use it when the
 variable or assignment expression is later executed, but where? One obvious
@@ -925,14 +925,14 @@ recalculating when they&rsquo;re hiding in the foliage of the syntax tree. A ben
 of storing this data outside of the nodes is that it makes it easy to <em>discard</em>
 it<span class="em">&mdash;</span>simply clear the map.</p>
 <div class="codehilite"><pre class="insert-before">  private Environment environment = globals;
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">Map</span>&lt;<span class="t">Expr</span>, <span class="t">Integer</span>&gt; <span class="i">locals</span> = <span class="k">new</span> <span class="t">HashMap</span>&lt;&gt;();
 </pre><pre class="insert-after">
 
   Interpreter() {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em></div>
 
 <p>You might think we&rsquo;d need some sort of nested tree structure to avoid getting
 confused when there are multiple expressions that reference the same variable,
@@ -940,37 +940,37 @@ but each expression node is its own Java object with its own unique identity. A
 single monolithic map doesn&rsquo;t have any trouble keeping them separated.</p>
 <p>As usual, using a collection requires us to import a couple of names.</p>
 <div class="codehilite"><pre class="insert-before">import java.util.ArrayList;
-</pre><div class="source-file"><em>lox/Interpreter.java</em></div>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
 <pre class="insert"><span class="k">import</span> <span class="i">java.util.HashMap</span>;
 </pre><pre class="insert-after">import java.util.List;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
 
 <p>And:</p>
 <div class="codehilite"><pre class="insert-before">import java.util.List;
-</pre><div class="source-file"><em>lox/Interpreter.java</em></div>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
 <pre class="insert"><span class="k">import</span> <span class="i">java.util.Map</span>;
 </pre><pre class="insert-after">
 
 class Interpreter implements Expr.Visitor&lt;Object&gt;,
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
 
 <h3><a href="#accessing-a-resolved-variable" id="accessing-a-resolved-variable"><small>11&#8202;.&#8202;4&#8202;.&#8202;1</small>Accessing a resolved variable</a></h3>
 <p>Our interpreter now has access to each variable&rsquo;s resolved location. Finally, we
 get to make use of that. We replace the visit method for variable expressions
 with this:</p>
 <div class="codehilite"><pre class="insert-before">  public Object visitVariableExpr(Expr.Variable expr) {
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitVariableExpr</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="k">return</span> <span class="i">lookUpVariable</span>(<span class="i">expr</span>.<span class="i">name</span>, <span class="i">expr</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitVariableExpr</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitVariableExpr</em>(), replace 1 line</div>
 
 <p>That delegates to:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitVariableExpr</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Object</span> <span class="i">lookUpVariable</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">Expr</span> <span class="i">expr</span>) {
     <span class="t">Integer</span> <span class="i">distance</span> = <span class="i">locals</span>.<span class="i">get</span>(<span class="i">expr</span>);
@@ -981,7 +981,7 @@ add after <em>visitVariableExpr</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitVariableExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitVariableExpr</em>()</div>
 
 <p>There are a couple of things going on here. First, we look up the resolved
 distance in the map. Remember that we resolved only <em>local</em> variables. Globals
@@ -992,19 +992,19 @@ runtime error if the variable isn&rsquo;t defined.</p>
 <p>If we <em>do</em> get a distance, we have a local variable, and we get to take
 advantage of the results of our static analysis. Instead of calling <code>get()</code>, we
 call this new method on Environment:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
 add after <em>define</em>()</div>
 <pre>  <span class="t">Object</span> <span class="i">getAt</span>(<span class="t">int</span> <span class="i">distance</span>, <span class="t">String</span> <span class="i">name</span>) {
     <span class="k">return</span> <span class="i">ancestor</span>(<span class="i">distance</span>).<span class="i">values</span>.<span class="i">get</span>(<span class="i">name</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Environment.java</em>, add after <em>define</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, add after <em>define</em>()</div>
 
 <p>The old <code>get()</code> method dynamically walks the chain of enclosing environments,
 scouring each one to see if the variable might be hiding in there somewhere. But
 now we know exactly which environment in the chain will have the variable. We
 reach it using this helper method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
 add after <em>define</em>()</div>
 <pre>  <span class="t">Environment</span> <span class="i">ancestor</span>(<span class="t">int</span> <span class="i">distance</span>) {
     <span class="t">Environment</span> <span class="i">environment</span> = <span class="k">this</span>;
@@ -1015,7 +1015,7 @@ add after <em>define</em>()</div>
     <span class="k">return</span> <span class="i">environment</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Environment.java</em>, add after <em>define</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, add after <em>define</em>()</div>
 
 <p>This walks a fixed number of hops up the parent chain and returns the
 environment there. Once we have that, <code>getAt()</code> simply returns the value of the
@@ -1040,7 +1040,7 @@ to have already upheld.</p>
 assignment expression are similar.</p>
 <div class="codehilite"><pre class="insert-before">  public Object visitAssignExpr(Expr.Assign expr) {
     Object value = evaluate(expr.value);
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in <em>visitAssignExpr</em>()<br>
 replace 1 line</div>
 <pre class="insert">
@@ -1054,17 +1054,17 @@ replace 1 line</div>
 
 </pre><pre class="insert-after">    return value;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitAssignExpr</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitAssignExpr</em>(), replace 1 line</div>
 
 <p>Again, we look up the variable&rsquo;s scope distance. If not found, we assume it&rsquo;s
 global and handle it the same way as before. Otherwise, we call this new method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
 add after <em>getAt</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">assignAt</span>(<span class="t">int</span> <span class="i">distance</span>, <span class="t">Token</span> <span class="i">name</span>, <span class="t">Object</span> <span class="i">value</span>) {
     <span class="i">ancestor</span>(<span class="i">distance</span>).<span class="i">values</span>.<span class="i">put</span>(<span class="i">name</span>.<span class="i">lexeme</span>, <span class="i">value</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Environment.java</em>, add after <em>getAt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, add after <em>getAt</em>()</div>
 
 <p>As <code>getAt()</code> is to <code>get()</code>, <code>assignAt()</code> is to <code>assign()</code>. It walks a fixed
 number of environments, and then stuffs the new value in that map.</p>
@@ -1078,14 +1078,14 @@ the parser does its magic.</p>
 <div class="codehilite"><pre class="insert-before">    // Stop if there was a syntax error.
     if (hadError) return;
 
-</pre><div class="source-file"><em>lox/Lox.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 in <em>run</em>()</div>
 <pre class="insert">    <span class="t">Resolver</span> <span class="i">resolver</span> = <span class="k">new</span> <span class="t">Resolver</span>(<span class="i">interpreter</span>);
     <span class="i">resolver</span>.<span class="i">resolve</span>(<span class="i">statements</span>);
 
 </pre><pre class="insert-after">    interpreter.interpret(statements);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>run</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>run</em>()</div>
 
 <p>We don&rsquo;t run the resolver if there are any parse errors. If the code has a
 syntax error, it&rsquo;s never going to run, so there&rsquo;s little value in resolving it.
@@ -1111,7 +1111,7 @@ And if they <em>didn&rsquo;t</em> know it existed, they probably didn&rsquo;t in
 the previous one.</p>
 <p>We can detect this mistake statically while resolving.</p>
 <div class="codehilite"><pre class="insert-before">    Map&lt;String, Boolean&gt; scope = scopes.peek();
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>declare</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">scope</span>.<span class="i">containsKey</span>(<span class="i">name</span>.<span class="i">lexeme</span>)) {
       <span class="t">Lox</span>.<span class="i">error</span>(<span class="i">name</span>,
@@ -1120,7 +1120,7 @@ in <em>declare</em>()</div>
 
 </pre><pre class="insert-after">    scope.put(name.lexeme, false);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>declare</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>declare</em>()</div>
 
 <p>When we declare a variable in a local scope, we already know the names of every
 variable previously declared in that same scope. If we see a collision, we
@@ -1136,41 +1136,41 @@ I don&rsquo;t think we want Lox to allow this.</p>
 as we walk the tree, we can track whether or not the code we are currently
 visiting is inside a function declaration.</p>
 <div class="codehilite"><pre class="insert-before">  private final Stack&lt;Map&lt;String, Boolean&gt;&gt; scopes = new Stack&lt;&gt;();
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in class <em>Resolver</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="t">FunctionType</span> <span class="i">currentFunction</span> = <span class="t">FunctionType</span>.<span class="i">NONE</span>;
 </pre><pre class="insert-after">
 
   Resolver(Interpreter interpreter) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in class <em>Resolver</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in class <em>Resolver</em></div>
 
 <p>Instead of a bare Boolean, we use this funny enum:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 add after <em>Resolver</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">enum</span> <span class="t">FunctionType</span> {
     <span class="i">NONE</span>,
     <span class="i">FUNCTION</span>
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>Resolver</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>Resolver</em>()</div>
 
 <p>It seems kind of dumb now, but we&rsquo;ll add a couple more cases to it later and
 then it will make more sense. When we resolve a function declaration, we pass
 that in.</p>
 <div class="codehilite"><pre class="insert-before">    define(stmt.name);
 
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitFunctionStmt</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="i">resolveFunction</span>(<span class="i">stmt</span>, <span class="t">FunctionType</span>.<span class="i">FUNCTION</span>);
 </pre><pre class="insert-after">    return null;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitFunctionStmt</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitFunctionStmt</em>(), replace 1 line</div>
 
 <p>Over in <code>resolveFunction()</code>, we take that parameter and store it in the field
 before resolving the body.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 method <em>resolveFunction</em>()<br>
 replace 1 line</div>
 <pre class="insert">  <span class="k">private</span> <span class="t">void</span> <span class="i">resolveFunction</span>(
@@ -1180,7 +1180,7 @@ replace 1 line</div>
 
 </pre><pre class="insert-after">    beginScope();
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, method <em>resolveFunction</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, method <em>resolveFunction</em>(), replace 1 line</div>
 
 <p>We stash the previous value of the field in a local variable first. Remember,
 Lox has local functions, so you can nest function declarations arbitrarily
@@ -1191,17 +1191,17 @@ we&rsquo;ll piggyback on the JVM. We store the previous value in a local on the 
 stack. When we&rsquo;re done resolving the function body, we restore the field to that
 value.</p>
 <div class="codehilite"><pre class="insert-before">    endScope();
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>resolveFunction</em>()</div>
 <pre class="insert">    <span class="i">currentFunction</span> = <span class="i">enclosingFunction</span>;
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>resolveFunction</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>resolveFunction</em>()</div>
 
 <p>Now that we can always tell whether or not we&rsquo;re inside a function declaration,
 we check that when resolving a <code>return</code> statement.</p>
 <div class="codehilite"><pre class="insert-before">  public Void visitReturnStmt(Stmt.Return stmt) {
-</pre><div class="source-file"><em>lox/Resolver.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
 in <em>visitReturnStmt</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">currentFunction</span> == <span class="t">FunctionType</span>.<span class="i">NONE</span>) {
       <span class="t">Lox</span>.<span class="i">error</span>(<span class="i">stmt</span>.<span class="i">keyword</span>, <span class="s">&quot;Can&#39;t return from top-level code.&quot;</span>);
@@ -1209,7 +1209,7 @@ in <em>visitReturnStmt</em>()</div>
 
 </pre><pre class="insert-after">    if (stmt.value != null) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitReturnStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitReturnStmt</em>()</div>
 
 <p>Neat, right?</p>
 <p>There&rsquo;s one more piece. Back in the main Lox class that stitches everything
@@ -1219,7 +1219,7 @@ resolve syntactically invalid code.</p>
 <p>But we also need to skip the interpreter if there are resolution errors, so we
 add <em>another</em> check.</p>
 <div class="codehilite"><pre class="insert-before">    resolver.resolve(statements);
-</pre><div class="source-file"><em>lox/Lox.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 in <em>run</em>()</div>
 <pre class="insert">
 
@@ -1229,7 +1229,7 @@ in <em>run</em>()</div>
 
     interpreter.interpret(statements);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>run</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>run</em>()</div>
 
 <p>You could imagine doing lots of other analysis in here. For example, if we added
 <code>break</code> statements to Lox, we would probably want to ensure they are only used

--- a/site/resolving-and-binding.html
+++ b/site/resolving-and-binding.html
@@ -394,7 +394,7 @@ the user&rsquo;s program grows.</p>
 </aside>
 <h2><a href="#a-resolver-class" id="a-resolver-class"><small>11&#8202;.&#8202;3</small>A Resolver Class</a></h2>
 <p>Like everything in Java, our variable resolution pass is embodied in a class.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -411,7 +411,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, create new file</div>
 
 <p>Since the resolver needs to visit every node in the syntax tree, it implements
 the visitor abstraction we already have in place. Only a few kinds of nodes are
@@ -438,7 +438,7 @@ operands might.</p>
 <h3><a href="#resolving-blocks" id="resolving-blocks"><small>11&#8202;.&#8202;3&#8202;.&#8202;1</small>Resolving blocks</a></h3>
 <p>We start with blocks since they create the local scopes where all the magic
 happens.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>Resolver</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitBlockStmt</span>(<span class="t">Stmt</span>.<span class="t">Block</span> <span class="i">stmt</span>) {
@@ -448,12 +448,12 @@ add after <em>Resolver</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>Resolver</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>Resolver</em>()</div>
 
 <p>This begins a new scope, traverses into the statements inside the block, and
 then discards the scope. The fun stuff lives in those helper methods. We start
 with the simple one.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>Resolver</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">resolve</span>(<span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span>) {
     <span class="k">for</span> (<span class="t">Stmt</span> <span class="i">statement</span> : <span class="i">statements</span>) {
@@ -461,52 +461,52 @@ add after <em>Resolver</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>Resolver</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>Resolver</em>()</div>
 
 <p>This walks a list of statements and resolves each one. It in turn calls:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">resolve</span>(<span class="t">Stmt</span> <span class="i">stmt</span>) {
     <span class="i">stmt</span>.<span class="i">accept</span>(<span class="k">this</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
 
 <p>While we&rsquo;re at it, let&rsquo;s add another overload that we&rsquo;ll need later for
 resolving an expression.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>resolve</em>(Stmt stmt)</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">resolve</span>(<span class="t">Expr</span> <span class="i">expr</span>) {
     <span class="i">expr</span>.<span class="i">accept</span>(<span class="k">this</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>resolve</em>(Stmt stmt)</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>resolve</em>(Stmt stmt)</div>
 
 <p>These methods are similar to the <code>evaluate()</code> and <code>execute()</code> methods in
 Interpreter<span class="em">&mdash;</span>they turn around and apply the Visitor pattern to the given
 syntax tree node.</p>
 <p>The real interesting behavior is around scopes. A new block scope is created
 like so:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>resolve</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">beginScope</span>() {
     <span class="i">scopes</span>.<span class="i">push</span>(<span class="k">new</span> <span class="t">HashMap</span>&lt;<span class="t">String</span>, <span class="t">Boolean</span>&gt;());
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>resolve</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>resolve</em>()</div>
 
 <p>Lexical scopes nest in both the interpreter and the resolver. They behave like a
 stack. The interpreter implements that stack using a linked list<span class="em">&mdash;</span>the chain of
 Environment objects. In the resolver, we use an actual Java Stack.</p>
 <div class="codehilite"><pre class="insert-before">  private final Interpreter interpreter;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in class <em>Resolver</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">Stack</span>&lt;<span class="t">Map</span>&lt;<span class="t">String</span>, <span class="t">Boolean</span>&gt;&gt; <span class="i">scopes</span> = <span class="k">new</span> <span class="t">Stack</span>&lt;&gt;();
 </pre><pre class="insert-after">
 
   Resolver(Interpreter interpreter) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in class <em>Resolver</em></div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in class <em>Resolver</em></div>
 
 <p>This field keeps track of the stack of scopes currently, uh, in scope. Each
 element in the stack is a Map representing a single block scope. Keys, as in
@@ -517,19 +517,19 @@ top level in the global scope are not tracked by the resolver since they are
 more dynamic in Lox. When resolving a variable, if we can&rsquo;t find it in the stack
 of local scopes, we assume it must be global.</p>
 <p>Since scopes are stored in an explicit stack, exiting one is straightforward.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>beginScope</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">endScope</span>() {
     <span class="i">scopes</span>.<span class="i">pop</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>beginScope</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>beginScope</em>()</div>
 
 <p>Now we can push and pop a stack of empty scopes. Let&rsquo;s put some things in them.</p>
 <h3><a href="#resolving-variable-declarations" id="resolving-variable-declarations"><small>11&#8202;.&#8202;3&#8202;.&#8202;2</small>Resolving variable declarations</a></h3>
 <p>Resolving a variable declaration adds a new entry to the current innermost
 scope&rsquo;s map. That seems simple, but there&rsquo;s a little dance we need to do.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitVarStmt</span>(<span class="t">Stmt</span>.<span class="t">Var</span> <span class="i">stmt</span>) {
@@ -541,7 +541,7 @@ add after <em>visitBlockStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
 
 <p>We split binding into two steps, declaring then defining, in order to handle
 funny edge cases like this:</p>
@@ -590,7 +590,7 @@ way, the user is alerted to the problem before any code is run.</p>
 <p>In order to do that, as we visit expressions, we need to know if we&rsquo;re inside
 the initializer for some variable. We do that by splitting binding into two
 steps. The first is <strong>declaring</strong> it.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>endScope</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">declare</span>(<span class="t">Token</span> <span class="i">name</span>) {
     <span class="k">if</span> (<span class="i">scopes</span>.<span class="i">isEmpty</span>()) <span class="k">return</span>;
@@ -599,7 +599,7 @@ add after <em>endScope</em>()</div>
     <span class="i">scope</span>.<span class="i">put</span>(<span class="i">name</span>.<span class="i">lexeme</span>, <span class="k">false</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>endScope</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>endScope</em>()</div>
 
 <p>Declaration adds the variable to the innermost scope so that it shadows any
 outer one and so that we know the variable exists. We mark it as &ldquo;not ready yet&rdquo;
@@ -610,21 +610,21 @@ variable&rsquo;s initializer.</p>
 scope where the new variable now exists but is unavailable. Once the initializer
 expression is done, the variable is ready for prime time. We do that by
 <strong>defining</strong> it.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>declare</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">define</span>(<span class="t">Token</span> <span class="i">name</span>) {
     <span class="k">if</span> (<span class="i">scopes</span>.<span class="i">isEmpty</span>()) <span class="k">return</span>;
     <span class="i">scopes</span>.<span class="i">peek</span>().<span class="i">put</span>(<span class="i">name</span>.<span class="i">lexeme</span>, <span class="k">true</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>declare</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>declare</em>()</div>
 
 <p>We set the variable&rsquo;s value in the scope map to <code>true</code> to mark it as fully
 initialized and available for use. It&rsquo;s alive! </p>
 <h3><a href="#resolving-variable-expressions" id="resolving-variable-expressions"><small>11&#8202;.&#8202;3&#8202;.&#8202;3</small>Resolving variable expressions</a></h3>
 <p>Variable declarations<span class="em">&mdash;</span>and function declarations, which we&rsquo;ll get to<span class="em">&mdash;</span>write
 to the scope maps. Those maps are read when we resolve variable expressions.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitVarStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitVariableExpr</span>(<span class="t">Expr</span>.<span class="t">Variable</span> <span class="i">expr</span>) {
@@ -638,14 +638,14 @@ add after <em>visitVarStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitVarStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitVarStmt</em>()</div>
 
 <p>First, we check to see if the variable is being accessed inside its own
 initializer. This is where the values in the scope map come into play. If the
 variable exists in the current scope but its value is <code>false</code>, that means we
 have declared it but not yet defined it. We report that error.</p>
 <p>After that check, we actually resolve the variable itself using this helper:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>define</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">resolveLocal</span>(<span class="t">Expr</span> <span class="i">expr</span>, <span class="t">Token</span> <span class="i">name</span>) {
     <span class="k">for</span> (<span class="t">int</span> <span class="i">i</span> = <span class="i">scopes</span>.<span class="i">size</span>() - <span class="n">1</span>; <span class="i">i</span> &gt;= <span class="n">0</span>; <span class="i">i</span>--) {
@@ -656,7 +656,7 @@ add after <em>define</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>define</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>define</em>()</div>
 
 <p>This looks, for good reason, a lot like the code in Environment for evaluating a
 variable. We start at the innermost scope and work outwards, looking in each map
@@ -671,7 +671,7 @@ other syntax nodes.</p>
 <h3><a href="#resolving-assignment-expressions" id="resolving-assignment-expressions"><small>11&#8202;.&#8202;3&#8202;.&#8202;4</small>Resolving assignment expressions</a></h3>
 <p>The other expression that references a variable is assignment. Resolving one
 looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitVarStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitAssignExpr</span>(<span class="t">Expr</span>.<span class="t">Assign</span> <span class="i">expr</span>) {
@@ -680,7 +680,7 @@ add after <em>visitVarStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitVarStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitVarStmt</em>()</div>
 
 <p>First, we resolve the expression for the assigned value in case it also contains
 references to other variables. Then we use our existing <code>resolveLocal()</code> method
@@ -690,7 +690,7 @@ to resolve the variable that&rsquo;s being assigned to.</p>
 the function itself is bound in the surrounding scope where the function is
 declared. When we step into the function&rsquo;s body, we also bind its parameters
 into that inner function scope.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitFunctionStmt</span>(<span class="t">Stmt</span>.<span class="t">Function</span> <span class="i">stmt</span>) {
@@ -701,14 +701,14 @@ add after <em>visitBlockStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
 
 <p>Similar to <code>visitVariableStmt()</code>, we declare and define the name of the function
 in the current scope. Unlike variables, though, we define the name eagerly,
 before resolving the function&rsquo;s body. This lets a function recursively refer to
 itself inside its own body.</p>
 <p>Then we resolve the function&rsquo;s body using this:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>resolve</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">resolveFunction</span>(<span class="t">Stmt</span>.<span class="t">Function</span> <span class="i">function</span>) {
     <span class="i">beginScope</span>();
@@ -720,7 +720,7 @@ add after <em>resolve</em>()</div>
     <span class="i">endScope</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>resolve</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>resolve</em>()</div>
 
 <p>It&rsquo;s a separate method since we will also use it for resolving Lox methods when
 we add classes later. It creates a new scope for the body and then binds
@@ -742,7 +742,7 @@ boring, but bear with me. We&rsquo;ll go kind of &ldquo;top down&rdquo; and star
 I didn&rsquo;t say they&rsquo;d all be exciting.</p>
 </aside>
 <p>An expression statement contains a single expression to traverse.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitBlockStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitExpressionStmt</span>(<span class="t">Stmt</span>.<span class="t">Expression</span> <span class="i">stmt</span>) {
@@ -750,11 +750,11 @@ add after <em>visitBlockStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitBlockStmt</em>()</div>
 
 <p>An if statement has an expression for its condition and one or two statements
 for the branches.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitFunctionStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitIfStmt</span>(<span class="t">Stmt</span>.<span class="t">If</span> <span class="i">stmt</span>) {
@@ -764,7 +764,7 @@ add after <em>visitFunctionStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitFunctionStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitFunctionStmt</em>()</div>
 
 <p>Here, we see how resolution is different from interpretation. When we resolve an
 <code>if</code> statement, there is no control flow. We resolve the condition and <em>both</em>
@@ -772,7 +772,7 @@ branches. Where a dynamic execution steps only into the branch that <em>is</em> 
 static analysis is conservative<span class="em">&mdash;</span>it analyzes any branch that <em>could</em> be run.
 Since either one could be reached at runtime, we resolve both.</p>
 <p>Like expression statements, a <code>print</code> statement contains a single subexpression.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitIfStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitPrintStmt</span>(<span class="t">Stmt</span>.<span class="t">Print</span> <span class="i">stmt</span>) {
@@ -780,10 +780,10 @@ add after <em>visitIfStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitIfStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitIfStmt</em>()</div>
 
 <p>Same deal for return.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitPrintStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitReturnStmt</span>(<span class="t">Stmt</span>.<span class="t">Return</span> <span class="i">stmt</span>) {
@@ -794,11 +794,11 @@ add after <em>visitPrintStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitPrintStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitPrintStmt</em>()</div>
 
 <p>As in <code>if</code> statements, with a <code>while</code> statement, we resolve its condition and
 resolve the body exactly once.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitVarStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitWhileStmt</span>(<span class="t">Stmt</span>.<span class="t">While</span> <span class="i">stmt</span>) {
@@ -807,12 +807,12 @@ add after <em>visitVarStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitVarStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitVarStmt</em>()</div>
 
 <p>That covers all the statements. On to expressions<span class="ellipse">&thinsp;.&thinsp;.&thinsp;.&nbsp;</span></p>
 <p>Our old friend the binary expression. We traverse into and resolve both
 operands.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitAssignExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitBinaryExpr</span>(<span class="t">Expr</span>.<span class="t">Binary</span> <span class="i">expr</span>) {
@@ -821,12 +821,12 @@ add after <em>visitAssignExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitAssignExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitAssignExpr</em>()</div>
 
 <p>Calls are similar<span class="em">&mdash;</span>we walk the argument list and resolve them all. The thing
 being called is also an expression (usually a variable expression), so that gets
 resolved too.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitBinaryExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitCallExpr</span>(<span class="t">Expr</span>.<span class="t">Call</span> <span class="i">expr</span>) {
@@ -839,10 +839,10 @@ add after <em>visitBinaryExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitBinaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitBinaryExpr</em>()</div>
 
 <p>Parentheses are easy.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitCallExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitGroupingExpr</span>(<span class="t">Expr</span>.<span class="t">Grouping</span> <span class="i">expr</span>) {
@@ -850,23 +850,23 @@ add after <em>visitCallExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitCallExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitCallExpr</em>()</div>
 
 <p>Literals are easiest of all.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitGroupingExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitLiteralExpr</span>(<span class="t">Expr</span>.<span class="t">Literal</span> <span class="i">expr</span>) {
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitGroupingExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitGroupingExpr</em>()</div>
 
 <p>A literal expression doesn&rsquo;t mention any variables and doesn&rsquo;t contain any
 subexpressions so there is no work to do.</p>
 <p>Since a static analysis does no control flow or short-circuiting, logical
 expressions are exactly the same as other binary operators.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitLiteralExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitLogicalExpr</span>(<span class="t">Expr</span>.<span class="t">Logical</span> <span class="i">expr</span>) {
@@ -875,10 +875,10 @@ add after <em>visitLiteralExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitLiteralExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitLiteralExpr</em>()</div>
 
 <p>And, finally, the last node. We resolve its one operand.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>visitLogicalExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitUnaryExpr</span>(<span class="t">Expr</span>.<span class="t">Unary</span> <span class="i">expr</span>) {
@@ -886,7 +886,7 @@ add after <em>visitLogicalExpr</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>visitLogicalExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>visitLogicalExpr</em>()</div>
 
 <p>With all of these visit methods, the Java compiler should be satisfied that
 Resolver fully implements Stmt.Visitor and Expr.Visitor. Now is a good time to
@@ -898,13 +898,13 @@ the scope where the variable is defined. At runtime, this corresponds exactly to
 the number of <em>environments</em> between the current one and the enclosing one where
 the interpreter can find the variable&rsquo;s value. The resolver hands that number to
 the interpreter by calling this:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>execute</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">resolve</span>(<span class="t">Expr</span> <span class="i">expr</span>, <span class="t">int</span> <span class="i">depth</span>) {
     <span class="i">locals</span>.<span class="i">put</span>(<span class="i">expr</span>, <span class="i">depth</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>execute</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>execute</em>()</div>
 
 <p>We want to store the resolution information somewhere so we can use it when the
 variable or assignment expression is later executed, but where? One obvious
@@ -925,14 +925,14 @@ recalculating when they&rsquo;re hiding in the foliage of the syntax tree. A ben
 of storing this data outside of the nodes is that it makes it easy to <em>discard</em>
 it<span class="em">&mdash;</span>simply clear the map.</p>
 <div class="codehilite"><pre class="insert-before">  private Environment environment = globals;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="k">final</span> <span class="t">Map</span>&lt;<span class="t">Expr</span>, <span class="t">Integer</span>&gt; <span class="i">locals</span> = <span class="k">new</span> <span class="t">HashMap</span>&lt;&gt;();
 </pre><pre class="insert-after">
 
   Interpreter() {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em></div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em></div>
 
 <p>You might think we&rsquo;d need some sort of nested tree structure to avoid getting
 confused when there are multiple expressions that reference the same variable,
@@ -940,37 +940,37 @@ but each expression node is its own Java object with its own unique identity. A
 single monolithic map doesn&rsquo;t have any trouble keeping them separated.</p>
 <p>As usual, using a collection requires us to import a couple of names.</p>
 <div class="codehilite"><pre class="insert-before">import java.util.ArrayList;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
+</pre><div class="source-file"><em>lox/Interpreter.java</em></div>
 <pre class="insert"><span class="k">import</span> <span class="i">java.util.HashMap</span>;
 </pre><pre class="insert-after">import java.util.List;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em></div>
 
 <p>And:</p>
 <div class="codehilite"><pre class="insert-before">import java.util.List;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
+</pre><div class="source-file"><em>lox/Interpreter.java</em></div>
 <pre class="insert"><span class="k">import</span> <span class="i">java.util.Map</span>;
 </pre><pre class="insert-after">
 
 class Interpreter implements Expr.Visitor&lt;Object&gt;,
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em></div>
 
 <h3><a href="#accessing-a-resolved-variable" id="accessing-a-resolved-variable"><small>11&#8202;.&#8202;4&#8202;.&#8202;1</small>Accessing a resolved variable</a></h3>
 <p>Our interpreter now has access to each variable&rsquo;s resolved location. Finally, we
 get to make use of that. We replace the visit method for variable expressions
 with this:</p>
 <div class="codehilite"><pre class="insert-before">  public Object visitVariableExpr(Expr.Variable expr) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitVariableExpr</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="k">return</span> <span class="i">lookUpVariable</span>(<span class="i">expr</span>.<span class="i">name</span>, <span class="i">expr</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitVariableExpr</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitVariableExpr</em>(), replace 1 line</div>
 
 <p>That delegates to:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitVariableExpr</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Object</span> <span class="i">lookUpVariable</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">Expr</span> <span class="i">expr</span>) {
     <span class="t">Integer</span> <span class="i">distance</span> = <span class="i">locals</span>.<span class="i">get</span>(<span class="i">expr</span>);
@@ -981,7 +981,7 @@ add after <em>visitVariableExpr</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitVariableExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitVariableExpr</em>()</div>
 
 <p>There are a couple of things going on here. First, we look up the resolved
 distance in the map. Remember that we resolved only <em>local</em> variables. Globals
@@ -992,19 +992,19 @@ runtime error if the variable isn&rsquo;t defined.</p>
 <p>If we <em>do</em> get a distance, we have a local variable, and we get to take
 advantage of the results of our static analysis. Instead of calling <code>get()</code>, we
 call this new method on Environment:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
 add after <em>define</em>()</div>
 <pre>  <span class="t">Object</span> <span class="i">getAt</span>(<span class="t">int</span> <span class="i">distance</span>, <span class="t">String</span> <span class="i">name</span>) {
     <span class="k">return</span> <span class="i">ancestor</span>(<span class="i">distance</span>).<span class="i">values</span>.<span class="i">get</span>(<span class="i">name</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, add after <em>define</em>()</div>
+<div class="source-file-narrow"><em>lox/Environment.java</em>, add after <em>define</em>()</div>
 
 <p>The old <code>get()</code> method dynamically walks the chain of enclosing environments,
 scouring each one to see if the variable might be hiding in there somewhere. But
 now we know exactly which environment in the chain will have the variable. We
 reach it using this helper method:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
 add after <em>define</em>()</div>
 <pre>  <span class="t">Environment</span> <span class="i">ancestor</span>(<span class="t">int</span> <span class="i">distance</span>) {
     <span class="t">Environment</span> <span class="i">environment</span> = <span class="k">this</span>;
@@ -1015,7 +1015,7 @@ add after <em>define</em>()</div>
     <span class="k">return</span> <span class="i">environment</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, add after <em>define</em>()</div>
+<div class="source-file-narrow"><em>lox/Environment.java</em>, add after <em>define</em>()</div>
 
 <p>This walks a fixed number of hops up the parent chain and returns the
 environment there. Once we have that, <code>getAt()</code> simply returns the value of the
@@ -1040,7 +1040,7 @@ to have already upheld.</p>
 assignment expression are similar.</p>
 <div class="codehilite"><pre class="insert-before">  public Object visitAssignExpr(Expr.Assign expr) {
     Object value = evaluate(expr.value);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in <em>visitAssignExpr</em>()<br>
 replace 1 line</div>
 <pre class="insert">
@@ -1054,17 +1054,17 @@ replace 1 line</div>
 
 </pre><pre class="insert-after">    return value;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in <em>visitAssignExpr</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in <em>visitAssignExpr</em>(), replace 1 line</div>
 
 <p>Again, we look up the variable&rsquo;s scope distance. If not found, we assume it&rsquo;s
 global and handle it the same way as before. Otherwise, we call this new method:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
 add after <em>getAt</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">assignAt</span>(<span class="t">int</span> <span class="i">distance</span>, <span class="t">Token</span> <span class="i">name</span>, <span class="t">Object</span> <span class="i">value</span>) {
     <span class="i">ancestor</span>(<span class="i">distance</span>).<span class="i">values</span>.<span class="i">put</span>(<span class="i">name</span>.<span class="i">lexeme</span>, <span class="i">value</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, add after <em>getAt</em>()</div>
+<div class="source-file-narrow"><em>lox/Environment.java</em>, add after <em>getAt</em>()</div>
 
 <p>As <code>getAt()</code> is to <code>get()</code>, <code>assignAt()</code> is to <code>assign()</code>. It walks a fixed
 number of environments, and then stuffs the new value in that map.</p>
@@ -1078,14 +1078,14 @@ the parser does its magic.</p>
 <div class="codehilite"><pre class="insert-before">    // Stop if there was a syntax error.
     if (hadError) return;
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+</pre><div class="source-file"><em>lox/Lox.java</em><br>
 in <em>run</em>()</div>
 <pre class="insert">    <span class="t">Resolver</span> <span class="i">resolver</span> = <span class="k">new</span> <span class="t">Resolver</span>(<span class="i">interpreter</span>);
     <span class="i">resolver</span>.<span class="i">resolve</span>(<span class="i">statements</span>);
 
 </pre><pre class="insert-after">    interpreter.interpret(statements);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>run</em>()</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>run</em>()</div>
 
 <p>We don&rsquo;t run the resolver if there are any parse errors. If the code has a
 syntax error, it&rsquo;s never going to run, so there&rsquo;s little value in resolving it.
@@ -1111,7 +1111,7 @@ And if they <em>didn&rsquo;t</em> know it existed, they probably didn&rsquo;t in
 the previous one.</p>
 <p>We can detect this mistake statically while resolving.</p>
 <div class="codehilite"><pre class="insert-before">    Map&lt;String, Boolean&gt; scope = scopes.peek();
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>declare</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">scope</span>.<span class="i">containsKey</span>(<span class="i">name</span>.<span class="i">lexeme</span>)) {
       <span class="t">Lox</span>.<span class="i">error</span>(<span class="i">name</span>,
@@ -1120,7 +1120,7 @@ in <em>declare</em>()</div>
 
 </pre><pre class="insert-after">    scope.put(name.lexeme, false);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>declare</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>declare</em>()</div>
 
 <p>When we declare a variable in a local scope, we already know the names of every
 variable previously declared in that same scope. If we see a collision, we
@@ -1136,41 +1136,41 @@ I don&rsquo;t think we want Lox to allow this.</p>
 as we walk the tree, we can track whether or not the code we are currently
 visiting is inside a function declaration.</p>
 <div class="codehilite"><pre class="insert-before">  private final Stack&lt;Map&lt;String, Boolean&gt;&gt; scopes = new Stack&lt;&gt;();
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in class <em>Resolver</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="t">FunctionType</span> <span class="i">currentFunction</span> = <span class="t">FunctionType</span>.<span class="i">NONE</span>;
 </pre><pre class="insert-after">
 
   Resolver(Interpreter interpreter) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in class <em>Resolver</em></div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in class <em>Resolver</em></div>
 
 <p>Instead of a bare Boolean, we use this funny enum:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 add after <em>Resolver</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">enum</span> <span class="t">FunctionType</span> {
     <span class="i">NONE</span>,
     <span class="i">FUNCTION</span>
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, add after <em>Resolver</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, add after <em>Resolver</em>()</div>
 
 <p>It seems kind of dumb now, but we&rsquo;ll add a couple more cases to it later and
 then it will make more sense. When we resolve a function declaration, we pass
 that in.</p>
 <div class="codehilite"><pre class="insert-before">    define(stmt.name);
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitFunctionStmt</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="i">resolveFunction</span>(<span class="i">stmt</span>, <span class="t">FunctionType</span>.<span class="i">FUNCTION</span>);
 </pre><pre class="insert-after">    return null;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitFunctionStmt</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitFunctionStmt</em>(), replace 1 line</div>
 
 <p>Over in <code>resolveFunction()</code>, we take that parameter and store it in the field
 before resolving the body.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Resolver.java</em><br>
 method <em>resolveFunction</em>()<br>
 replace 1 line</div>
 <pre class="insert">  <span class="k">private</span> <span class="t">void</span> <span class="i">resolveFunction</span>(
@@ -1180,7 +1180,7 @@ replace 1 line</div>
 
 </pre><pre class="insert-after">    beginScope();
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, method <em>resolveFunction</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, method <em>resolveFunction</em>(), replace 1 line</div>
 
 <p>We stash the previous value of the field in a local variable first. Remember,
 Lox has local functions, so you can nest function declarations arbitrarily
@@ -1191,17 +1191,17 @@ we&rsquo;ll piggyback on the JVM. We store the previous value in a local on the 
 stack. When we&rsquo;re done resolving the function body, we restore the field to that
 value.</p>
 <div class="codehilite"><pre class="insert-before">    endScope();
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>resolveFunction</em>()</div>
 <pre class="insert">    <span class="i">currentFunction</span> = <span class="i">enclosingFunction</span>;
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>resolveFunction</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>resolveFunction</em>()</div>
 
 <p>Now that we can always tell whether or not we&rsquo;re inside a function declaration,
 we check that when resolving a <code>return</code> statement.</p>
 <div class="codehilite"><pre class="insert-before">  public Void visitReturnStmt(Stmt.Return stmt) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Resolver.java</em><br>
+</pre><div class="source-file"><em>lox/Resolver.java</em><br>
 in <em>visitReturnStmt</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">currentFunction</span> == <span class="t">FunctionType</span>.<span class="i">NONE</span>) {
       <span class="t">Lox</span>.<span class="i">error</span>(<span class="i">stmt</span>.<span class="i">keyword</span>, <span class="s">&quot;Can&#39;t return from top-level code.&quot;</span>);
@@ -1209,7 +1209,7 @@ in <em>visitReturnStmt</em>()</div>
 
 </pre><pre class="insert-after">    if (stmt.value != null) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Resolver.java</em>, in <em>visitReturnStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Resolver.java</em>, in <em>visitReturnStmt</em>()</div>
 
 <p>Neat, right?</p>
 <p>There&rsquo;s one more piece. Back in the main Lox class that stitches everything
@@ -1219,7 +1219,7 @@ resolve syntactically invalid code.</p>
 <p>But we also need to skip the interpreter if there are resolution errors, so we
 add <em>another</em> check.</p>
 <div class="codehilite"><pre class="insert-before">    resolver.resolve(statements);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+</pre><div class="source-file"><em>lox/Lox.java</em><br>
 in <em>run</em>()</div>
 <pre class="insert">
 
@@ -1229,7 +1229,7 @@ in <em>run</em>()</div>
 
     interpreter.interpret(statements);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>run</em>()</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>run</em>()</div>
 
 <p>You could imagine doing lots of other analysis in here. For example, if we added
 <code>break</code> statements to Lox, we would probably want to ensure they are only used

--- a/site/scanning.html
+++ b/site/scanning.html
@@ -127,7 +127,7 @@ in the next chapter.</p>
 <p>Since this is our first real chapter, before we get to actually scanning some
 code we need to sketch out the basic shape of our interpreter, jlox. Everything
 starts with a class in Java.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -152,7 +152,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, create new file</div>
 
 <aside name="64">
 <p>For exit codes, I&rsquo;m using the conventions defined in the UNIX
@@ -164,14 +164,14 @@ I&rsquo;ll be right here when you&rsquo;re ready. Good? OK!</p>
 <p>Lox is a scripting language, which means it executes directly from source. Our
 interpreter supports two ways of running code. If you start jlox from the
 command line and give it a path to a file, it reads the file and executes it.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 add after <em>main</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">runFile</span>(<span class="t">String</span> <span class="i">path</span>) <span class="k">throws</span> <span class="t">IOException</span> {
     <span class="t">byte</span>[] <span class="i">bytes</span> = <span class="t">Files</span>.<span class="i">readAllBytes</span>(<span class="t">Paths</span>.<span class="i">get</span>(<span class="i">path</span>));
     <span class="i">run</span>(<span class="k">new</span> <span class="t">String</span>(<span class="i">bytes</span>, <span class="t">Charset</span>.<span class="i">defaultCharset</span>()));
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, add after <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, add after <em>main</em>()</div>
 
 <p>If you want a more intimate conversation with your interpreter, you can also run
 it interactively. Fire up jlox without any arguments, and it drops you into a
@@ -185,7 +185,7 @@ wrapping a loop around a few built-in functions:</p>
 <p>Working outwards from the most nested call, you <strong>R</strong>ead a line of input,
 <strong>E</strong>valuate it, <strong>P</strong>rint the result, then <strong>L</strong>oop and do it all over again.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 add after <em>runFile</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">runPrompt</span>() <span class="k">throws</span> <span class="t">IOException</span> {
     <span class="t">InputStreamReader</span> <span class="i">input</span> = <span class="k">new</span> <span class="t">InputStreamReader</span>(<span class="t">System</span>.<span class="i">in</span>);
@@ -199,7 +199,7 @@ add after <em>runFile</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, add after <em>runFile</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, add after <em>runFile</em>()</div>
 
 <p>The <code>readLine()</code> function, as the name so helpfully implies, reads a line of
 input from the user on the command line and returns the result. To kill an
@@ -207,7 +207,7 @@ interactive command-line app, you usually type Control-D. Doing so signals an
 &ldquo;end-of-file&rdquo; condition to the program. When that happens <code>readLine()</code> returns
 <code>null</code>, so we check for that to exit the loop.</p>
 <p>Both the prompt and the file runner are thin wrappers around this core function:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 add after <em>runPrompt</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">run</span>(<span class="t">String</span> <span class="i">source</span>) {
     <span class="t">Scanner</span> <span class="i">scanner</span> = <span class="k">new</span> <span class="t">Scanner</span>(<span class="i">source</span>);
@@ -219,7 +219,7 @@ add after <em>runPrompt</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, add after <em>runPrompt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, add after <em>runPrompt</em>()</div>
 
 <p>It&rsquo;s not super useful yet since we haven&rsquo;t written the interpreter, but baby
 steps, you know? Right now, it prints out the tokens our forthcoming scanner
@@ -242,7 +242,7 @@ handling all through the implementation of our interpreter, starting now.</p>
 bones. I&rsquo;d love to talk about interactive debuggers, static analyzers, and other
 fun stuff, but there&rsquo;s only so much ink in the pen.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 add after <em>run</em>()</div>
 <pre>  <span class="k">static</span> <span class="t">void</span> <span class="i">error</span>(<span class="t">int</span> <span class="i">line</span>, <span class="t">String</span> <span class="i">message</span>) {
     <span class="i">report</span>(<span class="i">line</span>, <span class="s">&quot;&quot;</span>, <span class="i">message</span>);
@@ -255,7 +255,7 @@ add after <em>run</em>()</div>
     <span class="i">hadError</span> = <span class="k">true</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, add after <em>run</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, add after <em>run</em>()</div>
 
 <p>This <code>error()</code> function and its <code>report()</code> helper tells the user some syntax
 error occurred on a given line. That is really the bare minimum to be able to
@@ -279,17 +279,17 @@ not as I do.</p>
 <p>The primary reason we&rsquo;re sticking this error reporting function in the main Lox
 class is because of that <code>hadError</code> field. It&rsquo;s defined here:</p>
 <div class="codehilite"><pre class="insert-before">public class Lox {
-</pre><div class="source-file"><em>lox/Lox.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 in class <em>Lox</em></div>
 <pre class="insert">  <span class="k">static</span> <span class="t">boolean</span> <span class="i">hadError</span> = <span class="k">false</span>;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, in class <em>Lox</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in class <em>Lox</em></div>
 
 <p>We&rsquo;ll use this to ensure we don&rsquo;t try to execute code that has a known error.
 Also, it lets us exit with a non-zero exit code like a good command line citizen
 should.</p>
 <div class="codehilite"><pre class="insert-before">    run(new String(bytes, Charset.defaultCharset()));
-</pre><div class="source-file"><em>lox/Lox.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 in <em>runFile</em>()</div>
 <pre class="insert">
 
@@ -297,17 +297,17 @@ in <em>runFile</em>()</div>
     <span class="k">if</span> (<span class="i">hadError</span>) <span class="t">System</span>.<span class="i">exit</span>(<span class="n">65</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>runFile</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>runFile</em>()</div>
 
 <p>We need to reset this flag in the interactive loop. If the user makes a mistake,
 it shouldn&rsquo;t kill their entire session.</p>
 <div class="codehilite"><pre class="insert-before">      run(line);
-</pre><div class="source-file"><em>lox/Lox.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 in <em>runPrompt</em>()</div>
 <pre class="insert">      <span class="i">hadError</span> = <span class="k">false</span>;
 </pre><pre class="insert-after">    }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>runPrompt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>runPrompt</em>()</div>
 
 <p>The other reason I pulled the error reporting out here instead of stuffing it
 into the scanner and other phases where the error might occur is to remind you
@@ -359,7 +359,7 @@ punctuation, and literal type.</p>
 <p>After all, string comparison ends up looking at individual characters, and isn&rsquo;t
 that the scanner&rsquo;s job?</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/TokenType.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\TokenType.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -384,7 +384,7 @@ create new file</div>
   <span class="i">EOF</span>
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/TokenType.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\TokenType.java</em>, create new file</div>
 
 <h3><a href="#literal-value" id="literal-value"><small>4&#8202;.&#8202;2&#8202;.&#8202;2</small>Literal value</a></h3>
 <p>There are lexemes for literal values<span class="em">&mdash;</span>numbers and strings and the like. Since
@@ -409,7 +409,7 @@ those, the less time you spend calculating position information ahead of time,
 the better.</p>
 </aside>
 <p>We take all of this data and wrap it in a class.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Token.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Token.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -431,7 +431,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Token.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Token.java</em>, create new file</div>
 
 <p>Now we have an object with enough structure to be useful for all of the later
 phases of the interpreter.</p>
@@ -483,7 +483,7 @@ mega billionaire among us.</p>
 delegating that task. We&rsquo;re about handcrafted goods.</p>
 <h2><a href="#the-scanner-class" id="the-scanner-class"><small>4&#8202;.&#8202;4</small>The Scanner Class</a></h2>
 <p>Without further ado, let&rsquo;s make ourselves a scanner.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -503,7 +503,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, create new file</div>
 
 <aside name="static-import">
 <p>I know static imports are considered bad style by some, but they save me from
@@ -513,7 +513,7 @@ every character counts in a book.</p>
 <p>We store the raw source code as a simple string, and we have a list ready to
 fill with tokens we&rsquo;re going to generate. The aforementioned loop that does that
 looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 add after <em>Scanner</em>()</div>
 <pre>  <span class="t">List</span>&lt;<span class="t">Token</span>&gt; <span class="i">scanTokens</span>() {
     <span class="k">while</span> (!<span class="i">isAtEnd</span>()) {
@@ -526,7 +526,7 @@ add after <em>Scanner</em>()</div>
     <span class="k">return</span> <span class="i">tokens</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>Scanner</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>Scanner</em>()</div>
 
 <p>The scanner works its way through the source code, adding tokens until it runs
 out of characters. Then it appends one final &ldquo;end of file&rdquo; token. That isn&rsquo;t
@@ -534,7 +534,7 @@ strictly needed, but it makes our parser a little cleaner.</p>
 <p>This loop depends on a couple of fields to keep track of where the scanner is in
 the source code.</p>
 <div class="codehilite"><pre class="insert-before">  private final List&lt;Token&gt; tokens = new ArrayList&lt;&gt;();
-</pre><div class="source-file"><em>lox/Scanner.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 in class <em>Scanner</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="t">int</span> <span class="i">start</span> = <span class="n">0</span>;
   <span class="k">private</span> <span class="t">int</span> <span class="i">current</span> = <span class="n">0</span>;
@@ -543,7 +543,7 @@ in class <em>Scanner</em></div>
 
   Scanner(String source) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, in class <em>Scanner</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in class <em>Scanner</em></div>
 
 <p>The <code>start</code> and <code>current</code> fields are offsets that index into the string. The
 <code>start</code> field points to the first character in the lexeme being scanned, and
@@ -552,13 +552,13 @@ tracks what source line <code>current</code> is on so we can produce tokens that
 location.</p>
 <p>Then we have one little helper function that tells us if we&rsquo;ve consumed all the
 characters.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 add after <em>scanTokens</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isAtEnd</span>() {
     <span class="k">return</span> <span class="i">current</span> &gt;= <span class="i">source</span>.<span class="i">length</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>scanTokens</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>scanTokens</em>()</div>
 
 <h2><a href="#recognizing-lexemes" id="recognizing-lexemes"><small>4&#8202;.&#8202;5</small>Recognizing Lexemes</a></h2>
 <p>In each turn of the loop, we scan a single token. This is the real heart of the
@@ -566,7 +566,7 @@ scanner. We&rsquo;ll start simple. Imagine if every lexeme were only a single ch
 long. All you would need to do is consume the next character and pick a token type for
 it. Several lexemes <em>are</em> only a single character in Lox, so let&rsquo;s start with
 those.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 add after <em>scanTokens</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">scanToken</span>() {
     <span class="t">char</span> <span class="i">c</span> = <span class="i">advance</span>();
@@ -584,13 +584,13 @@ add after <em>scanTokens</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>scanTokens</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>scanTokens</em>()</div>
 
 <aside name="slash">
 <p>Wondering why <code>/</code> isn&rsquo;t in here? Don&rsquo;t worry, we&rsquo;ll get to it.</p>
 </aside>
 <p>Again, we need a couple of helper methods.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 add after <em>isAtEnd</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">char</span> <span class="i">advance</span>() {
     <span class="k">return</span> <span class="i">source</span>.<span class="i">charAt</span>(<span class="i">current</span>++);
@@ -605,7 +605,7 @@ add after <em>isAtEnd</em>()</div>
     <span class="i">tokens</span>.<span class="i">add</span>(<span class="k">new</span> <span class="t">Token</span>(<span class="i">type</span>, <span class="i">text</span>, <span class="i">literal</span>, <span class="i">line</span>));
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>isAtEnd</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>isAtEnd</em>()</div>
 
 <p>The <code>advance()</code> method consumes the next character in the source file and
 returns it. Where <code>advance()</code> is for input, <code>addToken()</code> is for output. It grabs
@@ -619,7 +619,7 @@ characters get silently discarded. They aren&rsquo;t used by the Lox language, b
 that doesn&rsquo;t mean the interpreter can pretend they aren&rsquo;t there. Instead, we
 report an error.</p>
 <div class="codehilite"><pre class="insert-before">      case '*': addToken(STAR); break;<span name="slash"> </span>
-</pre><div class="source-file"><em>lox/Scanner.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">
 
@@ -628,7 +628,7 @@ in <em>scanToken</em>()</div>
         <span class="k">break</span>;
 </pre><pre class="insert-after">    }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>scanToken</em>()</div>
 
 <p>Note that the erroneous character is still <em>consumed</em> by the earlier call to
 <code>advance()</code>. That&rsquo;s important so that we don&rsquo;t get stuck in an infinite loop.</p>
@@ -656,7 +656,7 @@ can all be followed by <code>=</code> to create the other equality and compariso
 operators.</p>
 <p>For all of these, we need to look at the second character.</p>
 <div class="codehilite"><pre class="insert-before">      case '*': addToken(STAR); break;<span name="slash"> </span>
-</pre><div class="source-file"><em>lox/Scanner.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="s">&#39;!&#39;</span>:
         <span class="i">addToken</span>(<span class="i">match</span>(<span class="s">&#39;=&#39;</span>) ? <span class="i">BANG_EQUAL</span> : <span class="i">BANG</span>);
@@ -674,10 +674,10 @@ in <em>scanToken</em>()</div>
 
       default:
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>scanToken</em>()</div>
 
 <p>Those cases use this new method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 add after <em>scanToken</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">match</span>(<span class="t">char</span> <span class="i">expected</span>) {
     <span class="k">if</span> (<span class="i">isAtEnd</span>()) <span class="k">return</span> <span class="k">false</span>;
@@ -687,7 +687,7 @@ add after <em>scanToken</em>()</div>
     <span class="k">return</span> <span class="k">true</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>scanToken</em>()</div>
 
 <p>It&rsquo;s like a conditional <code>advance()</code>. We only consume the current character if
 it&rsquo;s what we&rsquo;re looking for.</p>
@@ -699,7 +699,7 @@ merely a <code>!</code>.</p>
 <p>We&rsquo;re still missing one operator: <code>/</code> for division. That character needs a
 little special handling because comments begin with a slash too.</p>
 <div class="codehilite"><pre class="insert-before">        break;
-</pre><div class="source-file"><em>lox/Scanner.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="s">&#39;/&#39;</span>:
         <span class="k">if</span> (<span class="i">match</span>(<span class="s">&#39;/&#39;</span>)) {
@@ -713,7 +713,7 @@ in <em>scanToken</em>()</div>
 
       default:
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>scanToken</em>()</div>
 
 <p>This is similar to the other two-character operators, except that when we find a
 second <code>/</code>, we don&rsquo;t end the token yet. Instead, we keep consuming characters
@@ -722,14 +722,14 @@ until we reach the end of the line.</p>
 beginning of one, we shunt over to some lexeme-specific code that keeps eating
 characters until it sees the end.</p>
 <p>We&rsquo;ve got another helper:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 add after <em>match</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">char</span> <span class="i">peek</span>() {
     <span class="k">if</span> (<span class="i">isAtEnd</span>()) <span class="k">return</span> <span class="s">&#39;\0&#39;</span>;
     <span class="k">return</span> <span class="i">source</span>.<span class="i">charAt</span>(<span class="i">current</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>match</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>match</em>()</div>
 
 <p>It&rsquo;s sort of like <code>advance()</code>, but doesn&rsquo;t consume the character. This is called
 <span name="match"><strong>lookahead</strong></span>. Since it only looks at the current
@@ -748,7 +748,7 @@ reset and the comment&rsquo;s lexeme disappears in a puff of smoke.</p>
 <p>While we&rsquo;re at it, now&rsquo;s a good time to skip over those other meaningless
 characters: newlines and whitespace.</p>
 <div class="codehilite"><pre class="insert-before">        break;
-</pre><div class="source-file"><em>lox/Scanner.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">
 
@@ -766,7 +766,7 @@ in <em>scanToken</em>()</div>
       default:
         Lox.error(line, &quot;Unexpected character.&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>scanToken</em>()</div>
 
 <p>When encountering whitespace, we simply go back to the beginning of the scan
 loop. That starts a new lexeme <em>after</em> the whitespace character. For newlines,
@@ -782,7 +782,7 @@ that newline to get us here so we can update <code>line</code>.)</p>
 <p>Now that we&rsquo;re comfortable with longer lexemes, we&rsquo;re ready to tackle literals.
 We&rsquo;ll do strings first, since they always begin with a specific character, <code>"</code>.</p>
 <div class="codehilite"><pre class="insert-before">        break;
-</pre><div class="source-file"><em>lox/Scanner.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">
 
@@ -791,10 +791,10 @@ in <em>scanToken</em>()</div>
 
       default:
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>scanToken</em>()</div>
 
 <p>That calls:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 add after <em>scanToken</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">string</span>() {
     <span class="k">while</span> (<span class="i">peek</span>() != <span class="s">&#39;&quot;&#39;</span> &amp;&amp; !<span class="i">isAtEnd</span>()) {
@@ -815,7 +815,7 @@ add after <em>scanToken</em>()</div>
     <span class="i">addToken</span>(<span class="i">STRING</span>, <span class="i">value</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>scanToken</em>()</div>
 
 <p>Like with comments, we consume characters until we hit the <code>"</code> that ends the
 string. We also gracefully handle running out of input before the string is
@@ -861,7 +861,7 @@ latter gets weird if we ever want to allow methods on numbers like <code>123.sqr
 of tedious to add cases for every decimal digit, so we&rsquo;ll stuff it in the
 default case instead.</p>
 <div class="codehilite"><pre class="insert-before">      default:
-</pre><div class="source-file"><em>lox/Scanner.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 in <em>scanToken</em>()<br>
 replace 1 line</div>
 <pre class="insert">        <span class="k">if</span> (<span class="i">isDigit</span>(<span class="i">c</span>)) {
@@ -871,16 +871,16 @@ replace 1 line</div>
         }
 </pre><pre class="insert-after">        break;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>scanToken</em>(), replace 1 line</div>
 
 <p>This relies on this little utility:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 add after <em>peek</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isDigit</span>(<span class="t">char</span> <span class="i">c</span>) {
     <span class="k">return</span> <span class="i">c</span> &gt;= <span class="s">&#39;0&#39;</span> &amp;&amp; <span class="i">c</span> &lt;= <span class="s">&#39;9&#39;</span>;
   }<span name="is-digit"> </span>
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>peek</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>peek</em>()</div>
 
 <aside name="is-digit">
 <p>The Java standard library provides <a href="http://docs.oracle.com/javase/7/docs/api/java/lang/Character.html#isDigit(char)"><code>Character.isDigit()</code></a>, which seems
@@ -889,7 +889,7 @@ full-width numbers, and other funny stuff we don&rsquo;t want.</p>
 </aside>
 <p>Once we know we are in a number, we branch to a separate method to consume the
 rest of the literal, like we do with strings.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 add after <em>scanToken</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">number</span>() {
     <span class="k">while</span> (<span class="i">isDigit</span>(<span class="i">peek</span>())) <span class="i">advance</span>();
@@ -906,7 +906,7 @@ add after <em>scanToken</em>()</div>
         <span class="t">Double</span>.<span class="i">parseDouble</span>(<span class="i">source</span>.<span class="i">substring</span>(<span class="i">start</span>, <span class="i">current</span>)));
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>scanToken</em>()</div>
 
 <p>We consume as many digits as we find for the integer part of the literal. Then
 we look for a fractional part, which is a decimal point (<code>.</code>) followed by at
@@ -915,14 +915,14 @@ digits as we can find.</p>
 <p>Looking past the decimal point requires a second character of lookahead since we
 don&rsquo;t want to consume the <code>.</code> until we&rsquo;re sure there is a digit <em>after</em> it. So
 we add:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 add after <em>peek</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">char</span> <span class="i">peekNext</span>() {
     <span class="k">if</span> (<span class="i">current</span> + <span class="n">1</span> &gt;= <span class="i">source</span>.<span class="i">length</span>()) <span class="k">return</span> <span class="s">&#39;\0&#39;</span>;
     <span class="k">return</span> <span class="i">source</span>.<span class="i">charAt</span>(<span class="i">current</span> + <span class="n">1</span>);
   }<span name="peek-next"> </span>
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>peek</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>peek</em>()</div>
 
 <aside name="peek-next">
 <p>I could have made <code>peek()</code> take a parameter for the number of characters ahead
@@ -982,7 +982,7 @@ identifier.</p>
 <div class="codehilite"><pre class="insert-before">      default:
         if (isDigit(c)) {
           number();
-</pre><div class="source-file"><em>lox/Scanner.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">        } <span class="k">else</span> <span class="k">if</span> (<span class="i">isAlpha</span>(<span class="i">c</span>)) {
           <span class="i">identifier</span>();
@@ -990,10 +990,10 @@ in <em>scanToken</em>()</div>
           Lox.error(line, &quot;Unexpected character.&quot;);
         }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>scanToken</em>()</div>
 
 <p>The rest of the code lives over here:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 add after <em>scanToken</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">identifier</span>() {
     <span class="k">while</span> (<span class="i">isAlphaNumeric</span>(<span class="i">peek</span>())) <span class="i">advance</span>();
@@ -1001,10 +1001,10 @@ add after <em>scanToken</em>()</div>
     <span class="i">addToken</span>(<span class="i">IDENTIFIER</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>scanToken</em>()</div>
 
 <p>We define that in terms of these helpers:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 add after <em>peekNext</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isAlpha</span>(<span class="t">char</span> <span class="i">c</span>) {
     <span class="k">return</span> (<span class="i">c</span> &gt;= <span class="s">&#39;a&#39;</span> &amp;&amp; <span class="i">c</span> &lt;= <span class="s">&#39;z&#39;</span>) ||
@@ -1016,12 +1016,12 @@ add after <em>peekNext</em>()</div>
     <span class="k">return</span> <span class="i">isAlpha</span>(<span class="i">c</span>) || <span class="i">isDigit</span>(<span class="i">c</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>peekNext</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>peekNext</em>()</div>
 
 <p>That gets identifiers working. To handle keywords, we see if the identifier&rsquo;s
 lexeme is one of the reserved words. If so, we use a token type specific to that
 keyword. We define the set of reserved words in a map.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 in class <em>Scanner</em></div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="k">final</span> <span class="t">Map</span>&lt;<span class="t">String</span>, <span class="t">TokenType</span>&gt; <span class="i">keywords</span>;
 
@@ -1045,13 +1045,13 @@ in class <em>Scanner</em></div>
     <span class="i">keywords</span>.<span class="i">put</span>(<span class="s">&quot;while&quot;</span>,  <span class="i">WHILE</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, in class <em>Scanner</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in class <em>Scanner</em></div>
 
 <p>Then, after we scan an identifier, we check to see if it matches anything in the
 map.</p>
 <div class="codehilite"><pre class="insert-before">    while (isAlphaNumeric(peek())) advance();
 
-</pre><div class="source-file"><em>lox/Scanner.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
 in <em>identifier</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">String</span> <span class="i">text</span> = <span class="i">source</span>.<span class="i">substring</span>(<span class="i">start</span>, <span class="i">current</span>);
@@ -1060,7 +1060,7 @@ replace 1 line</div>
     <span class="i">addToken</span>(<span class="i">type</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>identifier</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>identifier</em>(), replace 1 line</div>
 
 <p>If so, we use that keyword&rsquo;s token type. Otherwise, it&rsquo;s a regular user-defined
 identifier.</p>

--- a/site/scanning.html
+++ b/site/scanning.html
@@ -127,7 +127,7 @@ in the next chapter.</p>
 <p>Since this is our first real chapter, before we get to actually scanning some
 code we need to sketch out the basic shape of our interpreter, jlox. Everything
 starts with a class in Java.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -152,7 +152,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, create new file</div>
 
 <aside name="64">
 <p>For exit codes, I&rsquo;m using the conventions defined in the UNIX
@@ -164,14 +164,14 @@ I&rsquo;ll be right here when you&rsquo;re ready. Good? OK!</p>
 <p>Lox is a scripting language, which means it executes directly from source. Our
 interpreter supports two ways of running code. If you start jlox from the
 command line and give it a path to a file, it reads the file and executes it.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
 add after <em>main</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">runFile</span>(<span class="t">String</span> <span class="i">path</span>) <span class="k">throws</span> <span class="t">IOException</span> {
     <span class="t">byte</span>[] <span class="i">bytes</span> = <span class="t">Files</span>.<span class="i">readAllBytes</span>(<span class="t">Paths</span>.<span class="i">get</span>(<span class="i">path</span>));
     <span class="i">run</span>(<span class="k">new</span> <span class="t">String</span>(<span class="i">bytes</span>, <span class="t">Charset</span>.<span class="i">defaultCharset</span>()));
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, add after <em>main</em>()</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, add after <em>main</em>()</div>
 
 <p>If you want a more intimate conversation with your interpreter, you can also run
 it interactively. Fire up jlox without any arguments, and it drops you into a
@@ -185,7 +185,7 @@ wrapping a loop around a few built-in functions:</p>
 <p>Working outwards from the most nested call, you <strong>R</strong>ead a line of input,
 <strong>E</strong>valuate it, <strong>P</strong>rint the result, then <strong>L</strong>oop and do it all over again.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
 add after <em>runFile</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">runPrompt</span>() <span class="k">throws</span> <span class="t">IOException</span> {
     <span class="t">InputStreamReader</span> <span class="i">input</span> = <span class="k">new</span> <span class="t">InputStreamReader</span>(<span class="t">System</span>.<span class="i">in</span>);
@@ -199,7 +199,7 @@ add after <em>runFile</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, add after <em>runFile</em>()</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, add after <em>runFile</em>()</div>
 
 <p>The <code>readLine()</code> function, as the name so helpfully implies, reads a line of
 input from the user on the command line and returns the result. To kill an
@@ -207,7 +207,7 @@ interactive command-line app, you usually type Control-D. Doing so signals an
 &ldquo;end-of-file&rdquo; condition to the program. When that happens <code>readLine()</code> returns
 <code>null</code>, so we check for that to exit the loop.</p>
 <p>Both the prompt and the file runner are thin wrappers around this core function:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
 add after <em>runPrompt</em>()</div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="t">void</span> <span class="i">run</span>(<span class="t">String</span> <span class="i">source</span>) {
     <span class="t">Scanner</span> <span class="i">scanner</span> = <span class="k">new</span> <span class="t">Scanner</span>(<span class="i">source</span>);
@@ -219,7 +219,7 @@ add after <em>runPrompt</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, add after <em>runPrompt</em>()</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, add after <em>runPrompt</em>()</div>
 
 <p>It&rsquo;s not super useful yet since we haven&rsquo;t written the interpreter, but baby
 steps, you know? Right now, it prints out the tokens our forthcoming scanner
@@ -242,7 +242,7 @@ handling all through the implementation of our interpreter, starting now.</p>
 bones. I&rsquo;d love to talk about interactive debuggers, static analyzers, and other
 fun stuff, but there&rsquo;s only so much ink in the pen.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Lox.java</em><br>
 add after <em>run</em>()</div>
 <pre>  <span class="k">static</span> <span class="t">void</span> <span class="i">error</span>(<span class="t">int</span> <span class="i">line</span>, <span class="t">String</span> <span class="i">message</span>) {
     <span class="i">report</span>(<span class="i">line</span>, <span class="s">&quot;&quot;</span>, <span class="i">message</span>);
@@ -255,7 +255,7 @@ add after <em>run</em>()</div>
     <span class="i">hadError</span> = <span class="k">true</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, add after <em>run</em>()</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, add after <em>run</em>()</div>
 
 <p>This <code>error()</code> function and its <code>report()</code> helper tells the user some syntax
 error occurred on a given line. That is really the bare minimum to be able to
@@ -279,17 +279,17 @@ not as I do.</p>
 <p>The primary reason we&rsquo;re sticking this error reporting function in the main Lox
 class is because of that <code>hadError</code> field. It&rsquo;s defined here:</p>
 <div class="codehilite"><pre class="insert-before">public class Lox {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+</pre><div class="source-file"><em>lox/Lox.java</em><br>
 in class <em>Lox</em></div>
 <pre class="insert">  <span class="k">static</span> <span class="t">boolean</span> <span class="i">hadError</span> = <span class="k">false</span>;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in class <em>Lox</em></div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, in class <em>Lox</em></div>
 
 <p>We&rsquo;ll use this to ensure we don&rsquo;t try to execute code that has a known error.
 Also, it lets us exit with a non-zero exit code like a good command line citizen
 should.</p>
 <div class="codehilite"><pre class="insert-before">    run(new String(bytes, Charset.defaultCharset()));
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+</pre><div class="source-file"><em>lox/Lox.java</em><br>
 in <em>runFile</em>()</div>
 <pre class="insert">
 
@@ -297,17 +297,17 @@ in <em>runFile</em>()</div>
     <span class="k">if</span> (<span class="i">hadError</span>) <span class="t">System</span>.<span class="i">exit</span>(<span class="n">65</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>runFile</em>()</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>runFile</em>()</div>
 
 <p>We need to reset this flag in the interactive loop. If the user makes a mistake,
 it shouldn&rsquo;t kill their entire session.</p>
 <div class="codehilite"><pre class="insert-before">      run(line);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+</pre><div class="source-file"><em>lox/Lox.java</em><br>
 in <em>runPrompt</em>()</div>
 <pre class="insert">      <span class="i">hadError</span> = <span class="k">false</span>;
 </pre><pre class="insert-after">    }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>runPrompt</em>()</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>runPrompt</em>()</div>
 
 <p>The other reason I pulled the error reporting out here instead of stuffing it
 into the scanner and other phases where the error might occur is to remind you
@@ -359,7 +359,7 @@ punctuation, and literal type.</p>
 <p>After all, string comparison ends up looking at individual characters, and isn&rsquo;t
 that the scanner&rsquo;s job?</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\TokenType.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/TokenType.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -384,7 +384,7 @@ create new file</div>
   <span class="i">EOF</span>
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\TokenType.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/TokenType.java</em>, create new file</div>
 
 <h3><a href="#literal-value" id="literal-value"><small>4&#8202;.&#8202;2&#8202;.&#8202;2</small>Literal value</a></h3>
 <p>There are lexemes for literal values<span class="em">&mdash;</span>numbers and strings and the like. Since
@@ -409,7 +409,7 @@ those, the less time you spend calculating position information ahead of time,
 the better.</p>
 </aside>
 <p>We take all of this data and wrap it in a class.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Token.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Token.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -431,7 +431,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Token.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/Token.java</em>, create new file</div>
 
 <p>Now we have an object with enough structure to be useful for all of the later
 phases of the interpreter.</p>
@@ -483,7 +483,7 @@ mega billionaire among us.</p>
 delegating that task. We&rsquo;re about handcrafted goods.</p>
 <h2><a href="#the-scanner-class" id="the-scanner-class"><small>4&#8202;.&#8202;4</small>The Scanner Class</a></h2>
 <p>Without further ado, let&rsquo;s make ourselves a scanner.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -503,7 +503,7 @@ create new file</div>
   }
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, create new file</div>
 
 <aside name="static-import">
 <p>I know static imports are considered bad style by some, but they save me from
@@ -513,7 +513,7 @@ every character counts in a book.</p>
 <p>We store the raw source code as a simple string, and we have a list ready to
 fill with tokens we&rsquo;re going to generate. The aforementioned loop that does that
 looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>Scanner</em>()</div>
 <pre>  <span class="t">List</span>&lt;<span class="t">Token</span>&gt; <span class="i">scanTokens</span>() {
     <span class="k">while</span> (!<span class="i">isAtEnd</span>()) {
@@ -526,7 +526,7 @@ add after <em>Scanner</em>()</div>
     <span class="k">return</span> <span class="i">tokens</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>Scanner</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>Scanner</em>()</div>
 
 <p>The scanner works its way through the source code, adding tokens until it runs
 out of characters. Then it appends one final &ldquo;end of file&rdquo; token. That isn&rsquo;t
@@ -534,7 +534,7 @@ strictly needed, but it makes our parser a little cleaner.</p>
 <p>This loop depends on a couple of fields to keep track of where the scanner is in
 the source code.</p>
 <div class="codehilite"><pre class="insert-before">  private final List&lt;Token&gt; tokens = new ArrayList&lt;&gt;();
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+</pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in class <em>Scanner</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="t">int</span> <span class="i">start</span> = <span class="n">0</span>;
   <span class="k">private</span> <span class="t">int</span> <span class="i">current</span> = <span class="n">0</span>;
@@ -543,7 +543,7 @@ in class <em>Scanner</em></div>
 
   Scanner(String source) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in class <em>Scanner</em></div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, in class <em>Scanner</em></div>
 
 <p>The <code>start</code> and <code>current</code> fields are offsets that index into the string. The
 <code>start</code> field points to the first character in the lexeme being scanned, and
@@ -552,13 +552,13 @@ tracks what source line <code>current</code> is on so we can produce tokens that
 location.</p>
 <p>Then we have one little helper function that tells us if we&rsquo;ve consumed all the
 characters.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>scanTokens</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isAtEnd</span>() {
     <span class="k">return</span> <span class="i">current</span> &gt;= <span class="i">source</span>.<span class="i">length</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>scanTokens</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>scanTokens</em>()</div>
 
 <h2><a href="#recognizing-lexemes" id="recognizing-lexemes"><small>4&#8202;.&#8202;5</small>Recognizing Lexemes</a></h2>
 <p>In each turn of the loop, we scan a single token. This is the real heart of the
@@ -566,7 +566,7 @@ scanner. We&rsquo;ll start simple. Imagine if every lexeme were only a single ch
 long. All you would need to do is consume the next character and pick a token type for
 it. Several lexemes <em>are</em> only a single character in Lox, so let&rsquo;s start with
 those.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>scanTokens</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">scanToken</span>() {
     <span class="t">char</span> <span class="i">c</span> = <span class="i">advance</span>();
@@ -584,13 +584,13 @@ add after <em>scanTokens</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>scanTokens</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>scanTokens</em>()</div>
 
 <aside name="slash">
 <p>Wondering why <code>/</code> isn&rsquo;t in here? Don&rsquo;t worry, we&rsquo;ll get to it.</p>
 </aside>
 <p>Again, we need a couple of helper methods.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>isAtEnd</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">char</span> <span class="i">advance</span>() {
     <span class="k">return</span> <span class="i">source</span>.<span class="i">charAt</span>(<span class="i">current</span>++);
@@ -605,7 +605,7 @@ add after <em>isAtEnd</em>()</div>
     <span class="i">tokens</span>.<span class="i">add</span>(<span class="k">new</span> <span class="t">Token</span>(<span class="i">type</span>, <span class="i">text</span>, <span class="i">literal</span>, <span class="i">line</span>));
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>isAtEnd</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>isAtEnd</em>()</div>
 
 <p>The <code>advance()</code> method consumes the next character in the source file and
 returns it. Where <code>advance()</code> is for input, <code>addToken()</code> is for output. It grabs
@@ -619,7 +619,7 @@ characters get silently discarded. They aren&rsquo;t used by the Lox language, b
 that doesn&rsquo;t mean the interpreter can pretend they aren&rsquo;t there. Instead, we
 report an error.</p>
 <div class="codehilite"><pre class="insert-before">      case '*': addToken(STAR); break;<span name="slash"> </span>
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+</pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">
 
@@ -628,7 +628,7 @@ in <em>scanToken</em>()</div>
         <span class="k">break</span>;
 </pre><pre class="insert-after">    }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>()</div>
 
 <p>Note that the erroneous character is still <em>consumed</em> by the earlier call to
 <code>advance()</code>. That&rsquo;s important so that we don&rsquo;t get stuck in an infinite loop.</p>
@@ -656,7 +656,7 @@ can all be followed by <code>=</code> to create the other equality and compariso
 operators.</p>
 <p>For all of these, we need to look at the second character.</p>
 <div class="codehilite"><pre class="insert-before">      case '*': addToken(STAR); break;<span name="slash"> </span>
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+</pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="s">&#39;!&#39;</span>:
         <span class="i">addToken</span>(<span class="i">match</span>(<span class="s">&#39;=&#39;</span>) ? <span class="i">BANG_EQUAL</span> : <span class="i">BANG</span>);
@@ -674,10 +674,10 @@ in <em>scanToken</em>()</div>
 
       default:
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>()</div>
 
 <p>Those cases use this new method:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>scanToken</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">match</span>(<span class="t">char</span> <span class="i">expected</span>) {
     <span class="k">if</span> (<span class="i">isAtEnd</span>()) <span class="k">return</span> <span class="k">false</span>;
@@ -687,7 +687,7 @@ add after <em>scanToken</em>()</div>
     <span class="k">return</span> <span class="k">true</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>scanToken</em>()</div>
 
 <p>It&rsquo;s like a conditional <code>advance()</code>. We only consume the current character if
 it&rsquo;s what we&rsquo;re looking for.</p>
@@ -699,7 +699,7 @@ merely a <code>!</code>.</p>
 <p>We&rsquo;re still missing one operator: <code>/</code> for division. That character needs a
 little special handling because comments begin with a slash too.</p>
 <div class="codehilite"><pre class="insert-before">        break;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+</pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">      <span class="k">case</span> <span class="s">&#39;/&#39;</span>:
         <span class="k">if</span> (<span class="i">match</span>(<span class="s">&#39;/&#39;</span>)) {
@@ -713,7 +713,7 @@ in <em>scanToken</em>()</div>
 
       default:
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>()</div>
 
 <p>This is similar to the other two-character operators, except that when we find a
 second <code>/</code>, we don&rsquo;t end the token yet. Instead, we keep consuming characters
@@ -722,14 +722,14 @@ until we reach the end of the line.</p>
 beginning of one, we shunt over to some lexeme-specific code that keeps eating
 characters until it sees the end.</p>
 <p>We&rsquo;ve got another helper:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>match</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">char</span> <span class="i">peek</span>() {
     <span class="k">if</span> (<span class="i">isAtEnd</span>()) <span class="k">return</span> <span class="s">&#39;\0&#39;</span>;
     <span class="k">return</span> <span class="i">source</span>.<span class="i">charAt</span>(<span class="i">current</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>match</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>match</em>()</div>
 
 <p>It&rsquo;s sort of like <code>advance()</code>, but doesn&rsquo;t consume the character. This is called
 <span name="match"><strong>lookahead</strong></span>. Since it only looks at the current
@@ -748,7 +748,7 @@ reset and the comment&rsquo;s lexeme disappears in a puff of smoke.</p>
 <p>While we&rsquo;re at it, now&rsquo;s a good time to skip over those other meaningless
 characters: newlines and whitespace.</p>
 <div class="codehilite"><pre class="insert-before">        break;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+</pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">
 
@@ -766,7 +766,7 @@ in <em>scanToken</em>()</div>
       default:
         Lox.error(line, &quot;Unexpected character.&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>()</div>
 
 <p>When encountering whitespace, we simply go back to the beginning of the scan
 loop. That starts a new lexeme <em>after</em> the whitespace character. For newlines,
@@ -782,7 +782,7 @@ that newline to get us here so we can update <code>line</code>.)</p>
 <p>Now that we&rsquo;re comfortable with longer lexemes, we&rsquo;re ready to tackle literals.
 We&rsquo;ll do strings first, since they always begin with a specific character, <code>"</code>.</p>
 <div class="codehilite"><pre class="insert-before">        break;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+</pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">
 
@@ -791,10 +791,10 @@ in <em>scanToken</em>()</div>
 
       default:
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>()</div>
 
 <p>That calls:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>scanToken</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">string</span>() {
     <span class="k">while</span> (<span class="i">peek</span>() != <span class="s">&#39;&quot;&#39;</span> &amp;&amp; !<span class="i">isAtEnd</span>()) {
@@ -815,7 +815,7 @@ add after <em>scanToken</em>()</div>
     <span class="i">addToken</span>(<span class="i">STRING</span>, <span class="i">value</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>scanToken</em>()</div>
 
 <p>Like with comments, we consume characters until we hit the <code>"</code> that ends the
 string. We also gracefully handle running out of input before the string is
@@ -861,7 +861,7 @@ latter gets weird if we ever want to allow methods on numbers like <code>123.sqr
 of tedious to add cases for every decimal digit, so we&rsquo;ll stuff it in the
 default case instead.</p>
 <div class="codehilite"><pre class="insert-before">      default:
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+</pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()<br>
 replace 1 line</div>
 <pre class="insert">        <span class="k">if</span> (<span class="i">isDigit</span>(<span class="i">c</span>)) {
@@ -871,16 +871,16 @@ replace 1 line</div>
         }
 </pre><pre class="insert-after">        break;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>scanToken</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>(), replace 1 line</div>
 
 <p>This relies on this little utility:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>peek</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isDigit</span>(<span class="t">char</span> <span class="i">c</span>) {
     <span class="k">return</span> <span class="i">c</span> &gt;= <span class="s">&#39;0&#39;</span> &amp;&amp; <span class="i">c</span> &lt;= <span class="s">&#39;9&#39;</span>;
   }<span name="is-digit"> </span>
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>peek</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>peek</em>()</div>
 
 <aside name="is-digit">
 <p>The Java standard library provides <a href="http://docs.oracle.com/javase/7/docs/api/java/lang/Character.html#isDigit(char)"><code>Character.isDigit()</code></a>, which seems
@@ -889,7 +889,7 @@ full-width numbers, and other funny stuff we don&rsquo;t want.</p>
 </aside>
 <p>Once we know we are in a number, we branch to a separate method to consume the
 rest of the literal, like we do with strings.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>scanToken</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">number</span>() {
     <span class="k">while</span> (<span class="i">isDigit</span>(<span class="i">peek</span>())) <span class="i">advance</span>();
@@ -906,7 +906,7 @@ add after <em>scanToken</em>()</div>
         <span class="t">Double</span>.<span class="i">parseDouble</span>(<span class="i">source</span>.<span class="i">substring</span>(<span class="i">start</span>, <span class="i">current</span>)));
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>scanToken</em>()</div>
 
 <p>We consume as many digits as we find for the integer part of the literal. Then
 we look for a fractional part, which is a decimal point (<code>.</code>) followed by at
@@ -915,14 +915,14 @@ digits as we can find.</p>
 <p>Looking past the decimal point requires a second character of lookahead since we
 don&rsquo;t want to consume the <code>.</code> until we&rsquo;re sure there is a digit <em>after</em> it. So
 we add:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>peek</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">char</span> <span class="i">peekNext</span>() {
     <span class="k">if</span> (<span class="i">current</span> + <span class="n">1</span> &gt;= <span class="i">source</span>.<span class="i">length</span>()) <span class="k">return</span> <span class="s">&#39;\0&#39;</span>;
     <span class="k">return</span> <span class="i">source</span>.<span class="i">charAt</span>(<span class="i">current</span> + <span class="n">1</span>);
   }<span name="peek-next"> </span>
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>peek</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>peek</em>()</div>
 
 <aside name="peek-next">
 <p>I could have made <code>peek()</code> take a parameter for the number of characters ahead
@@ -982,7 +982,7 @@ identifier.</p>
 <div class="codehilite"><pre class="insert-before">      default:
         if (isDigit(c)) {
           number();
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+</pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>scanToken</em>()</div>
 <pre class="insert">        } <span class="k">else</span> <span class="k">if</span> (<span class="i">isAlpha</span>(<span class="i">c</span>)) {
           <span class="i">identifier</span>();
@@ -990,10 +990,10 @@ in <em>scanToken</em>()</div>
           Lox.error(line, &quot;Unexpected character.&quot;);
         }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>scanToken</em>()</div>
 
 <p>The rest of the code lives over here:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>scanToken</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">identifier</span>() {
     <span class="k">while</span> (<span class="i">isAlphaNumeric</span>(<span class="i">peek</span>())) <span class="i">advance</span>();
@@ -1001,10 +1001,10 @@ add after <em>scanToken</em>()</div>
     <span class="i">addToken</span>(<span class="i">IDENTIFIER</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>scanToken</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>scanToken</em>()</div>
 
 <p>We define that in terms of these helpers:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
 add after <em>peekNext</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">boolean</span> <span class="i">isAlpha</span>(<span class="t">char</span> <span class="i">c</span>) {
     <span class="k">return</span> (<span class="i">c</span> &gt;= <span class="s">&#39;a&#39;</span> &amp;&amp; <span class="i">c</span> &lt;= <span class="s">&#39;z&#39;</span>) ||
@@ -1016,12 +1016,12 @@ add after <em>peekNext</em>()</div>
     <span class="k">return</span> <span class="i">isAlpha</span>(<span class="i">c</span>) || <span class="i">isDigit</span>(<span class="i">c</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, add after <em>peekNext</em>()</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, add after <em>peekNext</em>()</div>
 
 <p>That gets identifiers working. To handle keywords, we see if the identifier&rsquo;s
 lexeme is one of the reserved words. If so, we use a token type specific to that
 keyword. We define the set of reserved words in a map.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Scanner.java</em><br>
 in class <em>Scanner</em></div>
 <pre>  <span class="k">private</span> <span class="k">static</span> <span class="k">final</span> <span class="t">Map</span>&lt;<span class="t">String</span>, <span class="t">TokenType</span>&gt; <span class="i">keywords</span>;
 
@@ -1045,13 +1045,13 @@ in class <em>Scanner</em></div>
     <span class="i">keywords</span>.<span class="i">put</span>(<span class="s">&quot;while&quot;</span>,  <span class="i">WHILE</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in class <em>Scanner</em></div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, in class <em>Scanner</em></div>
 
 <p>Then, after we scan an identifier, we check to see if it matches anything in the
 map.</p>
 <div class="codehilite"><pre class="insert-before">    while (isAlphaNumeric(peek())) advance();
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Scanner.java</em><br>
+</pre><div class="source-file"><em>lox/Scanner.java</em><br>
 in <em>identifier</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">String</span> <span class="i">text</span> = <span class="i">source</span>.<span class="i">substring</span>(<span class="i">start</span>, <span class="i">current</span>);
@@ -1060,7 +1060,7 @@ replace 1 line</div>
     <span class="i">addToken</span>(<span class="i">type</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Scanner.java</em>, in <em>identifier</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Scanner.java</em>, in <em>identifier</em>(), replace 1 line</div>
 
 <p>If so, we use that keyword&rsquo;s token type. Otherwise, it&rsquo;s a regular user-defined
 identifier.</p>

--- a/site/statements-and-state.html
+++ b/site/statements-and-state.html
@@ -196,7 +196,7 @@ chapters.</p>
 </aside>
 <div class="codehilite"><pre class="insert-before">      &quot;Unary    : Token operator, Expr right&quot;
     ));
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">
 
@@ -206,7 +206,7 @@ in <em>main</em>()</div>
     ));
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="stmt-ast">
 <p>The generated code for the new nodes is in <a href="appendix-ii.html">Appendix II</a>: <a href="appendix-ii.html#expression-statement">Expression statement</a>, <a href="appendix-ii.html#print-statement">Print statement</a>.</p>
@@ -218,7 +218,7 @@ to add the file to your IDE project or makefile or whatever.</p>
 <p>The parser&rsquo;s <code>parse()</code> method that parses and returns a single expression was a
 temporary hack to get the last chapter up and running. Now that our grammar has
 the correct starting rule, <code>program</code>, we can turn <code>parse()</code> into the real deal.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 method <em>parse</em>()<br>
 replace 7 lines</div>
 <pre>  <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">parse</span>() {
@@ -230,7 +230,7 @@ replace 7 lines</div>
     <span class="k">return</span> <span class="i">statements</span>;<span name="parse-error-handling"> </span>
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, method <em>parse</em>(), replace 7 lines</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, method <em>parse</em>(), replace 7 lines</div>
 
 <aside name="parse-error-handling">
 <p>What about the code we had in here for catching <code>ParseError</code> exceptions? We&rsquo;ll
@@ -243,15 +243,15 @@ recursive descent style. We must also chant a minor prayer to the Java verbosity
 gods since we are using ArrayList now.</p>
 <div class="codehilite"><pre class="insert-before">package com.craftinginterpreters.lox;
 
-</pre><div class="source-file"><em>lox/Parser.java</em></div>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em></div>
 <pre class="insert"><span class="k">import</span> <span class="i">java.util.ArrayList</span>;
 </pre><pre class="insert-after">import java.util.List;
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em></div>
 
 <p>A program is a list of statements, and we parse one of those statements using
 this method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>expression</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">statement</span>() {
     <span class="k">if</span> (<span class="i">match</span>(<span class="i">PRINT</span>)) <span class="k">return</span> <span class="i">printStatement</span>();
@@ -259,7 +259,7 @@ add after <em>expression</em>()</div>
     <span class="k">return</span> <span class="i">expressionStatement</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>expression</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>expression</em>()</div>
 
 <p>A little bare bones, but we&rsquo;ll fill it in with more statement types later. We
 determine which specific statement rule is matched by looking at the current
@@ -269,7 +269,7 @@ must be an expression statement. That&rsquo;s the typical final fallthrough case
 parsing a statement, since it&rsquo;s hard to proactively recognize an expression from
 its first token.</p>
 <p>Each statement kind gets its own method. First <code>print</code>:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>statement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">printStatement</span>() {
     <span class="t">Expr</span> <span class="i">value</span> = <span class="i">expression</span>();
@@ -277,13 +277,13 @@ add after <em>statement</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Print</span>(<span class="i">value</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>statement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>statement</em>()</div>
 
 <p>Since we already matched and consumed the <code>print</code> token itself, we don&rsquo;t need to
 do that here. We parse the subsequent expression, consume the terminating
 semicolon, and emit the syntax tree.</p>
 <p>If we didn&rsquo;t match a <code>print</code> statement, we must have one of these:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>printStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">expressionStatement</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">expression</span>();
@@ -291,7 +291,7 @@ add after <em>printStatement</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Expression</span>(<span class="i">expr</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>printStatement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>printStatement</em>()</div>
 
 <p>Similar to the previous method, we parse an expression followed by a semicolon.
 We wrap that Expr in a Stmt of the right type and return it.</p>
@@ -302,13 +302,13 @@ the next and final step is to interpret them. As in expressions, we use the
 Visitor pattern, but we have a new visitor interface, Stmt.Visitor, to
 implement since statements have their own base class.</p>
 <p>We add that to the list of interfaces Interpreter implements.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 replace 1 line</div>
 <pre class="insert"><span class="k">class</span> <span class="t">Interpreter</span> <span class="k">implements</span> <span class="t">Expr</span>.<span class="t">Visitor</span>&lt;<span class="t">Object</span>&gt;,
                              <span class="t">Stmt</span>.<span class="t">Visitor</span>&lt;<span class="t">Void</span>&gt; {
 </pre><pre class="insert-after">  void interpret(Expr expression) {<span name="void"> </span>
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, replace 1 line</div>
 
 <aside name="void">
 <p>Java doesn&rsquo;t let you use lowercase &ldquo;void&rdquo; as a generic type argument for obscure
@@ -319,7 +319,7 @@ separate &ldquo;Void&rdquo; type specifically for this use. Sort of a &ldquo;box
 <p>Unlike expressions, statements produce no values, so the return type of the
 visit methods is Void, not Object. We have two statement types, and we need a
 visit method for each. The easiest is expression statements.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>evaluate</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitExpressionStmt</span>(<span class="t">Stmt</span>.<span class="t">Expression</span> <span class="i">stmt</span>) {
@@ -327,7 +327,7 @@ add after <em>evaluate</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>evaluate</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>evaluate</em>()</div>
 
 <p>We evaluate the inner expression using our existing <code>evaluate()</code> method and
 <span name="discard">discard</span> the value. Then we return <code>null</code>. Java
@@ -338,7 +338,7 @@ what can you do?</p>
 that call inside a <em>Java</em> expression statement.</p>
 </aside>
 <p>The <code>print</code> statement&rsquo;s visit method isn&rsquo;t much different.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitExpressionStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitPrintStmt</span>(<span class="t">Stmt</span>.<span class="t">Print</span> <span class="i">stmt</span>) {
@@ -347,7 +347,7 @@ add after <em>visitExpressionStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitExpressionStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitExpressionStmt</em>()</div>
 
 <p>Before discarding the expression&rsquo;s value, we convert it to a string using the
 <code>stringify()</code> method we introduced in the last chapter and then dump it to
@@ -355,7 +355,7 @@ stdout.</p>
 <p>Our interpreter is able to visit statements now, but we have some work to do to
 feed them to it. First, modify the old <code>interpret()</code> method in the Interpreter
 class to accept a list of statements<span class="em">&mdash;</span>in other words, a program.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 method <em>interpret</em>()<br>
 replace 8 lines</div>
 <pre>  <span class="t">void</span> <span class="i">interpret</span>(<span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span>) {
@@ -368,22 +368,22 @@ replace 8 lines</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, method <em>interpret</em>(), replace 8 lines</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, method <em>interpret</em>(), replace 8 lines</div>
 
 <p>This replaces the old code which took a single expression. The new code relies
 on this tiny helper method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>evaluate</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">execute</span>(<span class="t">Stmt</span> <span class="i">stmt</span>) {
     <span class="i">stmt</span>.<span class="i">accept</span>(<span class="k">this</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>evaluate</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>evaluate</em>()</div>
 
 <p>That&rsquo;s the statement analogue to the <code>evaluate()</code> method we have for
 expressions. Since we&rsquo;re working with lists now, we need to let Java know.</p>
 <div class="codehilite"><pre class="insert-before">package com.craftinginterpreters.lox;
-</pre><div class="source-file"><em>lox/Interpreter.java</em></div>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
 <pre class="insert">
 
 <span class="k">import</span> <span class="i">java.util.List</span>;
@@ -391,12 +391,12 @@ expressions. Since we&rsquo;re working with lists now, we need to let Java know.
 
 class Interpreter implements Expr.Visitor&lt;Object&gt;,
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
 
 <p>The main Lox class is still trying to parse a single expression and pass it to
 the interpreter. We fix the parsing line like so:</p>
 <div class="codehilite"><pre class="insert-before">    Parser parser = new Parser(tokens);
-</pre><div class="source-file"><em>lox/Lox.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 in <em>run</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span> = <span class="i">parser</span>.<span class="i">parse</span>();
@@ -404,18 +404,18 @@ replace 1 line</div>
 
     // Stop if there was a syntax error.
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>run</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>run</em>(), replace 1 line</div>
 
 <p>And then replace the call to the interpreter with this:</p>
 <div class="codehilite"><pre class="insert-before">    if (hadError) return;
 
-</pre><div class="source-file"><em>lox/Lox.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
 in <em>run</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="i">interpreter</span>.<span class="i">interpret</span>(<span class="i">statements</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>run</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>run</em>(), replace 1 line</div>
 
 <p>Basically just plumbing the new syntax through. OK, fire up the interpreter and
 give it a try. At this point, it&rsquo;s worth sketching out a little Lox program in a
@@ -524,13 +524,13 @@ generator, we add a <span name="var-stmt-ast">new statement</span> node for a
 variable declaration.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Expression : Expr expression&quot;,
 </pre><pre class="insert-before">      <span class="s">&quot;Print      : Expr expression&quot;</span><span class="insert-comma">,</span>
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()<br>
 add <em>&ldquo;,&rdquo;</em> to previous line</div>
 <pre class="insert">      <span class="s">&quot;Var        : Token name, Expr initializer&quot;</span>
 </pre><pre class="insert-after">    ));
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>(), add <em>&ldquo;,&rdquo;</em> to previous line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>(), add <em>&ldquo;,&rdquo;</em> to previous line</div>
 
 <aside name="var-stmt-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#variable-statement">Appendix II</a>.</p>
@@ -540,13 +540,13 @@ initializer expression. (If there isn&rsquo;t an initializer, that field is <cod
 <p>Then we add an expression node for accessing a variable.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Literal  : Object value&quot;,
 </pre><pre class="insert-before">      <span class="s">&quot;Unary    : Token operator, Expr right&quot;</span><span class="insert-comma">,</span>
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()<br>
 add <em>&ldquo;,&rdquo;</em> to previous line</div>
 <pre class="insert">      <span class="s">&quot;Variable : Token name&quot;</span>
 </pre><pre class="insert-after">    ));
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>(), add <em>&ldquo;,&rdquo;</em> to previous line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>(), add <em>&ldquo;,&rdquo;</em> to previous line</div>
 
 <p><span name="var-expr-ast">It&rsquo;s</span> simply a wrapper around the token for the
 variable name. That&rsquo;s it. As always, don&rsquo;t forget to run the AST generator
@@ -561,7 +561,7 @@ is now a list of declarations, so the entrypoint method to the parser changes.</
 <div class="codehilite"><pre class="insert-before">  List&lt;Stmt&gt; parse() {
     List&lt;Stmt&gt; statements = new ArrayList&lt;&gt;();
     while (!isAtEnd()) {
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>parse</em>()<br>
 replace 1 line</div>
 <pre class="insert">      <span class="i">statements</span>.<span class="i">add</span>(<span class="i">declaration</span>());
@@ -570,10 +570,10 @@ replace 1 line</div>
     return statements;<span name="parse-error-handling"> </span>
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>parse</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>parse</em>(), replace 1 line</div>
 
 <p>That calls this new method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>expression</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">declaration</span>() {
     <span class="k">try</span> {
@@ -586,7 +586,7 @@ add after <em>expression</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>expression</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>expression</em>()</div>
 
 <p>Hey, do you remember way back in that <a href="parsing-expressions.html">earlier chapter</a> when we put the
 infrastructure in place to do error recovery? We are finally ready to hook that
@@ -606,7 +606,7 @@ statement matches? And <code>expression()</code> reports a syntax error if it ca
 an expression at the current token? That chain of calls ensures we report an
 error if a valid declaration or statement isn&rsquo;t parsed.</p>
 <p>When the parser matches a <code>var</code> token, it branches to:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>printStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">varDeclaration</span>() {
     <span class="t">Token</span> <span class="i">name</span> = <span class="i">consume</span>(<span class="i">IDENTIFIER</span>, <span class="s">&quot;Expect variable name.&quot;</span>);
@@ -620,7 +620,7 @@ add after <em>printStatement</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Var</span>(<span class="i">name</span>, <span class="i">initializer</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>printStatement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>printStatement</em>()</div>
 
 <p>As always, the recursive descent code follows the grammar rule. The parser has
 already matched the <code>var</code> token, so next it requires and consumes an identifier
@@ -633,7 +633,7 @@ Stmt.Var syntax tree node and we&rsquo;re groovy.</p>
 identifier token.</p>
 <div class="codehilite"><pre class="insert-before">      return new Expr.Literal(previous().literal);
     }
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>primary</em>()</div>
 <pre class="insert">
 
@@ -644,7 +644,7 @@ in <em>primary</em>()</div>
 
     if (match(LEFT_PAREN)) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>primary</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>primary</em>()</div>
 
 <p>That gives us a working front end for declaring and using variables. All that&rsquo;s
 left is to feed it into the interpreter. Before we get to that, we need to talk
@@ -669,7 +669,7 @@ tables</strong>, <strong>dictionaries</strong> (Python and C#), <strong>hashes</
 <strong>tables</strong> (Lua), or <strong>associative arrays</strong> (PHP). Way back when, they were
 known as <strong>scatter tables</strong>.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -680,7 +680,7 @@ create new file</div>
   <span class="k">private</span> <span class="k">final</span> <span class="t">Map</span>&lt;<span class="t">String</span>, <span class="t">Object</span>&gt; <span class="i">values</span> = <span class="k">new</span> <span class="t">HashMap</span>&lt;&gt;();
 }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Environment.java</em>, create new file</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, create new file</div>
 
 <p>There&rsquo;s a Java Map in there to store the bindings. It uses bare strings for the
 keys, not tokens. A token represents a unit of code at a specific place in the
@@ -689,13 +689,13 @@ with the same name should refer to the same variable (ignoring scope for now).
 Using the raw string ensures all of those tokens refer to the same map key.</p>
 <p>There are two operations we need to support. First, a variable definition binds
 a new name to a value.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
 in class <em>Environment</em></div>
 <pre>  <span class="t">void</span> <span class="i">define</span>(<span class="t">String</span> <span class="i">name</span>, <span class="t">Object</span> <span class="i">value</span>) {
     <span class="i">values</span>.<span class="i">put</span>(<span class="i">name</span>, <span class="i">value</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Environment.java</em>, in class <em>Environment</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, in class <em>Environment</em></div>
 
 <p>Not exactly brain surgery, but we have made one interesting semantic choice.
 When we add the key to the map, we don&rsquo;t check to see if it&rsquo;s already present.
@@ -727,7 +727,7 @@ footsteps.</p>
 variables. Once a variable exists, we need a way to look it up.</p>
 <div class="codehilite"><pre class="insert-before">class Environment {
   private final Map&lt;String, Object&gt; values = new HashMap&lt;&gt;();
-</pre><div class="source-file"><em>lox/Environment.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
 in class <em>Environment</em></div>
 <pre class="insert">
 
@@ -742,7 +742,7 @@ in class <em>Environment</em></div>
 
 </pre><pre class="insert-after">  void define(String name, Object value) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Environment.java</em>, in class <em>Environment</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, in class <em>Environment</em></div>
 
 <p>This is a little more semantically interesting. If the variable is found, it
 simply returns the value bound to it. But what if it&rsquo;s not? Again, we have a
@@ -817,19 +817,19 @@ tell the user where in their code they messed up.</p>
 <p>The Interpreter class gets an instance of the new Environment class.</p>
 <div class="codehilite"><pre class="insert-before">class Interpreter implements Expr.Visitor&lt;Object&gt;,
                              Stmt.Visitor&lt;Void&gt; {
-</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="t">Environment</span> <span class="i">environment</span> = <span class="k">new</span> <span class="t">Environment</span>();
 
 </pre><pre class="insert-after">  void interpret(List&lt;Stmt&gt; statements) {
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em></div>
 
 <p>We store it as a field directly in Interpreter so that the variables stay in
 memory as long as the interpreter is still running.</p>
 <p>We have two new syntax trees, so that&rsquo;s two new visit methods. The first is for
 declaration statements.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitPrintStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitVarStmt</span>(<span class="t">Stmt</span>.<span class="t">Var</span> <span class="i">stmt</span>) {
@@ -842,7 +842,7 @@ add after <em>visitPrintStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitPrintStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitPrintStmt</em>()</div>
 
 <p>If the variable has an initializer, we evaluate it. If not, we have another
 choice to make. We could have made this a syntax error in the parser by
@@ -860,14 +860,14 @@ explicitly initialized.</p>
 Java representation of Lox&rsquo;s <code>nil</code> value. Then we tell the environment to bind
 the variable to that value.</p>
 <p>Next, we evaluate a variable expression.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitUnaryExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitVariableExpr</span>(<span class="t">Expr</span>.<span class="t">Variable</span> <span class="i">expr</span>) {
     <span class="k">return</span> <span class="i">environment</span>.<span class="i">get</span>(<span class="i">expr</span>.<span class="i">name</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitUnaryExpr</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitUnaryExpr</em>()</div>
 
 <p>This simply forwards to the environment which does the heavy lifting to make
 sure the variable is defined. With that, we&rsquo;ve got rudimentary variables
@@ -919,12 +919,12 @@ objects, like:</p>
 </pre></div>
 <p>The easy part is adding the <span name="assign-ast">new syntax tree node</span>.</p>
 <div class="codehilite"><pre class="insert-before">    defineAst(outputDir, &quot;Expr&quot;, Arrays.asList(
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Assign   : Token name, Expr value&quot;</span>,
 </pre><pre class="insert-after">      &quot;Binary   : Expr left, Token operator, Expr right&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="assign-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#assign-expression">Appendix II</a>.</p>
@@ -934,13 +934,13 @@ value. After you run the AstGenerator to get the new Expr.Assign class, swap out
 the body of the parser&rsquo;s existing <code>expression()</code> method to match the updated
 rule.</p>
 <div class="codehilite"><pre class="insert-before">  private Expr expression() {
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>expression</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="k">return</span> <span class="i">assignment</span>();
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>expression</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>expression</em>(), replace 1 line</div>
 
 <p>Here is where it gets tricky. A single token lookahead recursive descent parser
 can&rsquo;t see far enough to tell that it&rsquo;s parsing an assignment until <em>after</em> it
@@ -977,7 +977,7 @@ tokens of lookahead to find the <code>=</code>.</p>
 </aside>
 <p>We have only a single token of lookahead, so what do we do? We use a little
 trick, and it looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>expressionStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">assignment</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">equality</span>();
@@ -997,7 +997,7 @@ add after <em>expressionStatement</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>expressionStatement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>expressionStatement</em>()</div>
 
 <p>Most of the code for parsing an assignment expression looks similar to that of
 the other binary operators like <code>+</code>. We parse the left-hand side, which can be
@@ -1052,7 +1052,7 @@ that knows what it is assigning to and has an expression subtree for the value
 being assigned. All with only a single token of lookahead and no backtracking.</p>
 <h3><a href="#assignment-semantics" id="assignment-semantics"><small>8&#8202;.&#8202;4&#8202;.&#8202;2</small>Assignment semantics</a></h3>
 <p>We have a new syntax tree node, so our interpreter gets a new visit method.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>visitVarStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitAssignExpr</span>(<span class="t">Expr</span>.<span class="t">Assign</span> <span class="i">expr</span>) {
@@ -1061,12 +1061,12 @@ add after <em>visitVarStmt</em>()</div>
     <span class="k">return</span> <span class="i">value</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitVarStmt</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitVarStmt</em>()</div>
 
 <p>For obvious reasons, it&rsquo;s similar to variable declaration. It evaluates the
 right-hand side to get the value, then stores it in the named variable. Instead
 of using <code>define()</code> on Environment, it calls this new method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
 add after <em>get</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">assign</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">Object</span> <span class="i">value</span>) {
     <span class="k">if</span> (<span class="i">values</span>.<span class="i">containsKey</span>(<span class="i">name</span>.<span class="i">lexeme</span>)) {
@@ -1078,7 +1078,7 @@ add after <em>get</em>()</div>
         <span class="s">&quot;Undefined variable &#39;&quot;</span> + <span class="i">name</span>.<span class="i">lexeme</span> + <span class="s">&quot;&#39;.&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Environment.java</em>, add after <em>get</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, add after <em>get</em>()</div>
 
 <p>The key difference between assignment and definition is that assignment is not
 <span name="new">allowed</span> to create a <em>new</em> variable. In terms of our
@@ -1246,15 +1246,15 @@ much prefer the evocative <strong>cactus stack</strong>.</p><img class="above" s
 with support for this nesting. First, we give each environment a reference to
 its enclosing one.</p>
 <div class="codehilite"><pre class="insert-before">class Environment {
-</pre><div class="source-file"><em>lox/Environment.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
 in class <em>Environment</em></div>
 <pre class="insert">  <span class="k">final</span> <span class="t">Environment</span> <span class="i">enclosing</span>;
 </pre><pre class="insert-after">  private final Map&lt;String, Object&gt; values = new HashMap&lt;&gt;();
 </pre></div>
-<div class="source-file-narrow"><em>lox/Environment.java</em>, in class <em>Environment</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, in class <em>Environment</em></div>
 
 <p>This field needs to be initialized, so we add a couple of constructors.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
 in class <em>Environment</em></div>
 <pre>  <span class="t">Environment</span>() {
     <span class="i">enclosing</span> = <span class="k">null</span>;
@@ -1264,7 +1264,7 @@ in class <em>Environment</em></div>
     <span class="k">this</span>.<span class="i">enclosing</span> = <span class="i">enclosing</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Environment.java</em>, in class <em>Environment</em></div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, in class <em>Environment</em></div>
 
 <p>The no-argument constructor is for the global scope&rsquo;s environment, which ends
 the chain. The other constructor creates a new local scope nested inside the
@@ -1275,7 +1275,7 @@ with existing variables and they need to walk the chain to find them. First,
 lookup:</p>
 <div class="codehilite"><pre class="insert-before">      return values.get(name.lexeme);
     }
-</pre><div class="source-file"><em>lox/Environment.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
 in <em>get</em>()</div>
 <pre class="insert">
 
@@ -1285,7 +1285,7 @@ in <em>get</em>()</div>
     throw new RuntimeError(name,
         &quot;Undefined variable '&quot; + name.lexeme + &quot;'.&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>lox/Environment.java</em>, in <em>get</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, in <em>get</em>()</div>
 
 <p>If the variable isn&rsquo;t found in this environment, we simply try the enclosing
 one. That in turn does the same thing <span name="recurse">recursively</span>,
@@ -1301,7 +1301,7 @@ solution is prettier. We&rsquo;ll do something <em>much</em> faster in clox.</p>
       return;
     }
 
-</pre><div class="source-file"><em>lox/Environment.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
 in <em>assign</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">enclosing</span> != <span class="k">null</span>) {
       <span class="i">enclosing</span>.<span class="i">assign</span>(<span class="i">name</span>, <span class="i">value</span>);
@@ -1310,7 +1310,7 @@ in <em>assign</em>()</div>
 
 </pre><pre class="insert-after">    throw new RuntimeError(name,
 </pre></div>
-<div class="source-file-narrow"><em>lox/Environment.java</em>, in <em>assign</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, in <em>assign</em>()</div>
 
 <p>Again, if the variable isn&rsquo;t in this environment, it checks the outer one,
 recursively.</p>
@@ -1327,12 +1327,12 @@ the grammar:</p>
 curly braces. A block is itself a statement and can appear anywhere a statement
 is allowed. The <span name="block-ast">syntax tree</span> node looks like this:</p>
 <div class="codehilite"><pre class="insert-before">    defineAst(outputDir, &quot;Stmt&quot;, Arrays.asList(
-</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Block      : List&lt;Stmt&gt; statements&quot;</span>,
 </pre><pre class="insert-after">      &quot;Expression : Expr expression&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="block-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#block-statement">Appendix II</a>.</p>
@@ -1345,17 +1345,17 @@ beginning of a block by its leading token<span class="em">&mdash;</span>in this 
 <p>As always, don&rsquo;t forget to run &ldquo;GenerateAst.java&rdquo;.</p>
 </aside>
 <div class="codehilite"><pre class="insert-before">    if (match(PRINT)) return printStatement();
-</pre><div class="source-file"><em>lox/Parser.java</em><br>
+</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">match</span>(<span class="i">LEFT_BRACE</span>)) <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Block</span>(<span class="i">block</span>());
 </pre><pre class="insert-after">
 
     return expressionStatement();
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>statement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>statement</em>()</div>
 
 <p>All the real work happens here:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
 add after <em>expressionStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">block</span>() {
     <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span> = <span class="k">new</span> <span class="t">ArrayList</span>&lt;&gt;();
@@ -1368,7 +1368,7 @@ add after <em>expressionStatement</em>()</div>
     <span class="k">return</span> <span class="i">statements</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>expressionStatement</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>expressionStatement</em>()</div>
 
 <p>We <span name="list">create</span> an empty list and then parse statements and
 add them to the list until we reach the end of the block, marked by the closing
@@ -1382,7 +1382,7 @@ way because we&rsquo;ll reuse <code>block()</code> later for parsing function bo
 want that body wrapped in a Stmt.Block.</p>
 </aside>
 <p>That&rsquo;s it for syntax. For semantics, we add another visit method to Interpreter.</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>execute</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitBlockStmt</span>(<span class="t">Stmt</span>.<span class="t">Block</span> <span class="i">stmt</span>) {
@@ -1390,11 +1390,11 @@ add after <em>execute</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>execute</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>execute</em>()</div>
 
 <p>To execute a block, we create a new environment for the block&rsquo;s scope and pass
 it off to this other method:</p>
-<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
 add after <em>execute</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">executeBlock</span>(<span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span>,
                     <span class="t">Environment</span> <span class="i">environment</span>) {
@@ -1410,7 +1410,7 @@ add after <em>execute</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>execute</em>()</div>
+<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>execute</em>()</div>
 
 <p>This new method executes a list of statements in the context of a given <span
 name="param">environment</span>. Up until now, the <code>environment</code> field in

--- a/site/statements-and-state.html
+++ b/site/statements-and-state.html
@@ -196,7 +196,7 @@ chapters.</p>
 </aside>
 <div class="codehilite"><pre class="insert-before">      &quot;Unary    : Token operator, Expr right&quot;
     ));
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">
 
@@ -206,7 +206,7 @@ in <em>main</em>()</div>
     ));
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="stmt-ast">
 <p>The generated code for the new nodes is in <a href="appendix-ii.html">Appendix II</a>: <a href="appendix-ii.html#expression-statement">Expression statement</a>, <a href="appendix-ii.html#print-statement">Print statement</a>.</p>
@@ -218,7 +218,7 @@ to add the file to your IDE project or makefile or whatever.</p>
 <p>The parser&rsquo;s <code>parse()</code> method that parses and returns a single expression was a
 temporary hack to get the last chapter up and running. Now that our grammar has
 the correct starting rule, <code>program</code>, we can turn <code>parse()</code> into the real deal.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 method <em>parse</em>()<br>
 replace 7 lines</div>
 <pre>  <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">parse</span>() {
@@ -230,7 +230,7 @@ replace 7 lines</div>
     <span class="k">return</span> <span class="i">statements</span>;<span name="parse-error-handling"> </span>
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, method <em>parse</em>(), replace 7 lines</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, method <em>parse</em>(), replace 7 lines</div>
 
 <aside name="parse-error-handling">
 <p>What about the code we had in here for catching <code>ParseError</code> exceptions? We&rsquo;ll
@@ -243,15 +243,15 @@ recursive descent style. We must also chant a minor prayer to the Java verbosity
 gods since we are using ArrayList now.</p>
 <div class="codehilite"><pre class="insert-before">package com.craftinginterpreters.lox;
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em></div>
+</pre><div class="source-file"><em>lox/Parser.java</em></div>
 <pre class="insert"><span class="k">import</span> <span class="i">java.util.ArrayList</span>;
 </pre><pre class="insert-after">import java.util.List;
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em></div>
+<div class="source-file-narrow"><em>lox/Parser.java</em></div>
 
 <p>A program is a list of statements, and we parse one of those statements using
 this method:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>expression</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">statement</span>() {
     <span class="k">if</span> (<span class="i">match</span>(<span class="i">PRINT</span>)) <span class="k">return</span> <span class="i">printStatement</span>();
@@ -259,7 +259,7 @@ add after <em>expression</em>()</div>
     <span class="k">return</span> <span class="i">expressionStatement</span>();
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>expression</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>expression</em>()</div>
 
 <p>A little bare bones, but we&rsquo;ll fill it in with more statement types later. We
 determine which specific statement rule is matched by looking at the current
@@ -269,7 +269,7 @@ must be an expression statement. That&rsquo;s the typical final fallthrough case
 parsing a statement, since it&rsquo;s hard to proactively recognize an expression from
 its first token.</p>
 <p>Each statement kind gets its own method. First <code>print</code>:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>statement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">printStatement</span>() {
     <span class="t">Expr</span> <span class="i">value</span> = <span class="i">expression</span>();
@@ -277,13 +277,13 @@ add after <em>statement</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Print</span>(<span class="i">value</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>statement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>statement</em>()</div>
 
 <p>Since we already matched and consumed the <code>print</code> token itself, we don&rsquo;t need to
 do that here. We parse the subsequent expression, consume the terminating
 semicolon, and emit the syntax tree.</p>
 <p>If we didn&rsquo;t match a <code>print</code> statement, we must have one of these:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>printStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">expressionStatement</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">expression</span>();
@@ -291,7 +291,7 @@ add after <em>printStatement</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Expression</span>(<span class="i">expr</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>printStatement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>printStatement</em>()</div>
 
 <p>Similar to the previous method, we parse an expression followed by a semicolon.
 We wrap that Expr in a Stmt of the right type and return it.</p>
@@ -302,13 +302,13 @@ the next and final step is to interpret them. As in expressions, we use the
 Visitor pattern, but we have a new visitor interface, Stmt.Visitor, to
 implement since statements have their own base class.</p>
 <p>We add that to the list of interfaces Interpreter implements.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 replace 1 line</div>
 <pre class="insert"><span class="k">class</span> <span class="t">Interpreter</span> <span class="k">implements</span> <span class="t">Expr</span>.<span class="t">Visitor</span>&lt;<span class="t">Object</span>&gt;,
                              <span class="t">Stmt</span>.<span class="t">Visitor</span>&lt;<span class="t">Void</span>&gt; {
 </pre><pre class="insert-after">  void interpret(Expr expression) {<span name="void"> </span>
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, replace 1 line</div>
 
 <aside name="void">
 <p>Java doesn&rsquo;t let you use lowercase &ldquo;void&rdquo; as a generic type argument for obscure
@@ -319,7 +319,7 @@ separate &ldquo;Void&rdquo; type specifically for this use. Sort of a &ldquo;box
 <p>Unlike expressions, statements produce no values, so the return type of the
 visit methods is Void, not Object. We have two statement types, and we need a
 visit method for each. The easiest is expression statements.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>evaluate</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitExpressionStmt</span>(<span class="t">Stmt</span>.<span class="t">Expression</span> <span class="i">stmt</span>) {
@@ -327,7 +327,7 @@ add after <em>evaluate</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>evaluate</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>evaluate</em>()</div>
 
 <p>We evaluate the inner expression using our existing <code>evaluate()</code> method and
 <span name="discard">discard</span> the value. Then we return <code>null</code>. Java
@@ -338,7 +338,7 @@ what can you do?</p>
 that call inside a <em>Java</em> expression statement.</p>
 </aside>
 <p>The <code>print</code> statement&rsquo;s visit method isn&rsquo;t much different.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitExpressionStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitPrintStmt</span>(<span class="t">Stmt</span>.<span class="t">Print</span> <span class="i">stmt</span>) {
@@ -347,7 +347,7 @@ add after <em>visitExpressionStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitExpressionStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitExpressionStmt</em>()</div>
 
 <p>Before discarding the expression&rsquo;s value, we convert it to a string using the
 <code>stringify()</code> method we introduced in the last chapter and then dump it to
@@ -355,7 +355,7 @@ stdout.</p>
 <p>Our interpreter is able to visit statements now, but we have some work to do to
 feed them to it. First, modify the old <code>interpret()</code> method in the Interpreter
 class to accept a list of statements<span class="em">&mdash;</span>in other words, a program.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 method <em>interpret</em>()<br>
 replace 8 lines</div>
 <pre>  <span class="t">void</span> <span class="i">interpret</span>(<span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span>) {
@@ -368,22 +368,22 @@ replace 8 lines</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, method <em>interpret</em>(), replace 8 lines</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, method <em>interpret</em>(), replace 8 lines</div>
 
 <p>This replaces the old code which took a single expression. The new code relies
 on this tiny helper method:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>evaluate</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">void</span> <span class="i">execute</span>(<span class="t">Stmt</span> <span class="i">stmt</span>) {
     <span class="i">stmt</span>.<span class="i">accept</span>(<span class="k">this</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>evaluate</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>evaluate</em>()</div>
 
 <p>That&rsquo;s the statement analogue to the <code>evaluate()</code> method we have for
 expressions. Since we&rsquo;re working with lists now, we need to let Java know.</p>
 <div class="codehilite"><pre class="insert-before">package com.craftinginterpreters.lox;
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
+</pre><div class="source-file"><em>lox/Interpreter.java</em></div>
 <pre class="insert">
 
 <span class="k">import</span> <span class="i">java.util.List</span>;
@@ -391,12 +391,12 @@ expressions. Since we&rsquo;re working with lists now, we need to let Java know.
 
 class Interpreter implements Expr.Visitor&lt;Object&gt;,
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em></div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em></div>
 
 <p>The main Lox class is still trying to parse a single expression and pass it to
 the interpreter. We fix the parsing line like so:</p>
 <div class="codehilite"><pre class="insert-before">    Parser parser = new Parser(tokens);
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+</pre><div class="source-file"><em>lox/Lox.java</em><br>
 in <em>run</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span> = <span class="i">parser</span>.<span class="i">parse</span>();
@@ -404,18 +404,18 @@ replace 1 line</div>
 
     // Stop if there was a syntax error.
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>run</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>run</em>(), replace 1 line</div>
 
 <p>And then replace the call to the interpreter with this:</p>
 <div class="codehilite"><pre class="insert-before">    if (hadError) return;
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Lox.java</em><br>
+</pre><div class="source-file"><em>lox/Lox.java</em><br>
 in <em>run</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="i">interpreter</span>.<span class="i">interpret</span>(<span class="i">statements</span>);
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Lox.java</em>, in <em>run</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Lox.java</em>, in <em>run</em>(), replace 1 line</div>
 
 <p>Basically just plumbing the new syntax through. OK, fire up the interpreter and
 give it a try. At this point, it&rsquo;s worth sketching out a little Lox program in a
@@ -524,13 +524,13 @@ generator, we add a <span name="var-stmt-ast">new statement</span> node for a
 variable declaration.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Expression : Expr expression&quot;,
 </pre><pre class="insert-before">      <span class="s">&quot;Print      : Expr expression&quot;</span><span class="insert-comma">,</span>
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()<br>
 add <em>&ldquo;,&rdquo;</em> to previous line</div>
 <pre class="insert">      <span class="s">&quot;Var        : Token name, Expr initializer&quot;</span>
 </pre><pre class="insert-after">    ));
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>(), add <em>&ldquo;,&rdquo;</em> to previous line</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>(), add <em>&ldquo;,&rdquo;</em> to previous line</div>
 
 <aside name="var-stmt-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#variable-statement">Appendix II</a>.</p>
@@ -540,13 +540,13 @@ initializer expression. (If there isn&rsquo;t an initializer, that field is <cod
 <p>Then we add an expression node for accessing a variable.</p>
 <div class="codehilite"><pre class="insert-before">      &quot;Literal  : Object value&quot;,
 </pre><pre class="insert-before">      <span class="s">&quot;Unary    : Token operator, Expr right&quot;</span><span class="insert-comma">,</span>
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()<br>
 add <em>&ldquo;,&rdquo;</em> to previous line</div>
 <pre class="insert">      <span class="s">&quot;Variable : Token name&quot;</span>
 </pre><pre class="insert-after">    ));
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>(), add <em>&ldquo;,&rdquo;</em> to previous line</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>(), add <em>&ldquo;,&rdquo;</em> to previous line</div>
 
 <p><span name="var-expr-ast">It&rsquo;s</span> simply a wrapper around the token for the
 variable name. That&rsquo;s it. As always, don&rsquo;t forget to run the AST generator
@@ -561,7 +561,7 @@ is now a list of declarations, so the entrypoint method to the parser changes.</
 <div class="codehilite"><pre class="insert-before">  List&lt;Stmt&gt; parse() {
     List&lt;Stmt&gt; statements = new ArrayList&lt;&gt;();
     while (!isAtEnd()) {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>parse</em>()<br>
 replace 1 line</div>
 <pre class="insert">      <span class="i">statements</span>.<span class="i">add</span>(<span class="i">declaration</span>());
@@ -570,10 +570,10 @@ replace 1 line</div>
     return statements;<span name="parse-error-handling"> </span>
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>parse</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>parse</em>(), replace 1 line</div>
 
 <p>That calls this new method:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>expression</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">declaration</span>() {
     <span class="k">try</span> {
@@ -586,7 +586,7 @@ add after <em>expression</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>expression</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>expression</em>()</div>
 
 <p>Hey, do you remember way back in that <a href="parsing-expressions.html">earlier chapter</a> when we put the
 infrastructure in place to do error recovery? We are finally ready to hook that
@@ -606,7 +606,7 @@ statement matches? And <code>expression()</code> reports a syntax error if it ca
 an expression at the current token? That chain of calls ensures we report an
 error if a valid declaration or statement isn&rsquo;t parsed.</p>
 <p>When the parser matches a <code>var</code> token, it branches to:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>printStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Stmt</span> <span class="i">varDeclaration</span>() {
     <span class="t">Token</span> <span class="i">name</span> = <span class="i">consume</span>(<span class="i">IDENTIFIER</span>, <span class="s">&quot;Expect variable name.&quot;</span>);
@@ -620,7 +620,7 @@ add after <em>printStatement</em>()</div>
     <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Var</span>(<span class="i">name</span>, <span class="i">initializer</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>printStatement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>printStatement</em>()</div>
 
 <p>As always, the recursive descent code follows the grammar rule. The parser has
 already matched the <code>var</code> token, so next it requires and consumes an identifier
@@ -633,7 +633,7 @@ Stmt.Var syntax tree node and we&rsquo;re groovy.</p>
 identifier token.</p>
 <div class="codehilite"><pre class="insert-before">      return new Expr.Literal(previous().literal);
     }
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>primary</em>()</div>
 <pre class="insert">
 
@@ -644,7 +644,7 @@ in <em>primary</em>()</div>
 
     if (match(LEFT_PAREN)) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>primary</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>primary</em>()</div>
 
 <p>That gives us a working front end for declaring and using variables. All that&rsquo;s
 left is to feed it into the interpreter. Before we get to that, we need to talk
@@ -669,7 +669,7 @@ tables</strong>, <strong>dictionaries</strong> (Python and C#), <strong>hashes</
 <strong>tables</strong> (Lua), or <strong>associative arrays</strong> (PHP). Way back when, they were
 known as <strong>scatter tables</strong>.</p>
 </aside>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
 create new file</div>
 <pre><span class="k">package</span> <span class="i">com.craftinginterpreters.lox</span>;
 
@@ -680,7 +680,7 @@ create new file</div>
   <span class="k">private</span> <span class="k">final</span> <span class="t">Map</span>&lt;<span class="t">String</span>, <span class="t">Object</span>&gt; <span class="i">values</span> = <span class="k">new</span> <span class="t">HashMap</span>&lt;&gt;();
 }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, create new file</div>
+<div class="source-file-narrow"><em>lox/Environment.java</em>, create new file</div>
 
 <p>There&rsquo;s a Java Map in there to store the bindings. It uses bare strings for the
 keys, not tokens. A token represents a unit of code at a specific place in the
@@ -689,13 +689,13 @@ with the same name should refer to the same variable (ignoring scope for now).
 Using the raw string ensures all of those tokens refer to the same map key.</p>
 <p>There are two operations we need to support. First, a variable definition binds
 a new name to a value.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
 in class <em>Environment</em></div>
 <pre>  <span class="t">void</span> <span class="i">define</span>(<span class="t">String</span> <span class="i">name</span>, <span class="t">Object</span> <span class="i">value</span>) {
     <span class="i">values</span>.<span class="i">put</span>(<span class="i">name</span>, <span class="i">value</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, in class <em>Environment</em></div>
+<div class="source-file-narrow"><em>lox/Environment.java</em>, in class <em>Environment</em></div>
 
 <p>Not exactly brain surgery, but we have made one interesting semantic choice.
 When we add the key to the map, we don&rsquo;t check to see if it&rsquo;s already present.
@@ -727,7 +727,7 @@ footsteps.</p>
 variables. Once a variable exists, we need a way to look it up.</p>
 <div class="codehilite"><pre class="insert-before">class Environment {
   private final Map&lt;String, Object&gt; values = new HashMap&lt;&gt;();
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
+</pre><div class="source-file"><em>lox/Environment.java</em><br>
 in class <em>Environment</em></div>
 <pre class="insert">
 
@@ -742,7 +742,7 @@ in class <em>Environment</em></div>
 
 </pre><pre class="insert-after">  void define(String name, Object value) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, in class <em>Environment</em></div>
+<div class="source-file-narrow"><em>lox/Environment.java</em>, in class <em>Environment</em></div>
 
 <p>This is a little more semantically interesting. If the variable is found, it
 simply returns the value bound to it. But what if it&rsquo;s not? Again, we have a
@@ -817,19 +817,19 @@ tell the user where in their code they messed up.</p>
 <p>The Interpreter class gets an instance of the new Environment class.</p>
 <div class="codehilite"><pre class="insert-before">class Interpreter implements Expr.Visitor&lt;Object&gt;,
                              Stmt.Visitor&lt;Void&gt; {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+</pre><div class="source-file"><em>lox/Interpreter.java</em><br>
 in class <em>Interpreter</em></div>
 <pre class="insert">  <span class="k">private</span> <span class="t">Environment</span> <span class="i">environment</span> = <span class="k">new</span> <span class="t">Environment</span>();
 
 </pre><pre class="insert-after">  void interpret(List&lt;Stmt&gt; statements) {
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, in class <em>Interpreter</em></div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, in class <em>Interpreter</em></div>
 
 <p>We store it as a field directly in Interpreter so that the variables stay in
 memory as long as the interpreter is still running.</p>
 <p>We have two new syntax trees, so that&rsquo;s two new visit methods. The first is for
 declaration statements.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitPrintStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitVarStmt</span>(<span class="t">Stmt</span>.<span class="t">Var</span> <span class="i">stmt</span>) {
@@ -842,7 +842,7 @@ add after <em>visitPrintStmt</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitPrintStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitPrintStmt</em>()</div>
 
 <p>If the variable has an initializer, we evaluate it. If not, we have another
 choice to make. We could have made this a syntax error in the parser by
@@ -860,14 +860,14 @@ explicitly initialized.</p>
 Java representation of Lox&rsquo;s <code>nil</code> value. Then we tell the environment to bind
 the variable to that value.</p>
 <p>Next, we evaluate a variable expression.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitUnaryExpr</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitVariableExpr</span>(<span class="t">Expr</span>.<span class="t">Variable</span> <span class="i">expr</span>) {
     <span class="k">return</span> <span class="i">environment</span>.<span class="i">get</span>(<span class="i">expr</span>.<span class="i">name</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitUnaryExpr</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitUnaryExpr</em>()</div>
 
 <p>This simply forwards to the environment which does the heavy lifting to make
 sure the variable is defined. With that, we&rsquo;ve got rudimentary variables
@@ -919,12 +919,12 @@ objects, like:</p>
 </pre></div>
 <p>The easy part is adding the <span name="assign-ast">new syntax tree node</span>.</p>
 <div class="codehilite"><pre class="insert-before">    defineAst(outputDir, &quot;Expr&quot;, Arrays.asList(
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Assign   : Token name, Expr value&quot;</span>,
 </pre><pre class="insert-after">      &quot;Binary   : Expr left, Token operator, Expr right&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="assign-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#assign-expression">Appendix II</a>.</p>
@@ -934,13 +934,13 @@ value. After you run the AstGenerator to get the new Expr.Assign class, swap out
 the body of the parser&rsquo;s existing <code>expression()</code> method to match the updated
 rule.</p>
 <div class="codehilite"><pre class="insert-before">  private Expr expression() {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>expression</em>()<br>
 replace 1 line</div>
 <pre class="insert">    <span class="k">return</span> <span class="i">assignment</span>();
 </pre><pre class="insert-after">  }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>expression</em>(), replace 1 line</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>expression</em>(), replace 1 line</div>
 
 <p>Here is where it gets tricky. A single token lookahead recursive descent parser
 can&rsquo;t see far enough to tell that it&rsquo;s parsing an assignment until <em>after</em> it
@@ -977,7 +977,7 @@ tokens of lookahead to find the <code>=</code>.</p>
 </aside>
 <p>We have only a single token of lookahead, so what do we do? We use a little
 trick, and it looks like this:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>expressionStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">Expr</span> <span class="i">assignment</span>() {
     <span class="t">Expr</span> <span class="i">expr</span> = <span class="i">equality</span>();
@@ -997,7 +997,7 @@ add after <em>expressionStatement</em>()</div>
     <span class="k">return</span> <span class="i">expr</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>expressionStatement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>expressionStatement</em>()</div>
 
 <p>Most of the code for parsing an assignment expression looks similar to that of
 the other binary operators like <code>+</code>. We parse the left-hand side, which can be
@@ -1052,7 +1052,7 @@ that knows what it is assigning to and has an expression subtree for the value
 being assigned. All with only a single token of lookahead and no backtracking.</p>
 <h3><a href="#assignment-semantics" id="assignment-semantics"><small>8&#8202;.&#8202;4&#8202;.&#8202;2</small>Assignment semantics</a></h3>
 <p>We have a new syntax tree node, so our interpreter gets a new visit method.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>visitVarStmt</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Object</span> <span class="i">visitAssignExpr</span>(<span class="t">Expr</span>.<span class="t">Assign</span> <span class="i">expr</span>) {
@@ -1061,12 +1061,12 @@ add after <em>visitVarStmt</em>()</div>
     <span class="k">return</span> <span class="i">value</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>visitVarStmt</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>visitVarStmt</em>()</div>
 
 <p>For obvious reasons, it&rsquo;s similar to variable declaration. It evaluates the
 right-hand side to get the value, then stores it in the named variable. Instead
 of using <code>define()</code> on Environment, it calls this new method:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
 add after <em>get</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">assign</span>(<span class="t">Token</span> <span class="i">name</span>, <span class="t">Object</span> <span class="i">value</span>) {
     <span class="k">if</span> (<span class="i">values</span>.<span class="i">containsKey</span>(<span class="i">name</span>.<span class="i">lexeme</span>)) {
@@ -1078,7 +1078,7 @@ add after <em>get</em>()</div>
         <span class="s">&quot;Undefined variable &#39;&quot;</span> + <span class="i">name</span>.<span class="i">lexeme</span> + <span class="s">&quot;&#39;.&quot;</span>);
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, add after <em>get</em>()</div>
+<div class="source-file-narrow"><em>lox/Environment.java</em>, add after <em>get</em>()</div>
 
 <p>The key difference between assignment and definition is that assignment is not
 <span name="new">allowed</span> to create a <em>new</em> variable. In terms of our
@@ -1246,15 +1246,15 @@ much prefer the evocative <strong>cactus stack</strong>.</p><img class="above" s
 with support for this nesting. First, we give each environment a reference to
 its enclosing one.</p>
 <div class="codehilite"><pre class="insert-before">class Environment {
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
+</pre><div class="source-file"><em>lox/Environment.java</em><br>
 in class <em>Environment</em></div>
 <pre class="insert">  <span class="k">final</span> <span class="t">Environment</span> <span class="i">enclosing</span>;
 </pre><pre class="insert-after">  private final Map&lt;String, Object&gt; values = new HashMap&lt;&gt;();
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, in class <em>Environment</em></div>
+<div class="source-file-narrow"><em>lox/Environment.java</em>, in class <em>Environment</em></div>
 
 <p>This field needs to be initialized, so we add a couple of constructors.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Environment.java</em><br>
 in class <em>Environment</em></div>
 <pre>  <span class="t">Environment</span>() {
     <span class="i">enclosing</span> = <span class="k">null</span>;
@@ -1264,7 +1264,7 @@ in class <em>Environment</em></div>
     <span class="k">this</span>.<span class="i">enclosing</span> = <span class="i">enclosing</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, in class <em>Environment</em></div>
+<div class="source-file-narrow"><em>lox/Environment.java</em>, in class <em>Environment</em></div>
 
 <p>The no-argument constructor is for the global scope&rsquo;s environment, which ends
 the chain. The other constructor creates a new local scope nested inside the
@@ -1275,7 +1275,7 @@ with existing variables and they need to walk the chain to find them. First,
 lookup:</p>
 <div class="codehilite"><pre class="insert-before">      return values.get(name.lexeme);
     }
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
+</pre><div class="source-file"><em>lox/Environment.java</em><br>
 in <em>get</em>()</div>
 <pre class="insert">
 
@@ -1285,7 +1285,7 @@ in <em>get</em>()</div>
     throw new RuntimeError(name,
         &quot;Undefined variable '&quot; + name.lexeme + &quot;'.&quot;);
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, in <em>get</em>()</div>
+<div class="source-file-narrow"><em>lox/Environment.java</em>, in <em>get</em>()</div>
 
 <p>If the variable isn&rsquo;t found in this environment, we simply try the enclosing
 one. That in turn does the same thing <span name="recurse">recursively</span>,
@@ -1301,7 +1301,7 @@ solution is prettier. We&rsquo;ll do something <em>much</em> faster in clox.</p>
       return;
     }
 
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Environment.java</em><br>
+</pre><div class="source-file"><em>lox/Environment.java</em><br>
 in <em>assign</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">enclosing</span> != <span class="k">null</span>) {
       <span class="i">enclosing</span>.<span class="i">assign</span>(<span class="i">name</span>, <span class="i">value</span>);
@@ -1310,7 +1310,7 @@ in <em>assign</em>()</div>
 
 </pre><pre class="insert-after">    throw new RuntimeError(name,
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Environment.java</em>, in <em>assign</em>()</div>
+<div class="source-file-narrow"><em>lox/Environment.java</em>, in <em>assign</em>()</div>
 
 <p>Again, if the variable isn&rsquo;t in this environment, it checks the outer one,
 recursively.</p>
@@ -1327,12 +1327,12 @@ the grammar:</p>
 curly braces. A block is itself a statement and can appear anywhere a statement
 is allowed. The <span name="block-ast">syntax tree</span> node looks like this:</p>
 <div class="codehilite"><pre class="insert-before">    defineAst(outputDir, &quot;Stmt&quot;, Arrays.asList(
-</pre><div class="source-file"><em>com\craftinginterpreters\tool\GenerateAst.java</em><br>
+</pre><div class="source-file"><em>tool/GenerateAst.java</em><br>
 in <em>main</em>()</div>
 <pre class="insert">      <span class="s">&quot;Block      : List&lt;Stmt&gt; statements&quot;</span>,
 </pre><pre class="insert-after">      &quot;Expression : Expr expression&quot;,
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\tool\GenerateAst.java</em>, in <em>main</em>()</div>
+<div class="source-file-narrow"><em>tool/GenerateAst.java</em>, in <em>main</em>()</div>
 
 <aside name="block-ast">
 <p>The generated code for the new node is in <a href="appendix-ii.html#block-statement">Appendix II</a>.</p>
@@ -1345,17 +1345,17 @@ beginning of a block by its leading token<span class="em">&mdash;</span>in this 
 <p>As always, don&rsquo;t forget to run &ldquo;GenerateAst.java&rdquo;.</p>
 </aside>
 <div class="codehilite"><pre class="insert-before">    if (match(PRINT)) return printStatement();
-</pre><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+</pre><div class="source-file"><em>lox/Parser.java</em><br>
 in <em>statement</em>()</div>
 <pre class="insert">    <span class="k">if</span> (<span class="i">match</span>(<span class="i">LEFT_BRACE</span>)) <span class="k">return</span> <span class="k">new</span> <span class="t">Stmt</span>.<span class="t">Block</span>(<span class="i">block</span>());
 </pre><pre class="insert-after">
 
     return expressionStatement();
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, in <em>statement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, in <em>statement</em>()</div>
 
 <p>All the real work happens here:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Parser.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Parser.java</em><br>
 add after <em>expressionStatement</em>()</div>
 <pre>  <span class="k">private</span> <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">block</span>() {
     <span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span> = <span class="k">new</span> <span class="t">ArrayList</span>&lt;&gt;();
@@ -1368,7 +1368,7 @@ add after <em>expressionStatement</em>()</div>
     <span class="k">return</span> <span class="i">statements</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Parser.java</em>, add after <em>expressionStatement</em>()</div>
+<div class="source-file-narrow"><em>lox/Parser.java</em>, add after <em>expressionStatement</em>()</div>
 
 <p>We <span name="list">create</span> an empty list and then parse statements and
 add them to the list until we reach the end of the block, marked by the closing
@@ -1382,7 +1382,7 @@ way because we&rsquo;ll reuse <code>block()</code> later for parsing function bo
 want that body wrapped in a Stmt.Block.</p>
 </aside>
 <p>That&rsquo;s it for syntax. For semantics, we add another visit method to Interpreter.</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>execute</em>()</div>
 <pre>  <span class="a">@Override</span>
   <span class="k">public</span> <span class="t">Void</span> <span class="i">visitBlockStmt</span>(<span class="t">Stmt</span>.<span class="t">Block</span> <span class="i">stmt</span>) {
@@ -1390,11 +1390,11 @@ add after <em>execute</em>()</div>
     <span class="k">return</span> <span class="k">null</span>;
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>execute</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>execute</em>()</div>
 
 <p>To execute a block, we create a new environment for the block&rsquo;s scope and pass
 it off to this other method:</p>
-<div class="codehilite"><div class="source-file"><em>com\craftinginterpreters\lox\Interpreter.java</em><br>
+<div class="codehilite"><div class="source-file"><em>lox/Interpreter.java</em><br>
 add after <em>execute</em>()</div>
 <pre>  <span class="t">void</span> <span class="i">executeBlock</span>(<span class="t">List</span>&lt;<span class="t">Stmt</span>&gt; <span class="i">statements</span>,
                     <span class="t">Environment</span> <span class="i">environment</span>) {
@@ -1410,7 +1410,7 @@ add after <em>execute</em>()</div>
     }
   }
 </pre></div>
-<div class="source-file-narrow"><em>com\craftinginterpreters\lox\Interpreter.java</em>, add after <em>execute</em>()</div>
+<div class="source-file-narrow"><em>lox/Interpreter.java</em>, add after <em>execute</em>()</div>
 
 <p>This new method executes a list of statements in the context of a given <span
 name="param">environment</span>. Up until now, the <code>environment</code> field in

--- a/site/strings.html
+++ b/site/strings.html
@@ -695,7 +695,7 @@ add after <em>isFalsey</em>()</div>
   <span class="t">ObjString</span>* <span class="i">a</span> = <span class="a">AS_STRING</span>(<span class="i">pop</span>());
 
   <span class="t">int</span> <span class="i">length</span> = <span class="i">a</span>-&gt;<span class="i">length</span> + <span class="i">b</span>-&gt;<span class="i">length</span>;
-  <span class="t">char</span>* <span class="i">chars</span> = <span class="a">ALLOCATE</span>(<span class="t">char</span>, <span class="i">length</span> + <span class="n">1</span>);
+  <span class="t">char</span>* <span class="i">volatile</span> <span class="i">chars</span> = <span class="a">ALLOCATE</span>(<span class="t">char</span>, <span class="i">length</span> + <span class="n">1</span>);
   <span class="i">memcpy</span>(<span class="i">chars</span>, <span class="i">a</span>-&gt;<span class="i">chars</span>, <span class="i">a</span>-&gt;<span class="i">length</span>);
   <span class="i">memcpy</span>(<span class="i">chars</span> + <span class="i">a</span>-&gt;<span class="i">length</span>, <span class="i">b</span>-&gt;<span class="i">chars</span>, <span class="i">b</span>-&gt;<span class="i">length</span>);
   <span class="i">chars</span>[<span class="i">length</span>] = <span class="s">&#39;\0&#39;</span>;

--- a/site/the-lox-language.html
+++ b/site/the-lox-language.html
@@ -333,20 +333,15 @@ versa.</p>
 </pre></div>
 <p>The other two logical operators really are control flow constructs in the guise
 of expressions. An <span name="and"><code>and</code></span> expression determines if two
-values are <em>both</em> true. Consequently if it is able to determine this, it 
-will return true, otherwise false.</p>
+values are <em>both</em> true. It returns the left operand if it&rsquo;s false, or the
+right operand otherwise.</p>
 <div class="codehilite"><pre><span class="k">true</span> <span class="k">and</span> <span class="k">false</span>; <span class="c">// false.</span>
-<span class="k">false</span> <span class="k">and</span> <span class="k">true</span>; <span class="c">// false.</span>
 <span class="k">true</span> <span class="k">and</span> <span class="k">true</span>;  <span class="c">// true.</span>
-<span class="k">false</span> <span class="k">and</span> <span class="k">false</span>; <span class="c">// false.</span>
 </pre></div>
 <p>And an <code>or</code> expression determines if <em>either</em> of two values (or both) are true.
-And much like the <span name="and"><code>and</code></span> expression, it will return true,
-otherwise false.</p>
-<div class="codehilite"><pre><span class="k">true</span> <span class="k">or</span> <span class="k">false</span>;  <span class="c">// true.</span>
-<span class="k">false</span> <span class="k">or</span> <span class="k">true</span>; <span class="c">// true.</span>
-<span class="k">true</span> <span class="k">or</span> <span class="k">true</span>; <span class="c">// true.</span>
-<span class="k">false</span> <span class="k">or</span> <span class="k">false</span>; <span class="c">// false.</span>
+It returns the left operand if it is true and the right operand otherwise.</p>
+<div class="codehilite"><pre><span class="k">false</span> <span class="k">or</span> <span class="k">false</span>; <span class="c">// false.</span>
+<span class="k">true</span> <span class="k">or</span> <span class="k">false</span>;  <span class="c">// true.</span>
 </pre></div>
 <aside name="and">
 <p>I used <code>and</code> and <code>or</code> for these instead of <code>&amp;&amp;</code> and <code>||</code> because Lox doesn&rsquo;t use

--- a/site/the-lox-language.html
+++ b/site/the-lox-language.html
@@ -333,13 +333,13 @@ versa.</p>
 </pre></div>
 <p>The other two logical operators really are control flow constructs in the guise
 of expressions. An <span name="and"><code>and</code></span> expression determines if two
-values are <em>both</em> true. It returns the left operand if it&rsquo;s false, or the
+values are <em>both</em> true. It returns the left operand if the operand&rsquo;s false, or the
 right operand otherwise.</p>
 <div class="codehilite"><pre><span class="k">true</span> <span class="k">and</span> <span class="k">false</span>; <span class="c">// false.</span>
 <span class="k">true</span> <span class="k">and</span> <span class="k">true</span>;  <span class="c">// true.</span>
 </pre></div>
 <p>And an <code>or</code> expression determines if <em>either</em> of two values (or both) are true.
-It returns the left operand if it is true and the right operand otherwise.</p>
+It returns the left operand if the operand is true and the right operand otherwise.</p>
 <div class="codehilite"><pre><span class="k">false</span> <span class="k">or</span> <span class="k">false</span>; <span class="c">// false.</span>
 <span class="k">true</span> <span class="k">or</span> <span class="k">false</span>;  <span class="c">// true.</span>
 </pre></div>

--- a/site/the-lox-language.html
+++ b/site/the-lox-language.html
@@ -333,15 +333,20 @@ versa.</p>
 </pre></div>
 <p>The other two logical operators really are control flow constructs in the guise
 of expressions. An <span name="and"><code>and</code></span> expression determines if two
-values are <em>both</em> true. It returns the left operand if it&rsquo;s false, or the
-right operand otherwise.</p>
+values are <em>both</em> true. Consequently if it is able to determine this, it 
+will return true, otherwise false.</p>
 <div class="codehilite"><pre><span class="k">true</span> <span class="k">and</span> <span class="k">false</span>; <span class="c">// false.</span>
+<span class="k">false</span> <span class="k">and</span> <span class="k">true</span>; <span class="c">// false.</span>
 <span class="k">true</span> <span class="k">and</span> <span class="k">true</span>;  <span class="c">// true.</span>
+<span class="k">false</span> <span class="k">and</span> <span class="k">false</span>; <span class="c">// false.</span>
 </pre></div>
 <p>And an <code>or</code> expression determines if <em>either</em> of two values (or both) are true.
-It returns the left operand if it is true and the right operand otherwise.</p>
-<div class="codehilite"><pre><span class="k">false</span> <span class="k">or</span> <span class="k">false</span>; <span class="c">// false.</span>
-<span class="k">true</span> <span class="k">or</span> <span class="k">false</span>;  <span class="c">// true.</span>
+And much like the <span name="and"><code>and</code></span> expression, it will return true,
+otherwise false.</p>
+<div class="codehilite"><pre><span class="k">true</span> <span class="k">or</span> <span class="k">false</span>;  <span class="c">// true.</span>
+<span class="k">false</span> <span class="k">or</span> <span class="k">true</span>; <span class="c">// true.</span>
+<span class="k">true</span> <span class="k">or</span> <span class="k">true</span>; <span class="c">// true.</span>
+<span class="k">false</span> <span class="k">or</span> <span class="k">false</span>; <span class="c">// false.</span>
 </pre></div>
 <aside name="and">
 <p>I used <code>and</code> and <code>or</code> for these instead of <code>&amp;&amp;</code> and <code>||</code> because Lox doesn&rsquo;t use


### PR DESCRIPTION
New to programming languages, please correct me if I'm wrong.

I was reading the *Logical Operators* section of *The Lox Language* chapter and was really confused with the return statements for the `and` and `or` expressions. In the original prose, it says for `and`: *"It returns the left operand if it's false, or the right operand otherwise"* and then the first example shows `true and false; // false.` which is definitely not the left operand.

So I decided to try to emulate the style of the text to fix that misunderstanding and also provided all the possible expressions.

**UPDATE:**

Misunderstanding alleviated, changes is now making the subject of the sentence clearer i.e. changing *it* to *operand*.