### PR TITLE
Fix chapter08_statements.md

### DIFF
--- a/note/answers/chapter08_statements.md
+++ b/note/answers/chapter08_statements.md
@@ -91,7 +91,10 @@
         Object syntax = parser.parseRepl();
 
         // Ignore it if there was a syntax error.
-        if (hadError) continue;
+        if (hadError) {
+          hadError = false;
+          continue;
+        }
 
         if (syntax instanceof List) {
           interpreter.interpret((List<Stmt>)syntax);


### PR DESCRIPTION
Once REPL encounters an error, it stops interpreting valid statements, since hadError is never set to false.