### PR TITLE
updates test.dart to correctly handle windows paths

### DIFF
--- a/tool/bin/test.dart
+++ b/tool/bin/test.dart
@@ -205,13 +205,14 @@ class Test {
 
   bool parse() {
     // Get the path components.
-    var parts = _path.split("/");
+    var parts = _path.split(Platform.pathSeparator);
     var subpath = "";
     String state;
 
     // Figure out the state of the test. We don't break out of this loop because
     // we want lines for more specific paths to override more general ones.
     for (var part in parts) {
+      if (part == ".") continue;
       if (subpath.isNotEmpty) subpath += "/";
       subpath += part;
 


### PR DESCRIPTION
fixes #1003 

i have no idea if this has implications with a different OS, if this is even the right place for a fix, or if this is "ok" dart but it fixes running tests under windows (for me).