### PR TITLE
The current link for A Unified Theory of Garbage Collection is broken…

### DIFF
--- a/book/the-lox-language.md
+++ b/book/the-lox-language.md
@@ -148,7 +148,7 @@ retain calls if you squint.
 
 For lots more on this, see "[A Unified Theory of Garbage Collection][gc]" (PDF).
 
-[gc]: https://researcher.watson.ibm.com/researcher/files/us-bacon/Bacon04Unified.pdf
+[gc]: https://courses.cs.washington.edu/courses/cse590p/05au/p50-bacon.pdf
 
 </aside>
 


### PR DESCRIPTION
…. This is a link I've used, and I believe it to be stable -- it's hosted by UWash. If not stable, I still wanted to point to you that it's broken. Thanks