### PR TITLE
Modify command for generating script_dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ xcuserdata/
 # Dart stuff.
 /tool/.dart_tool/
 /tool/.packages
+
+# macOS-specific System Files
+*.DS_Store

--- a/jlox
+++ b/jlox
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-script_dir=$(dirname "$0")
+script_dir="$(dirname "$(readlink -f "$0")")"
 java -cp ${script_dir}/build/java com.craftinginterpreters.lox.Lox $@


### PR DESCRIPTION
Intent is to let the script find the correct path to the executable, even if it is being run via symlink

Add macOS-specific system files to .gitignore