### PR TITLE
update guidance around division by zero

### DIFF
--- a/note/answers/chapter07_evaluating.md
+++ b/note/answers/chapter07_evaluating.md
@@ -32,7 +32,7 @@
 3.  It returns Infinity, -Infinity, or NaN based on sign of the dividend. Given
     that Lox is a high level scripting language, I think it would be better to
     raise a runtime error to let the user know something got weird. That's what
-    Python and Ruby do.
+    Python does.
 
     On the other hand, given that Lox gives the user no way to catch and
     handle runtime errors, not throwing one might be more flexible.


### PR DESCRIPTION
Ruby doesn't throw an exception when dividing by 0.0, which is the equivalent to dividing by 0 in Lox.  Rather, it does the same thing as java (and javascript, and IEEE754) in returning Infinity/-Infinity/NaN.  Python seems to be the outlier here.

Tested on ruby 2.6 and 3.2.2.