### PR TITLE
Ch 19 Use BINARY_OP(NUMBER_VAL, +) instead of expanded form

### DIFF
--- a/c/vm.c
+++ b/c/vm.c
@@ -655,9 +655,7 @@ static InterpretResult run() {
         if (IS_STRING(peek(0)) && IS_STRING(peek(1))) {
           concatenate();
         } else if (IS_NUMBER(peek(0)) && IS_NUMBER(peek(1))) {
-          double b = AS_NUMBER(pop());
-          double a = AS_NUMBER(pop());
-          push(NUMBER_VAL(a + b));
+          BINARY_OP(NUMBER_VAL, +);
         } else {
           runtimeError(
               "Operands must be two numbers or two strings.");


### PR DESCRIPTION
Hey! I noticed that in https://craftinginterpreters.com/strings.html#struct-inheritance the `BINARY_OP(NUMBER_VAL, +);` is expanded for numbers but it doesn't add anything different than the old version.