### PR TITLE
Fix typos

### DIFF
--- a/asset/style.scss
+++ b/asset/style.scss
@@ -286,7 +286,7 @@ nav.narrow {
 }
 
 // Make ellipses follow Chicago style. The `&hellip;` entity puts a tiny amount
-// of space between each `.`, but not as much as Chicago style specificies. It
+// of space between each `.`, but not as much as Chicago style specifies. It
 // also doesn't put any space before. Instead, the build system writes a span
 // of this class with thin-space separated dots. This class here ensures there
 // is no splitting between the dots.

--- a/book/compiling-expressions.md
+++ b/book/compiling-expressions.md
@@ -595,7 +595,7 @@ The function we will use as the infix parser for `TOKEN_PLUS`, `TOKEN_MINUS`,
 ^code binary
 
 When a prefix parser function is called, the leading token has already been
-consumed. An infix parser function is even more *in medias res* -- the entire
+consumed. An infix parser function is even more *in media res* -- the entire
 left-hand operand expression has already been compiled and the subsequent infix
 operator consumed.
 

--- a/book/hash-tables.md
+++ b/book/hash-tables.md
@@ -1067,7 +1067,7 @@ then *everything* is slow.
     function, load factor, and growth rate.
 
     All of this variety wasn't created just to give CS doctoral candidates
-    something to <span name="publish">publish</span> theses on: each has its
+    something to <span name="publish">publish</span> thesis on: each has its
     uses in the many varied domains and hardware scenarios where hashing comes
     into play. Look up a few hash table implementations in different open source
     systems, research the choices they made, and try to figure out why they did

--- a/book/inheritance.md
+++ b/book/inheritance.md
@@ -523,7 +523,7 @@ with cream.
 ### Invalid uses of super
 
 As with previous language features, our implementation does the right thing when
-the user writes correct code, but we haven't bulletproofed the intepreter
+the user writes correct code, but we haven't bulletproofed the interpreter
 against bad code. In particular, consider:
 
 ```lox

--- a/book/methods-and-initializers.md
+++ b/book/methods-and-initializers.md
@@ -1233,23 +1233,23 @@ is one of the fundamental balancing acts of language design: similarity to other
 languages lowers learning cost, while divergence raises the compelling
 advantages.
 
-I think of this balancing act in terms of a <span name="idiosyncracy">**novelty
+I think of this balancing act in terms of a <span name="idiosyncrasy">**novelty
 budget**</span>, or as Steve Klabnik calls it, a "[strangeness budget][]". Users
 have a low threshold for the total amount of new stuff they are willing to
 accept to learn a new language. Exceed that, and they won't show up.
 
 [strangeness budget]: https://words.steveklabnik.com/the-language-strangeness-budget
 
-<aside name="idiosyncracy">
+<aside name="idiosyncrasy">
 
-A related concept in psychology is [**idiosyncrasy credit**][idiosyncracy], the
+A related concept in psychology is [**idiosyncrasy credit**][idiosyncrasy], the
 idea that other people in society grant you a finite amount of deviations from
 social norms. You earn credit by fitting in and doing in-group things, which you
 can then spend on oddball activities that might otherwise raise eyebrows. In
 other words, demonstrating that you are "one of the good ones" gives you license
 to raise your freak flag, but only so far.
 
-[idiosyncracy]: https://en.wikipedia.org/wiki/Idiosyncrasy_credit
+[idiosyncrasy]: https://en.wikipedia.org/wiki/Idiosyncrasy_credit
 
 </aside>
 

--- a/book/superclasses.md
+++ b/book/superclasses.md
@@ -464,7 +464,7 @@ information it needs to perform the super access:
 2.  The second instruction loads **the superclass where the method is
     resolved**.
 
-3.  Then the new `OP_GET_SUPER` instuction encodes **the name of the method to
+3.  Then the new `OP_GET_SUPER` instruction encodes **the name of the method to
     access** as an operand.
 
 The remaining instructions are the normal bytecode for evaluating an argument

--- a/book/types-of-values.md
+++ b/book/types-of-values.md
@@ -595,7 +595,7 @@ each token type. We add cases for the six new operators.
 ^code comparison-operators (1 before, 1 after)
 
 The `==`, `<`, and `>` operators output a single instruction. The others output
-a pair of instructions, one to evalute the inverse operation, and then an
+a pair of instructions, one to evaluate the inverse operation, and then an
 `OP_NOT` to flip the result. Six operators for the price of three instructions!
 
 That means over in the VM, our job is simpler. Equality is the most general
@@ -645,7 +645,7 @@ because of padding and different-sized union fields, a Value contains unused
 bits. C gives no guarantee about what is in those, so it's possible that two
 equal Values actually differ in memory that isn't used.
 
-<img src="image/types-of-values/memcmp.png" alt="The memory respresentations of two equal values that differ in unused bytes." />
+<img src="image/types-of-values/memcmp.png" alt="The memory representations of two equal values that differ in unused bytes." />
 
 (You wouldn't believe how much pain I went through before learning this fact.)
 

--- a/note/answers/chapter12_classes.md
+++ b/note/answers/chapter12_classes.md
@@ -242,7 +242,7 @@
     is up to the class to decide which state is exposed using getters and
     setters. Most statically typed languages offer access control modifiers
     like `private` and `public` to explicitly control on a per-member basis
-    which parts of a class are externally accesible.
+    which parts of a class are externally accessible.
 
     What are the trade-offs between these approaches and why might a language
     might prefer one or the other?

--- a/note/answers/chapter27_classes/3.md
+++ b/note/answers/chapter27_classes/3.md
@@ -1,5 +1,5 @@
 Ruby provides a private method, `remove_instance_variable` that an object can
-call on itself passing in the name of the instance vairable to delete. Ruby is
+call on itself passing in the name of the instance variable to delete. Ruby is
 interesting in that it has the model that accessing an undefined instance
 variable returns `nil`. But it it still makes a distinction between a deleted
 instance variable and an instance variable whose value has been set to `nil`.

--- a/note/outline.md
+++ b/note/outline.md
@@ -20,7 +20,7 @@ visible to user.
               state machines, memory management, optimization
             - hard, training with weights on
             - fun
-            - dispell magic
+            - dispel magic
         - structure of book
         - languages used in impl
         - what's in book

--- a/note/style guide.md
+++ b/note/style guide.md
@@ -50,7 +50,7 @@ TODO: How do we style keywords used in headers and subheaders?
 ### Code font
 
 *   References to statements like "`if` statement" and "`switch`". Use "`else`
-    clause" to refer to that part of an `if` statement's *sytax*, but "then
+    clause" to refer to that part of an `if` statement's *syntax*, but "then
     branch" and "else branch" to refer to those *concepts*.
 
 *   Use "`return` statement", but "early return". In almost all other cases,


### PR DESCRIPTION
Found via `codespell -S site -L nd,uper,ue,wirth,clos,fo`