### PR TITLE
Fix broken link to the wizard book page on the MIT press site

### DIFF
--- a/book/introduction.md
+++ b/book/introduction.md
@@ -144,7 +144,7 @@ texts on programming languages feature a [dragon][] and a [wizard][] on their
 covers.
 
 [dragon]: https://en.wikipedia.org/wiki/Compilers:_Principles,_Techniques,_and_Tools
-[wizard]: https://mitpress.mit.edu/sites/default/files/sicp/index.html
+[wizard]: https://mitpress.mit.edu/9780262510875/structure-and-interpretation-of-computer-programs/
 
 </aside>
 

--- a/site/introduction.html
+++ b/site/introduction.html
@@ -197,7 +197,7 @@ the courage to try to really learn them. That &ldquo;magical&rdquo; quality, tha
 exclusivity, excluded <em>me</em>.</p>
 <aside name="image">
 <p>And its practitioners don&rsquo;t hesitate to play up this image. Two of the seminal
-texts on programming languages feature a <a href="https://en.wikipedia.org/wiki/Compilers:_Principles,_Techniques,_and_Tools">dragon</a> and a <a href="https://mitpress.mit.edu/sites/default/files/sicp/index.html">wizard</a> on their
+texts on programming languages feature a <a href="https://en.wikipedia.org/wiki/Compilers:_Principles,_Techniques,_and_Tools">dragon</a> and a <a href="https://mitpress.mit.edu/9780262510875/structure-and-interpretation-of-computer-programs/">wizard</a> on their
 covers.</p>
 </aside>
 <p>When I did finally start cobbling together my own little interpreters, I quickly


### PR DESCRIPTION
This is a fix for issue [#1119](https://github.com/munificent/craftinginterpreters/issues/1119).

New URLs to point to the "wizard"-book at the MIT press site.