### PR TITLE
fix(vm): chapter 24.3.3 - add missing ".line" property

### DIFF
--- a/c/vm.c
+++ b/c/vm.c
@@ -57,7 +57,7 @@ static void runtimeError(const char* format, ...) {
 /* Calls and Functions runtime-error-temp < Calls and Functions runtime-error-stack
   CallFrame* frame = &vm.frames[vm.frameCount - 1];
   size_t instruction = frame->ip - frame->function->chunk.code - 1;
-  int line = frame->function->chunk.lines[instruction];
+  int line = frame->function->chunk.lines[instruction].line;
 */
 /* Types of Values runtime-error < Calls and Functions runtime-error-stack
   fprintf(stderr, "[line %d] in script\n", line);


### PR DESCRIPTION
After modifying codebase according to 24.3.3 (before 24.4), executing code results in error below.

`frame->function->chunk.lines[instruction]` is type `LineStart`.

Get `int line` by adding `.line` property.

```org
#+header: :tangle /tmp/study/book/crafting_interpreters/clox/chapter_24.lox
#+begin_src lox
  print "foo";
#+end_src

#+header: :results output
#+header: :prologue exec 2>&1
#+begin_src shell
  cd clox
  gcc -o clox *.c
  ./clox chapter_24.lox
#+end_src

#+RESULTS:
#+begin_example
vm.c: In function ‘runtimeError’:
vm.c:28:14: error: incompatible types when initializing type ‘int’ using type ‘LineStart’
   28 |   int line = frame->function->chunk.lines[instruction];
      |              ^~~~~
== <script> ==
0000    1 OP_CONSTANT         0 'foo'
0002    | OP_PRINT
0003    2 OP_RETURN
          [ <script> ]
0000    1 OP_CONSTANT         0 'foo'
          [ <script> ][ foo ]
0002    | OP_PRINT
foo
          [ <script> ]
0003    2 OP_RETURN
#+end_example
```