### PR TITLE
Exit if the scanner fails (if he found an unexpected character).

### DIFF
--- a/java/com/craftinginterpreters/lox/Lox.java
+++ b/java/com/craftinginterpreters/lox/Lox.java
@@ -71,6 +71,8 @@ public class Lox {
       System.out.println(token);
     }
 */
+    // stop if scanner fails
+    if (hadError) return;
 //> Parsing Expressions print-ast
     Parser parser = new Parser(tokens);
 /* Parsing Expressions print-ast < Statements and State parse-statements


### PR DESCRIPTION
The parser will parse the tokens even if the scanner reports an error "unexpected character". This will eventually fix it.