### PR TITLE
Fixed test - moved super into top level function

### DIFF
--- a/test/super/super_in_top_level_function.lox
+++ b/test/super/super_in_top_level_function.lox
@@ -1,3 +1,3 @@
-  super.bar(); // Error at 'super': Can't use 'super' outside of a class.
 fun foo() {
+  super.bar(); // Error at 'super': Can't use 'super' outside of a class.
 }


### PR DESCRIPTION
This is a trivial change to fix a test for super.

While reading the tests, I saw the `super_in_top_level_function.lox` mistakenly had the super at the top level instead of in a top level **function**.

```
  super.bar(); // Error at 'super': Can't use 'super' outside of a class.
fun foo() {
}
```

This change makes the test case for `super_in_top_level_function.lox` similar to `this_in_top_level_function.lox`:

```
fun foo() {
  super.bar(); // Error at 'super': Can't use 'super' outside of a class.
}
```