### PR TITLE
Added link to content page

### DIFF
--- a/asset/mustache/prev-next.html
+++ b/asset/mustache/prev-next.html
@@ -4,6 +4,8 @@
   {{/ has_prev }}
   {{# has_up }}
     <a href="{{ up_file }}.html" title="{{ up }}">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
   {{/ has_up }}
   {{# has_next }}
     <a href="{{ next_file }}.html" title="{{ next }}" class="right">Next&nbsp;&rarr;</a>

--- a/site/a-bytecode-virtual-machine.html
+++ b/site/a-bytecode-virtual-machine.html
@@ -60,8 +60,11 @@
 <div class="prev-next">
     <a href="inheritance.html" title="Inheritance" class="left">&larr;&nbsp;Previous</a>
     <a href="contents.html" title="Table of Contents">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="chunks-of-bytecode.html" title="Chunks of Bytecode" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -101,8 +104,11 @@
 <div class="prev-next">
     <a href="inheritance.html" title="Inheritance" class="left">&larr;&nbsp;Previous</a>
     <a href="contents.html" title="Table of Contents">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="chunks-of-bytecode.html" title="Chunks of Bytecode" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/a-map-of-the-territory.html
+++ b/site/a-map-of-the-territory.html
@@ -49,8 +49,11 @@
 <div class="prev-next">
     <a href="introduction.html" title="Introduction" class="left">&larr;&nbsp;Previous</a>
     <a href="welcome.html" title="Welcome">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="the-lox-language.html" title="The Lox Language" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -79,8 +82,11 @@
 <div class="prev-next">
     <a href="introduction.html" title="Introduction" class="left">&larr;&nbsp;Previous</a>
     <a href="welcome.html" title="Welcome">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="the-lox-language.html" title="The Lox Language" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/a-tree-walk-interpreter.html
+++ b/site/a-tree-walk-interpreter.html
@@ -53,8 +53,11 @@
 <div class="prev-next">
     <a href="the-lox-language.html" title="The Lox Language" class="left">&larr;&nbsp;Previous</a>
     <a href="contents.html" title="Table of Contents">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="scanning.html" title="Scanning" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -87,8 +90,11 @@
 <div class="prev-next">
     <a href="the-lox-language.html" title="The Lox Language" class="left">&larr;&nbsp;Previous</a>
     <a href="contents.html" title="Table of Contents">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="scanning.html" title="Scanning" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/a-virtual-machine.html
+++ b/site/a-virtual-machine.html
@@ -49,8 +49,11 @@
 <div class="prev-next">
     <a href="chunks-of-bytecode.html" title="Chunks of Bytecode" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="scanning-on-demand.html" title="Scanning on Demand" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -79,8 +82,11 @@
 <div class="prev-next">
     <a href="chunks-of-bytecode.html" title="Chunks of Bytecode" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="scanning-on-demand.html" title="Scanning on Demand" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/acknowledgements.html
+++ b/site/acknowledgements.html
@@ -40,8 +40,11 @@
 <div class="prev-next">
     <a href="dedication.html" title="Dedication" class="left">&larr;&nbsp;Previous</a>
     <a href="contents.html" title="Table of Contents">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="contents.html" title="Table of Contents" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -61,8 +64,11 @@
 <div class="prev-next">
     <a href="dedication.html" title="Dedication" class="left">&larr;&nbsp;Previous</a>
     <a href="contents.html" title="Table of Contents">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="contents.html" title="Table of Contents" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/appendix-i.html
+++ b/site/appendix-i.html
@@ -45,8 +45,11 @@
 <div class="prev-next">
     <a href="backmatter.html" title="Backmatter" class="left">&larr;&nbsp;Previous</a>
     <a href="backmatter.html" title="Backmatter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="appendix-ii.html" title="Appendix II" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -71,8 +74,11 @@
 <div class="prev-next">
     <a href="backmatter.html" title="Backmatter" class="left">&larr;&nbsp;Previous</a>
     <a href="backmatter.html" title="Backmatter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="appendix-ii.html" title="Appendix II" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/appendix-ii.html
+++ b/site/appendix-ii.html
@@ -45,7 +45,10 @@
 <div class="prev-next">
     <a href="appendix-i.html" title="Appendix I" class="left">&larr;&nbsp;Previous</a>
     <a href="backmatter.html" title="Backmatter">&uarr;&nbsp;Up</a>
-</div>  </div>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -69,7 +72,10 @@
 <div class="prev-next">
     <a href="appendix-i.html" title="Appendix I" class="left">&larr;&nbsp;Previous</a>
     <a href="backmatter.html" title="Backmatter">&uarr;&nbsp;Up</a>
-</div>  </div>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/backmatter.html
+++ b/site/backmatter.html
@@ -45,8 +45,11 @@
 <div class="prev-next">
     <a href="optimization.html" title="Optimization" class="left">&larr;&nbsp;Previous</a>
     <a href="contents.html" title="Table of Contents">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="appendix-i.html" title="Appendix I" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -71,8 +74,11 @@
 <div class="prev-next">
     <a href="optimization.html" title="Optimization" class="left">&larr;&nbsp;Previous</a>
     <a href="contents.html" title="Table of Contents">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="appendix-i.html" title="Appendix I" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/calls-and-functions.html
+++ b/site/calls-and-functions.html
@@ -52,8 +52,11 @@
 <div class="prev-next">
     <a href="jumping-back-and-forth.html" title="Jumping Back and Forth" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="closures.html" title="Closures" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -85,8 +88,11 @@
 <div class="prev-next">
     <a href="jumping-back-and-forth.html" title="Jumping Back and Forth" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="closures.html" title="Closures" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/chunks-of-bytecode.html
+++ b/site/chunks-of-bytecode.html
@@ -52,8 +52,11 @@
 <div class="prev-next">
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="a-virtual-machine.html" title="A Virtual Machine" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -85,8 +88,11 @@
 <div class="prev-next">
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="a-virtual-machine.html" title="A Virtual Machine" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/classes-and-instances.html
+++ b/site/classes-and-instances.html
@@ -49,8 +49,11 @@
 <div class="prev-next">
     <a href="garbage-collection.html" title="Garbage Collection" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="methods-and-initializers.html" title="Methods and Initializers" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -79,8 +82,11 @@
 <div class="prev-next">
     <a href="garbage-collection.html" title="Garbage Collection" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="methods-and-initializers.html" title="Methods and Initializers" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/classes.html
+++ b/site/classes.html
@@ -53,8 +53,11 @@
 <div class="prev-next">
     <a href="resolving-and-binding.html" title="Resolving and Binding" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="inheritance.html" title="Inheritance" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -87,8 +90,11 @@
 <div class="prev-next">
     <a href="resolving-and-binding.html" title="Resolving and Binding" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="inheritance.html" title="Inheritance" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/closures.html
+++ b/site/closures.html
@@ -50,8 +50,11 @@
 <div class="prev-next">
     <a href="calls-and-functions.html" title="Calls and Functions" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="garbage-collection.html" title="Garbage Collection" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -81,8 +84,11 @@
 <div class="prev-next">
     <a href="calls-and-functions.html" title="Calls and Functions" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="garbage-collection.html" title="Garbage Collection" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/compiling-expressions.html
+++ b/site/compiling-expressions.html
@@ -53,8 +53,11 @@
 <div class="prev-next">
     <a href="scanning-on-demand.html" title="Scanning on Demand" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="types-of-values.html" title="Types of Values" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -87,8 +90,11 @@
 <div class="prev-next">
     <a href="scanning-on-demand.html" title="Scanning on Demand" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="types-of-values.html" title="Types of Values" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/contents.html
+++ b/site/contents.html
@@ -45,8 +45,11 @@
         <div class="prev-next">
         <a href="acknowledgements.html" title="Acknowledgements" class="left">&larr;&nbsp;Previous</a>
         <a href="index.html" title="Crafting Interpreters">&uarr;&nbsp;Up</a>
+    	//
+    	<a href="contents.html" title="Contents">Contents</a>
         <a href="welcome.html" title="Welcome" class="right">Next&nbsp;&rarr;</a>
-    </div>  </div>
+    </div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -70,8 +73,11 @@
         <div class="prev-next">
         <a href="acknowledgements.html" title="Acknowledgements" class="left">&larr;&nbsp;Previous</a>
         <a href="index.html" title="Crafting Interpreters">&uarr;&nbsp;Up</a>
+    	//
+    	<a href="contents.html" title="Contents">Contents</a>
         <a href="welcome.html" title="Welcome" class="right">Next&nbsp;&rarr;</a>
-    </div>  </div>
+    </div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/control-flow.html
+++ b/site/control-flow.html
@@ -51,8 +51,11 @@
 <div class="prev-next">
     <a href="statements-and-state.html" title="Statements and State" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="functions.html" title="Functions" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -83,8 +86,11 @@
 <div class="prev-next">
     <a href="statements-and-state.html" title="Statements and State" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="functions.html" title="Functions" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/dedication.html
+++ b/site/dedication.html
@@ -40,8 +40,11 @@
 <div class="prev-next">
     <a href="index.html" title="Crafting Interpreters" class="left">&larr;&nbsp;Previous</a>
     <a href="contents.html" title="Table of Contents">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="acknowledgements.html" title="Acknowledgements" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -61,8 +64,11 @@
 <div class="prev-next">
     <a href="index.html" title="Crafting Interpreters" class="left">&larr;&nbsp;Previous</a>
     <a href="contents.html" title="Table of Contents">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="acknowledgements.html" title="Acknowledgements" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/evaluating-expressions.html
+++ b/site/evaluating-expressions.html
@@ -50,8 +50,11 @@
 <div class="prev-next">
     <a href="parsing-expressions.html" title="Parsing Expressions" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="statements-and-state.html" title="Statements and State" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -81,8 +84,11 @@
 <div class="prev-next">
     <a href="parsing-expressions.html" title="Parsing Expressions" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="statements-and-state.html" title="Statements and State" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/functions.html
+++ b/site/functions.html
@@ -51,8 +51,11 @@
 <div class="prev-next">
     <a href="control-flow.html" title="Control Flow" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="resolving-and-binding.html" title="Resolving and Binding" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -83,8 +86,11 @@
 <div class="prev-next">
     <a href="control-flow.html" title="Control Flow" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="resolving-and-binding.html" title="Resolving and Binding" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/garbage-collection.html
+++ b/site/garbage-collection.html
@@ -53,8 +53,11 @@
 <div class="prev-next">
     <a href="closures.html" title="Closures" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="classes-and-instances.html" title="Classes and Instances" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -87,8 +90,11 @@
 <div class="prev-next">
     <a href="closures.html" title="Closures" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="classes-and-instances.html" title="Classes and Instances" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/global-variables.html
+++ b/site/global-variables.html
@@ -49,8 +49,11 @@
 <div class="prev-next">
     <a href="hash-tables.html" title="Hash Tables" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="local-variables.html" title="Local Variables" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -79,8 +82,11 @@
 <div class="prev-next">
     <a href="hash-tables.html" title="Hash Tables" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="local-variables.html" title="Local Variables" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/hash-tables.html
+++ b/site/hash-tables.html
@@ -50,8 +50,11 @@
 <div class="prev-next">
     <a href="strings.html" title="Strings" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="global-variables.html" title="Global Variables" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -81,8 +84,11 @@
 <div class="prev-next">
     <a href="strings.html" title="Strings" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="global-variables.html" title="Global Variables" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/inheritance.html
+++ b/site/inheritance.html
@@ -49,8 +49,11 @@
 <div class="prev-next">
     <a href="classes.html" title="Classes" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -79,8 +82,11 @@
 <div class="prev-next">
     <a href="classes.html" title="Classes" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/introduction.html
+++ b/site/introduction.html
@@ -50,8 +50,11 @@
 <div class="prev-next">
     <a href="welcome.html" title="Welcome" class="left">&larr;&nbsp;Previous</a>
     <a href="welcome.html" title="Welcome">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="a-map-of-the-territory.html" title="A Map of the Territory" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -81,8 +84,11 @@
 <div class="prev-next">
     <a href="welcome.html" title="Welcome" class="left">&larr;&nbsp;Previous</a>
     <a href="welcome.html" title="Welcome">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="a-map-of-the-territory.html" title="A Map of the Territory" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/jumping-back-and-forth.html
+++ b/site/jumping-back-and-forth.html
@@ -50,8 +50,11 @@
 <div class="prev-next">
     <a href="local-variables.html" title="Local Variables" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="calls-and-functions.html" title="Calls and Functions" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -81,8 +84,11 @@
 <div class="prev-next">
     <a href="local-variables.html" title="Local Variables" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="calls-and-functions.html" title="Calls and Functions" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/local-variables.html
+++ b/site/local-variables.html
@@ -49,8 +49,11 @@
 <div class="prev-next">
     <a href="global-variables.html" title="Global Variables" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="jumping-back-and-forth.html" title="Jumping Back and Forth" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -79,8 +82,11 @@
 <div class="prev-next">
     <a href="global-variables.html" title="Global Variables" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="jumping-back-and-forth.html" title="Jumping Back and Forth" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/methods-and-initializers.html
+++ b/site/methods-and-initializers.html
@@ -51,8 +51,11 @@
 <div class="prev-next">
     <a href="classes-and-instances.html" title="Classes and Instances" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="superclasses.html" title="Superclasses" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -83,8 +86,11 @@
 <div class="prev-next">
     <a href="classes-and-instances.html" title="Classes and Instances" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="superclasses.html" title="Superclasses" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/optimization.html
+++ b/site/optimization.html
@@ -49,8 +49,11 @@
 <div class="prev-next">
     <a href="superclasses.html" title="Superclasses" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="backmatter.html" title="Backmatter" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -79,8 +82,11 @@
 <div class="prev-next">
     <a href="superclasses.html" title="Superclasses" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="backmatter.html" title="Backmatter" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/parsing-expressions.html
+++ b/site/parsing-expressions.html
@@ -50,8 +50,11 @@
 <div class="prev-next">
     <a href="representing-code.html" title="Representing Code" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="evaluating-expressions.html" title="Evaluating Expressions" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -81,8 +84,11 @@
 <div class="prev-next">
     <a href="representing-code.html" title="Representing Code" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="evaluating-expressions.html" title="Evaluating Expressions" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/representing-code.html
+++ b/site/representing-code.html
@@ -49,8 +49,11 @@
 <div class="prev-next">
     <a href="scanning.html" title="Scanning" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="parsing-expressions.html" title="Parsing Expressions" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -79,8 +82,11 @@
 <div class="prev-next">
     <a href="scanning.html" title="Scanning" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="parsing-expressions.html" title="Parsing Expressions" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/resolving-and-binding.html
+++ b/site/resolving-and-binding.html
@@ -50,8 +50,11 @@
 <div class="prev-next">
     <a href="functions.html" title="Functions" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="classes.html" title="Classes" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -81,8 +84,11 @@
 <div class="prev-next">
     <a href="functions.html" title="Functions" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="classes.html" title="Classes" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/scanning-on-demand.html
+++ b/site/scanning-on-demand.html
@@ -49,8 +49,11 @@
 <div class="prev-next">
     <a href="a-virtual-machine.html" title="A Virtual Machine" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="compiling-expressions.html" title="Compiling Expressions" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -79,8 +82,11 @@
 <div class="prev-next">
     <a href="a-virtual-machine.html" title="A Virtual Machine" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="compiling-expressions.html" title="Compiling Expressions" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/scanning.html
+++ b/site/scanning.html
@@ -53,8 +53,11 @@
 <div class="prev-next">
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="representing-code.html" title="Representing Code" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -87,8 +90,11 @@
 <div class="prev-next">
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="representing-code.html" title="Representing Code" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/statements-and-state.html
+++ b/site/statements-and-state.html
@@ -51,8 +51,11 @@
 <div class="prev-next">
     <a href="evaluating-expressions.html" title="Evaluating Expressions" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="control-flow.html" title="Control Flow" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -83,8 +86,11 @@
 <div class="prev-next">
     <a href="evaluating-expressions.html" title="Evaluating Expressions" class="left">&larr;&nbsp;Previous</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="control-flow.html" title="Control Flow" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/strings.html
+++ b/site/strings.html
@@ -51,8 +51,11 @@
 <div class="prev-next">
     <a href="types-of-values.html" title="Types of Values" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="hash-tables.html" title="Hash Tables" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -83,8 +86,11 @@
 <div class="prev-next">
     <a href="types-of-values.html" title="Types of Values" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="hash-tables.html" title="Hash Tables" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/superclasses.html
+++ b/site/superclasses.html
@@ -49,8 +49,11 @@
 <div class="prev-next">
     <a href="methods-and-initializers.html" title="Methods and Initializers" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="optimization.html" title="Optimization" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -79,8 +82,11 @@
 <div class="prev-next">
     <a href="methods-and-initializers.html" title="Methods and Initializers" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="optimization.html" title="Optimization" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/the-lox-language.html
+++ b/site/the-lox-language.html
@@ -56,8 +56,11 @@
 <div class="prev-next">
     <a href="a-map-of-the-territory.html" title="A Map of the Territory" class="left">&larr;&nbsp;Previous</a>
     <a href="welcome.html" title="Welcome">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -93,8 +96,11 @@
 <div class="prev-next">
     <a href="a-map-of-the-territory.html" title="A Map of the Territory" class="left">&larr;&nbsp;Previous</a>
     <a href="welcome.html" title="Welcome">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="a-tree-walk-interpreter.html" title="A Tree-Walk Interpreter" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/types-of-values.html
+++ b/site/types-of-values.html
@@ -49,8 +49,11 @@
 <div class="prev-next">
     <a href="compiling-expressions.html" title="Compiling Expressions" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="strings.html" title="Strings" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -79,8 +82,11 @@
 <div class="prev-next">
     <a href="compiling-expressions.html" title="Compiling Expressions" class="left">&larr;&nbsp;Previous</a>
     <a href="a-bytecode-virtual-machine.html" title="A Bytecode Virtual Machine">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="strings.html" title="Strings" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>

--- a/site/welcome.html
+++ b/site/welcome.html
@@ -46,8 +46,11 @@
 <div class="prev-next">
     <a href="contents.html" title="Table of Contents" class="left">&larr;&nbsp;Previous</a>
     <a href="contents.html" title="Table of Contents">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="introduction.html" title="Introduction" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
 </nav>
 
 <nav class="narrow">
@@ -73,8 +76,11 @@
 <div class="prev-next">
     <a href="contents.html" title="Table of Contents" class="left">&larr;&nbsp;Previous</a>
     <a href="contents.html" title="Table of Contents">&uarr;&nbsp;Up</a>
+	//
+	<a href="contents.html" title="Contents">Contents</a>
     <a href="introduction.html" title="Introduction" class="right">Next&nbsp;&rarr;</a>
-</div>  </div>
+</div>
+  </div>
   <a id="expand-nav">≡</a>
 </nav>
 </div>


### PR DESCRIPTION
I'm working through the book, and I'm finding it a bit awkward to navigate back to the contents page. So I have added a link to contents from the floating navbars.

This looks fine when the navbar is stretched. However, on some pages, or when you scroll down, it squashes, which doesn't look as good. Maybe someone who knows the project better than me can improve on this?

<img width="233" alt="image" src="https://user-images.githubusercontent.com/20501289/203657822-b54a3f08-54e8-4698-a221-6da415640048.png">&nbsp;&nbsp;&nbsp;This looks fine, IMO.

<img width="229" alt="image" src="https://user-images.githubusercontent.com/20501289/203657905-988a87e8-9f00-4eef-9087-dc22ba049b80.png">&nbsp;&nbsp;&nbsp;Scrolling down... not quite as nice?

<img width="219" alt="image" src="https://user-images.githubusercontent.com/20501289/203657941-9b875d27-33bc-48aa-b520-eced7976763d.png">&nbsp;&nbsp;&nbsp;The final page also doesn't look quite right.