### PR TITLE
Interpreter: removed need for null check in regards to variable declarations.

### DIFF
--- a/java/com/craftinginterpreters/lox/Interpreter.java
+++ b/java/com/craftinginterpreters/lox/Interpreter.java
@@ -223,10 +223,7 @@ class Interpreter implements Expr.Visitor<Object>,
 //> Statements and State visit-var
   @Override
   public Void visitVarStmt(Stmt.Var stmt) {
-    Object value = null;
-    if (stmt.initializer != null) {
-      value = evaluate(stmt.initializer);
-    }
+    Object value = evaluate(stmt.initializer);
 
     environment.define(stmt.name.lexeme, value);
     return null;

--- a/java/com/craftinginterpreters/lox/Parser.java
+++ b/java/com/craftinginterpreters/lox/Parser.java
@@ -223,7 +223,7 @@ class Parser {
   private Stmt varDeclaration() {
     Token name = consume(IDENTIFIER, "Expect variable name.");
 
-    Expr initializer = null;
+    Expr initializer = new Expr.Literal(null);
     if (match(EQUAL)) {
       initializer = expression();
     }


### PR DESCRIPTION
for cases of `var a;` where no initializer is given I sneak in a dummy `new Expr.Literal(null)` to give `Interpreter.visitVarStmt` something to chew on via `Interpreter.evaluate(Expr expr)` instead of having to do a check for `null`.

Pros:
- more natural "flow" in each section as we remove the checks for `null`

Cons:
- slight performance hit as we now need to `evaluate` the null literal