### PR TITLE
Mandelbrot benchmark and chained Negatives doc

### DIFF
--- a/book/the-lox-language.md
+++ b/book/the-lox-language.md
@@ -283,6 +283,15 @@ All of these operators work on numbers, and it's an error to pass any other
 types to them. The exception is the `+` operator -- you can also pass it two
 strings to concatenate them.
 
+### Chained Negation Example
+
+Lox allows chaining of the logical NOT operator. This means you can write expressions like:
+
+```lox
+!!!!true // evaluates to true
+!!!false // evaluates to true
+!!false  // evaluates to false
+
 ### Comparison and equality
 
 Moving along, we have a few more operators that always return a Boolean result.

--- a/book/the-lox-language.md
+++ b/book/the-lox-language.md
@@ -288,9 +288,10 @@ strings to concatenate them.
 Lox allows chaining of the logical NOT operator. This means you can write expressions like:
 
 ```lox
-!!!!true // evaluates to true
-!!!false // evaluates to true
-!!false  // evaluates to false
+!!!!true; // evaluates to true
+!!!false; // evaluates to true
+!!false;  // evaluates to false
+```
 
 ### Comparison and equality
 

--- a/test/benchmark/mandelbrot.lox
+++ b/test/benchmark/mandelbrot.lox
@@ -1,0 +1,27 @@
+// Mandelbrot
+var width = 78;
+var height = 44;
+var max_iter = 50;
+
+for (var y = 0; y < height; y = y + 1) {
+  var line = "";
+  for (var x = 0; x < width; x = x + 1) {
+    var cr = (x * 2.0 / width) - 1.5;
+    var ci = (y * 2.0 / height) - 1.0;
+    var zr = 0.0;
+    var zi = 0.0;
+    var iter = 0;
+    while (zr*zr + zi*zi < 4.0 and iter < max_iter) {
+      var tmp = zr*zr - zi*zi + cr;
+      zi = 2.0*zr*zi + ci;
+      zr = tmp;
+      iter = iter + 1;
+    }
+    if (iter == max_iter) {
+      line = line + "#";
+    } else {
+      line = line + " ";
+    }
+  }
+  print line;
+}


### PR DESCRIPTION
## Summary of Changes for Pull Request

### 1. Documented Chained Logical NOT (`!`) Operator in Lox

- Added an explanation and examples demonstrating that Lox supports chaining the logical NOT operator.
- Clarified that expressions such as `!!!!true` and `!!!false` are valid in Lox and how they evaluate.
- Provided sample code to illustrate this behavior:
  ```lox
  print !!!!true;  // prints true
  print !!!false;  // prints true
  print !!false;   // prints false
  ```

### 2. Added Mandelbrot Benchmark

- Created a new benchmark file: `test/benchmark/mandelbrot.lox`.
- This benchmark implements the Mandelbrot set calculation and prints the result as ASCII art.
- The benchmark can be used to evaluate the performance of the Lox interpreter on computationally intensive code.

---
These changes improve the documentation for Lox’s logical operators and expand the benchmark suite with a classic numerical benchmark.