### PR TITLE
introduction: Fix wizard book url 404

### DIFF
--- a/book/introduction.md
+++ b/book/introduction.md
@@ -144,7 +144,7 @@ texts on programming languages feature a [dragon][] and a [wizard][] on their
 covers.
 
 [dragon]: https://en.wikipedia.org/wiki/Compilers:_Principles,_Techniques,_and_Tools
-[wizard]: https://mitpress.mit.edu/sites/default/files/sicp/index.html
+[wizard]: https://en.wikipedia.org/wiki/Structure_and_Interpretation_of_Computer_Programs
 
 </aside>
 


### PR DESCRIPTION
Unfortunately, the url died. I replaced it with the Wikipedia page. At the bottom is a link to a pdf.

Alternatively, we could replace it with an Internet Archive url: https://web.archive.org/web/20170113163635/https://mitpress.mit.edu/sicp/full-text/book/book.html